### PR TITLE
feat: added Get_NetMode function in CkNet_Utils

### DIFF
--- a/Source/CkNet/Public/CkNet/CkNet_Utils.cpp
+++ b/Source/CkNet/Public/CkNet/CkNet_Utils.cpp
@@ -238,6 +238,32 @@ auto
 
 auto
     UCk_Utils_Net_UE::
+    Get_NetMode(
+        const UObject* InContext)
+    -> ECk_Net_NetRoleType
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InContext), TEXT("Invalid Object!"))
+    { return {}; }
+
+    switch(auto NetMode = InContext->GetWorld()->GetNetMode())
+    {
+    case NM_Standalone:
+        return ECk_Net_NetRoleType::Host;
+    case NM_DedicatedServer:
+        return ECk_Net_NetRoleType::Host;
+    case NM_ListenServer:
+        return ECk_Net_NetRoleType::Host;
+    case NM_Client:
+        return ECk_Net_NetRoleType::Client;
+    case NM_MAX:
+    default:
+        CK_ENSURE_FALSE(TEXT("Invalid NetMode for [{}]."), InContext);
+        return ECk_Net_NetRoleType::None;
+    }
+}
+
+auto
+    UCk_Utils_Net_UE::
     Get_IsEntityNetMode_Host(
         FCk_Handle InHandle)
     -> bool

--- a/Source/CkNet/Public/CkNet/CkNet_Utils.h
+++ b/Source/CkNet/Public/CkNet/CkNet_Utils.h
@@ -92,6 +92,11 @@ public:
     Get_NetRole(const UObject* InContext = nullptr);
 
     UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext", HidePin = "InContext"))
+    static ECk_Net_NetRoleType
+    Get_NetMode(const UObject* InContext = nullptr);
+
+    UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Net")
     static bool
     Get_IsEntityNetMode_Host(FCk_Handle InHandle);


### PR DESCRIPTION
- this returns ECk_Net_NetRoleType (to be renamed) which returns Host for Standalone, Server and ListenServer and Client for Clients

notes: this is one of the first few steps for us to write code that is agnostic of it being run 'on the server' i.e. the logic we write should work in SinglePlayer, on Server and ListenServer without any extra effort