### PR TITLE
fix: using SharedPtr to avoid heap corruption

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -438,7 +438,7 @@ auto
     FEntity_FragmentMapper::ConceptImpl_GetFragment<T_Fragment>::
     Get_Fragment(
         const FCk_Handle& InHandle) const
-    -> FCk_DebugWrapper*
+    -> DebugWrapperPtrType
 {
     if (NOT InHandle.Has<T_Fragment>())
     {
@@ -447,11 +447,14 @@ auto
 
     if constexpr (std::is_empty_v<T_Fragment>)
     {
-        return new TCk_DebugWrapper<T_Fragment>{nullptr};
+        DebugWrapperPtrType Ret = MakeShared<TCk_DebugWrapper<T_Fragment>, ESPMode::NotThreadSafe>(nullptr);
+        return Ret;
     }
     else
     {
-        return new TCk_DebugWrapper<T_Fragment>{&InHandle.Get<T_Fragment>()};
+        DebugWrapperPtrType Ret = TSharedPtr<TCk_DebugWrapper<T_Fragment>, ESPMode::NotThreadSafe>
+            {new TCk_DebugWrapper<T_Fragment>(&InHandle.Get<T_Fragment>())};
+        return Ret;
     }
 }
 

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Debugging.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Debugging.cpp
@@ -15,11 +15,12 @@ auto
     TArray<FName> FragmentNames;
 
     _AllFragments.Reset();
+
     ck::algo::ForEachIsValid(_GetFragments.begin(), _GetFragments.end(),
     [&](Concept_GetFragment_PolyType FragmentGetter)
     {
         FragmentNames.Emplace(FragmentGetter->Get_FragmentName());
-        if (const auto Fragment = FragmentGetter->Get_Fragment(InHandle))
+        if (const auto& Fragment = FragmentGetter->Get_Fragment(InHandle))
         {
             _AllFragments.Emplace(Fragment);
         }

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Debugging.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Debugging.h
@@ -49,13 +49,15 @@ public:
     // ReSharper disable once CppInconsistentNaming
     static constexpr auto in_place_delete = true;
 
+    using DebugWrapperPtrType = TSharedPtr<FCk_DebugWrapper, ESPMode::NotThreadSafe>;
+
 public:
-    struct Concept_GetFragment : entt::type_list<FCk_DebugWrapper*(const FCk_Handle&) const, FName()>
+    struct Concept_GetFragment : entt::type_list<DebugWrapperPtrType(const FCk_Handle&) const, FName()>
     {
         template <typename Base>
         struct type : Base
         {
-            auto Get_Fragment(const FCk_Handle& InHandle) const -> FCk_DebugWrapper*;
+            auto Get_Fragment(const FCk_Handle& InHandle) const -> DebugWrapperPtrType;
             auto Get_FragmentName() -> FName;
         };
 
@@ -68,7 +70,7 @@ public:
     struct ConceptImpl_GetFragment
     {
         using ValueType = T_Fragment;
-        auto Get_Fragment(const FCk_Handle& InHandle) const -> FCk_DebugWrapper*;
+        auto Get_Fragment(const FCk_Handle& InHandle) const -> DebugWrapperPtrType;
         auto Get_FragmentName() -> FName;
     };
 
@@ -82,7 +84,7 @@ public:
     using Concept_GetFragment_PolyType = entt::poly<Concept_GetFragment>;
 
 private:
-    mutable TArray<FCk_DebugWrapper*> _AllFragments;
+    mutable TArray<DebugWrapperPtrType> _AllFragments;
     mutable TArray<Concept_GetFragment_PolyType> _GetFragments;
 };
 
@@ -139,7 +141,7 @@ auto
     FEntity_FragmentMapper::Concept_GetFragment::type<Base>::
     Get_Fragment(
         const FCk_Handle& InHandle) const
-    -> FCk_DebugWrapper*
+    -> DebugWrapperPtrType
 {
     return entt::poly_call<0>(*this, InHandle);
 }


### PR DESCRIPTION
notes: although the logic is fairly straight-forward, the raw pointers were at some point being stomped. Converted to non-threadsafe SharedPtr which should be fast enough for our purpose. We may revisit this logic at a later date.