### PR TITLE
refactor: _ReplicatedObjects in ObjectReplicator is no longer a repli…

### DIFF
--- a/Source/CkCore/Public/CkCore/ObjectReplication/CkObjectReplicatorComponent.cpp
+++ b/Source/CkCore/Public/CkCore/ObjectReplication/CkObjectReplicatorComponent.cpp
@@ -13,7 +13,7 @@
 UCk_ObjectReplicator_ActorComponent_UE::
     UCk_ObjectReplicator_ActorComponent_UE()
 {
-    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.bCanEverTick = false;
     bReplicateUsingRegisteredSubObjectList = true;
     SetIsReplicatedByDefault(true);
 }
@@ -38,17 +38,6 @@ auto
     // TODO: add some checks
     _ReplicatedObjects.Remove(InObject);
     RemoveReplicatedSubObject(InObject);
-}
-
-auto
-    UCk_ObjectReplicator_ActorComponent_UE::
-    GetLifetimeReplicatedProps(
-        TArray<FLifetimeProperty>& OutLifetimeProps) const
-    -> void
-{
-    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
-
-    DOREPLIFETIME(ThisType, _ReplicatedObjects);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCore/Public/CkCore/ObjectReplication/CkObjectReplicatorComponent.h
+++ b/Source/CkCore/Public/CkCore/ObjectReplication/CkObjectReplicatorComponent.h
@@ -31,10 +31,8 @@ public:
     UFUNCTION(BlueprintCallable)
     void Request_UnregisterObjectForReplication(UCk_ReplicatedObject_UE* InObject);
 
-    auto GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const -> void override;
-
 public:
-    UPROPERTY(Replicated)
+    UPROPERTY(Transient)
     TArray<UCk_ReplicatedObject_UE*> _ReplicatedObjects;
 };
 


### PR DESCRIPTION
…cated array

notes: when this was first done, it was unclear whether this property (that is the Array of ReplicatedObjects) needed replication. Now that we have a hardened flow that works, we find that this property does not need to be replicated.