### PR TITLE
fix: crash-fix for the UObject that tracks debugging data for a FCk_H…

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -133,7 +133,7 @@ private:
 
 // --------------------------------------------------------------------------------------------------------------------
 
-auto CKECS_API GetTypeHash(FCk_Handle InHandle) -> uint32;
+auto CKECS_API GetTypeHash(const FCk_Handle& InHandle) -> uint32;
 
 namespace ck
 {


### PR DESCRIPTION
…andle

notes: all UObjects are garbage collected at some point _unless_ they are rooted. Before this change, we were rooting the UObject when it was constructed and removing it from root without tracking other Handles that may still want the Object to remain rooted. Ultimately, we need a special type (TSharedRootObj) that is able to do the tracking.