### PR TITLE
feat: Handle debugger can now be enabled/disabled using project settings

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
@@ -5,6 +5,7 @@
 #include "CkEcs/Handle/CkHandle_Debugging.h"
 #include "CkEcs/Handle/CkHandle_Debugging_Data.h"
 #include "CkEcs/Handle/CkHandle_Subsystem.h"
+#include "CkEcs/Settings/CkEcs_Settings.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -162,6 +163,9 @@ auto
     DoUpdate_MapperAndFragments()
     -> void
 {
+    if (UCk_Utils_Ecs_ProjectSettings_UE::Get_HandleDebuggerBehavior() == ECk_Ecs_HandleDebuggerBehavior::Disable)
+    { return; }
+
     if (NOT IsValid())
     { return; }
 

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Subsystem.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Subsystem.cpp
@@ -5,6 +5,7 @@
 #include "CkCore/Validation/CkIsValid.h"
 
 #include "CkEcs/Handle/CkHandle.h"
+#include "CkEcs/Settings/CkEcs_Settings.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -14,6 +15,9 @@ auto
         const FCk_Handle& InHandle)
     -> UCk_Handle_FragmentsDebug*
 {
+    if (UCk_Utils_Ecs_ProjectSettings_UE::Get_HandleDebuggerBehavior() == ECk_Ecs_HandleDebuggerBehavior::Disable)
+    { return {}; }
+
     if (ck::Is_NOT_Valid(GetTransientPackage()))
     { return Cast<UCk_Handle_FragmentsDebug>(UCk_Handle_FragmentsDebug::StaticClass()); }
 
@@ -36,6 +40,9 @@ auto
         const FCk_Handle& InHandle)
     -> void
 {
+    if (UCk_Utils_Ecs_ProjectSettings_UE::Get_HandleDebuggerBehavior() == ECk_Ecs_HandleDebuggerBehavior::Disable)
+    { return; }
+
     if (ck::Is_NOT_Valid(GetTransientPackage()))
     { return; }
 

--- a/Source/CkEcs/Public/CkEcs/Settings/CkEcs_Settings.cpp
+++ b/Source/CkEcs/Public/CkEcs/Settings/CkEcs_Settings.cpp
@@ -20,4 +20,12 @@ auto
     return UCk_Utils_Object_UE::Get_ClassDefaultObject<UCk_Ecs_ProjectSettings_UE>()->Get_EcsWorldTickingGroup();
 }
 
+auto
+    UCk_Utils_Ecs_ProjectSettings_UE::
+    Get_HandleDebuggerBehavior()
+    -> ECk_Ecs_HandleDebuggerBehavior
+{
+    return UCk_Utils_Object_UE::Get_ClassDefaultObject<UCk_Ecs_ProjectSettings_UE>()->Get_HandleDebuggerBehavior();
+}
+
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/Settings/CkEcs_Settings.h
+++ b/Source/CkEcs/Public/CkEcs/Settings/CkEcs_Settings.h
@@ -8,6 +8,15 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
+UENUM(BlueprintType)
+enum class ECk_Ecs_HandleDebuggerBehavior : uint8
+{
+    Disable,
+    Enable
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 UCLASS(meta = (DisplayName = "ECS"))
 class CKECS_API UCk_Ecs_ProjectSettings_UE : public UCk_Engine_ProjectSettings_UE
 {
@@ -25,9 +34,14 @@ private:
               meta = (AllowPrivateAccess = true))
     TEnumAsByte<ETickingGroup> _EcsWorldTickingGroup = TG_PrePhysics;
 
+    UPROPERTY(Config, EditDefaultsOnly, BlueprintReadOnly, Category = "Debugging",
+              meta = (AllowPrivateAccess = true))
+    ECk_Ecs_HandleDebuggerBehavior _HandleDebuggerBehavior = ECk_Ecs_HandleDebuggerBehavior::Disable;
+
 public:
     CK_PROPERTY_GET(_EcsWorldActorClass);
     CK_PROPERTY_GET(_EcsWorldTickingGroup);
+    CK_PROPERTY_GET(_HandleDebuggerBehavior);
 };
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -37,6 +51,7 @@ class CKECS_API UCk_Utils_Ecs_ProjectSettings_UE
 public:
     static auto Get_EcsWorldActorClass() -> TSubclassOf<class ACk_World_Actor_Base_UE>;
     static auto Get_EcsWorldTickingGroup() -> ETickingGroup;
+    static auto Get_HandleDebuggerBehavior() -> ECk_Ecs_HandleDebuggerBehavior;
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- disabled by default
- this can also be used as a temporary fix for the crash in the debugger