### PR TITLE
feat: added Copy function to copy network info

### DIFF
--- a/Source/CkNet/Public/CkNet/CkNet_Fragment.h
+++ b/Source/CkNet/Public/CkNet/CkNet_Fragment.h
@@ -7,7 +7,7 @@ namespace ck
 {
     struct FTag_HasAuthority {};
 
-    struct FTag_NetMode_DedicatedServer{};
+    struct FTag_NetMode_IsHost{};
 }
 
 namespace ck


### PR DESCRIPTION
- renamed DedicatedServer tag to IsHost

notes: we want to reduce (ideally eliminate) the usage of 'DedicatedServer' and instead use 'Host'. A game is running as a 'Host' if any of the following is true: running as Standalone or Dedicated Server or Listen Server