### PR TITLE
fix: fixed StackOverflow for fragments debug logic

### DIFF
--- a/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.h
+++ b/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.h
@@ -232,7 +232,7 @@ namespace ck
     // --------------------------------------------------------------------------------------------------------------------
 
     template <typename T>
-    auto Context(T InContext) -> FContext<T>
+    auto Context(T&& InContext) -> FContext<T>
     {
         return FContext<T>{InContext};
     }


### PR DESCRIPTION
notes: ensure on line 17 of CkHandle_Subsystem creates a copy of the Handle (fixed in this CL) which in turn calls GetOrAdd_FragmentsDebug which ensures again recursively causing a Stackoverflow.

additional notes: FCk_Handle will soon have aliases `FCk_Handle_Ref` and `FCk_Handle_ConstRef` that should be then used instead of the regular handle in function parameters. This is to avoid the copy overhead of the handle in debug/test builds while leaving it as a copy in final builds since in final builds a Handle is just 2 integers.