### PR TITLE
fix: EcsConstructionScript now works correctly in Standalone

### DIFF
--- a/Source/CkUnreal/Public/CkUnreal/ConstructionScript/CkEcsConstructionScript_ActorComponent.cpp
+++ b/Source/CkUnreal/Public/CkUnreal/ConstructionScript/CkEcsConstructionScript_ActorComponent.cpp
@@ -296,6 +296,12 @@ auto
         this, ctti::nameof_v<ThisType>, ck::Context(this))
     { return; }
 
+    if (GetWorld()->IsNetMode(NM_Standalone))
+    {
+        _Entity.Add<ck::FTag_HasAuthority>(OwningActor);
+        return;
+    }
+
     if (GetWorld()->IsNetMode(NM_Client))
     {
         _Entity.Add<ck::FTag_HasAuthority>(OwningActor);


### PR DESCRIPTION
- in Standalone, we do not invoke the requests to replicate the construction script on Server or Client
- we still add the 'HasAuthority' tag on the Entity