### PR TITLE
feat: AbilityOwner refactored to work with Ability Handles instead of…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Fragment.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Fragment.cpp
@@ -13,9 +13,9 @@ namespace ck::algo
             const FCk_Handle& InHandle) const
         -> bool
     {
-        const auto AbilityName = UCk_Utils_GameplayLabel_UE::Get_Label(InHandle);
+        const auto AbilityClass = UCk_Utils_Ability_UE::Get_ScriptClass(InHandle);
 
-        if (NOT UCk_Utils_AbilityOwner_UE::Has_Ability(InHandle, AbilityName))
+        if (UCk_Utils_Ability_UE::Get_ScriptClass(InHandle) != AbilityClass)
         { return false; }
 
         const auto CancelledByTags = [&]()

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.cpp
@@ -12,9 +12,9 @@ FCk_Request_AbilityOwner_GiveAbility::
 
 FCk_Request_AbilityOwner_RevokeAbility::
     FCk_Request_AbilityOwner_RevokeAbility(
-        FGameplayTag InAbilityName)
-    : _SearchPolicy(ECk_AbilityOwner_AbilitySearchPolicy::SearchByName)
-    , _AbilityName(InAbilityName)
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass)
+    : _SearchPolicy(ECk_AbilityOwner_AbilitySearchPolicy::SearchByClass)
+    , _AbilityClass(InAbilityClass)
 {
 }
 
@@ -30,10 +30,10 @@ FCk_Request_AbilityOwner_RevokeAbility::
 
 FCk_Request_AbilityOwner_ActivateAbility::
     FCk_Request_AbilityOwner_ActivateAbility(
-        FGameplayTag InAbilityName,
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass,
         FCk_Ability_ActivationPayload InActivationPayload)
-    : _SearchPolicy(ECk_AbilityOwner_AbilitySearchPolicy::SearchByName)
-    , _AbilityName(InAbilityName)
+    : _SearchPolicy(ECk_AbilityOwner_AbilitySearchPolicy::SearchByClass)
+    , _AbilityClass(InAbilityClass)
     , _ActivationPayload(InActivationPayload)
 {
 }
@@ -52,9 +52,9 @@ FCk_Request_AbilityOwner_ActivateAbility::
 
 FCk_Request_AbilityOwner_DeactivateAbility::
     FCk_Request_AbilityOwner_DeactivateAbility(
-        FGameplayTag InAbilityName)
-        : _SearchPolicy(ECk_AbilityOwner_AbilitySearchPolicy::SearchByName)
-        , _AbilityName(InAbilityName)
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass)
+        : _SearchPolicy(ECk_AbilityOwner_AbilitySearchPolicy::SearchByClass)
+        , _AbilityClass(InAbilityClass)
 { }
 
 FCk_Request_AbilityOwner_DeactivateAbility::

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.h
@@ -15,7 +15,7 @@
 UENUM(BlueprintType)
 enum class ECk_AbilityOwner_AbilitySearchPolicy : uint8
 {
-    SearchByName,
+    SearchByClass,
     SearchByHandle
 };
 
@@ -126,7 +126,7 @@ public:
 
     explicit
     FCk_Request_AbilityOwner_RevokeAbility(
-        FGameplayTag InAbilityName);
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass);
 
     explicit
     FCk_Request_AbilityOwner_RevokeAbility(
@@ -135,12 +135,12 @@ public:
 private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    ECk_AbilityOwner_AbilitySearchPolicy _SearchPolicy = ECk_AbilityOwner_AbilitySearchPolicy::SearchByName;
+    ECk_AbilityOwner_AbilitySearchPolicy _SearchPolicy = ECk_AbilityOwner_AbilitySearchPolicy::SearchByClass;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true,
                   EditCondition="_SearchPolicy == ECk_AbilityOwner_AbilitySearchPolicy::SearchByName"))
-    FGameplayTag _AbilityName = FGameplayTag::EmptyTag;
+    TSubclassOf<UCk_Ability_Script_PDA> _AbilityClass;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true,
@@ -149,7 +149,7 @@ private:
 
 public:
     CK_PROPERTY_GET(_SearchPolicy);
-    CK_PROPERTY_GET(_AbilityName);
+    CK_PROPERTY_GET(_AbilityClass);
     CK_PROPERTY_GET(_AbilityHandle);
 };
 
@@ -167,7 +167,7 @@ public:
     FCk_Request_AbilityOwner_ActivateAbility() = default;
 
     FCk_Request_AbilityOwner_ActivateAbility(
-        FGameplayTag InAbilityName,
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass,
         FCk_Ability_ActivationPayload InActivationPayload);
 
     FCk_Request_AbilityOwner_ActivateAbility(
@@ -177,12 +177,12 @@ public:
 private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    ECk_AbilityOwner_AbilitySearchPolicy _SearchPolicy = ECk_AbilityOwner_AbilitySearchPolicy::SearchByName;
+    ECk_AbilityOwner_AbilitySearchPolicy _SearchPolicy = ECk_AbilityOwner_AbilitySearchPolicy::SearchByClass;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true,
                   EditCondition="_SearchPolicy == ECk_AbilityOwner_AbilitySearchPolicy::SearchByName"))
-    FGameplayTag _AbilityName = FGameplayTag::EmptyTag;
+    TSubclassOf<UCk_Ability_Script_PDA> _AbilityClass;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true,
@@ -195,7 +195,7 @@ private:
 
 public:
     CK_PROPERTY_GET(_SearchPolicy);
-    CK_PROPERTY_GET(_AbilityName);
+    CK_PROPERTY_GET(_AbilityClass);
     CK_PROPERTY_GET(_AbilityHandle);
     CK_PROPERTY_GET(_ActivationPayload);
 };
@@ -215,7 +215,7 @@ public:
 
     explicit
     FCk_Request_AbilityOwner_DeactivateAbility(
-        FGameplayTag InAbilityName);
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass);
 
     explicit
     FCk_Request_AbilityOwner_DeactivateAbility(
@@ -224,12 +224,12 @@ public:
 private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    ECk_AbilityOwner_AbilitySearchPolicy _SearchPolicy = ECk_AbilityOwner_AbilitySearchPolicy::SearchByName;
+    ECk_AbilityOwner_AbilitySearchPolicy _SearchPolicy = ECk_AbilityOwner_AbilitySearchPolicy::SearchByClass;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true,
-                  EditCondition="_SearchPolicy == ECk_AbilityOwner_AbilitySearchPolicy::SearchByName"))
-    FGameplayTag _AbilityName = FGameplayTag::EmptyTag;
+                  EditCondition="_SearchPolicy == ECk_AbilityOwner_AbilitySearchPolicy::SearchByClass"))
+    TSubclassOf<UCk_Ability_Script_PDA> _AbilityClass;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true,
@@ -238,7 +238,7 @@ private:
 
 public:
     CK_PROPERTY_GET(_SearchPolicy);
-    CK_PROPERTY_GET(_AbilityName);
+    CK_PROPERTY_GET(_AbilityClass);
     CK_PROPERTY_GET(_AbilityHandle);
 };
 

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
@@ -93,9 +93,9 @@ namespace ck
             const FCk_Request_AbilityOwner_DeactivateAbility& InRequest) const -> void;
 
     private:
-        auto DoFindAbilityByName(
+        auto DoFindAbilityByClass(
             const FCk_Handle& InAbilityOwnerEntity,
-            const FGameplayTag& InAbilityName) const-> FCk_Handle;
+            const TSubclassOf<UCk_Ability_Script_PDA>& InAbilityClass) const -> FCk_Handle;
 
         auto DoFindAbilityByHandle(
             const FCk_Handle& InAbilityOwnerEntity,

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
@@ -42,15 +42,15 @@ auto
 auto
     UCk_Utils_AbilityOwner_UE::
     Has_Ability(
-        FCk_Handle   InAbilityOwnerEntity,
-        FGameplayTag InAbilityName)
+        FCk_Handle InAbilityOwnerEntity,
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass)
     -> bool
 {
-    const auto& AbilityEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Ability_UE,
-        RecordOfAbilities_Utils>(InAbilityOwnerEntity, InAbilityName);
-
-    return ck::IsValid(AbilityEntity);
+    return RecordOfAbilities_Utils::Get_HasValidEntry_If(InAbilityOwnerEntity,
+    [InAbilityClass](const FCk_Handle& InHandle)
+    {
+        return UCk_Utils_Ability_UE::Get_ScriptClass(InHandle) == InAbilityClass;
+    });
 }
 
 auto
@@ -65,12 +65,12 @@ auto
 auto
     UCk_Utils_AbilityOwner_UE::
     Ensure_Ability(
-        FCk_Handle   InAbilityOwnerEntity,
-        FGameplayTag InAbilityName)
+        FCk_Handle InAbilityOwnerEntity,
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass)
     -> bool
 {
-    CK_ENSURE_IF_NOT(Has_Ability(InAbilityOwnerEntity, InAbilityName),
-        TEXT("Handle [{}] does NOT have Ability [{}]"), InAbilityOwnerEntity, InAbilityName)
+    CK_ENSURE_IF_NOT(Has_Ability(InAbilityOwnerEntity, InAbilityClass),
+        TEXT("Handle [{}] does NOT have Ability [{}]"), InAbilityOwnerEntity, InAbilityClass)
     { return false; }
 
     return true;
@@ -91,13 +91,30 @@ auto
 auto
     UCk_Utils_AbilityOwner_UE::
     Get_Ability(
+        FCk_Handle                          InAbilityOwnerEntity,
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass)
+    -> FCk_Handle
+{
+    CK_ENSURE_IF_NOT(Has_Ability(InAbilityOwnerEntity, InAbilityClass),
+        TEXT("AbilityOwner [{}] does NOT have the Ability [{}]"), InAbilityOwnerEntity, InAbilityClass)
+    { return {}; }
+
+    auto Handle = RecordOfAbilities_Utils::Get_ValidEntry_If(InAbilityOwnerEntity,
+    [InAbilityClass](const FCk_Handle& InHandle)
+    {
+        return UCk_Utils_Ability_UE::Get_ScriptClass(InHandle) == InAbilityClass;
+    });
+
+    return Handle;
+}
+
+auto
+    UCk_Utils_AbilityOwner_UE::
+    Find_Ability(
         FCk_Handle   InAbilityOwnerEntity,
         FGameplayTag InAbilityName)
     -> FCk_Handle
 {
-    if (NOT Ensure_Ability(InAbilityOwnerEntity, InAbilityName))
-    { return {}; }
-
     const auto& AbilityEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
         UCk_Utils_Ability_UE,
         RecordOfAbilities_Utils>(InAbilityOwnerEntity, InAbilityName);
@@ -395,18 +412,18 @@ auto
 
 auto
     UCk_Utils_AbilityOwner_UE::
-    Make_Request_ActivateAbility_ByName(
-        FGameplayTag InAbilityName,
+    Make_Request_ActivateAbility_ByClass(
+        TSubclassOf<UCk_Ability_Script_PDA>  InAbilityScriptClass,
         FCk_Ability_ActivationPayload InActivationPayload)
     -> FCk_Request_AbilityOwner_ActivateAbility
 {
-    return FCk_Request_AbilityOwner_ActivateAbility{InAbilityName, InActivationPayload};
+    return FCk_Request_AbilityOwner_ActivateAbility{InAbilityScriptClass, InActivationPayload};
 }
 
 auto
     UCk_Utils_AbilityOwner_UE::
     Make_Request_ActivateAbility_ByEntity(
-        FCk_Handle InAbilityEntity,
+        FCk_Handle                    InAbilityEntity,
         FCk_Ability_ActivationPayload InActivationPayload)
     -> FCk_Request_AbilityOwner_ActivateAbility
 {
@@ -415,11 +432,11 @@ auto
 
 auto
     UCk_Utils_AbilityOwner_UE::
-    Make_Request_DeactivateAbility_ByName(
-        FGameplayTag InAbilityName)
+    Make_Request_DeactivateAbility_ByClass(
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityScriptClass)
     -> FCk_Request_AbilityOwner_DeactivateAbility
 {
-    return FCk_Request_AbilityOwner_DeactivateAbility{InAbilityName};
+    return FCk_Request_AbilityOwner_DeactivateAbility{InAbilityScriptClass};
 }
 
 auto
@@ -433,11 +450,11 @@ auto
 
 auto
     UCk_Utils_AbilityOwner_UE::
-    Make_Request_RevokeAbility_ByName(
-        FGameplayTag InAbilityName)
+    Make_Request_RevokeAbility_ByClass(
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityScriptClass)
     -> FCk_Request_AbilityOwner_RevokeAbility
 {
-    return FCk_Request_AbilityOwner_RevokeAbility{InAbilityName};
+    return FCk_Request_AbilityOwner_RevokeAbility{InAbilityScriptClass};
 }
 
 auto

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
@@ -58,7 +58,7 @@ public:
     static bool
     Has_Ability(
         FCk_Handle InAbilityOwnerEntity,
-        FGameplayTag InAbilityName);
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner",
@@ -73,7 +73,7 @@ public:
     static bool
     Ensure_Ability(
         FCk_Handle InAbilityOwnerEntity,
-        FGameplayTag InAbilityName);
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner",
@@ -84,9 +84,18 @@ public:
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner",
-              DisplayName="[Ck][AbilityOwner] Get Ability")
+              DisplayName="[Ck][AbilityOwner] Get Ability",
+              meta=(DevelopmentOnly))
     static FCk_Handle
     Get_Ability(
+        FCk_Handle InAbilityOwnerEntity,
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass);
+
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Ability|Owner",
+              DisplayName="[Ck][AbilityOwner] Find Ability")
+    static FCk_Handle
+    Find_Ability(
         FCk_Handle InAbilityOwnerEntity,
         FGameplayTag InAbilityName);
 
@@ -231,22 +240,22 @@ private:
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner")
     static FCk_Request_AbilityOwner_ActivateAbility
-    Make_Request_ActivateAbility_ByName(
-        FGameplayTag InAbilityName,
+    Make_Request_ActivateAbility_ByClass(
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityScriptClass,
         FCk_Ability_ActivationPayload InActivationPayload);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner")
     static FCk_Request_AbilityOwner_ActivateAbility
     Make_Request_ActivateAbility_ByEntity(
-        FCk_Handle InAbilityEntity,
+        FCk_Handle                    InAbilityEntity,
         FCk_Ability_ActivationPayload InActivationPayload);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner")
     static FCk_Request_AbilityOwner_DeactivateAbility
-    Make_Request_DeactivateAbility_ByName(
-        FGameplayTag InAbilityName);
+    Make_Request_DeactivateAbility_ByClass(
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityScriptClass);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner")
@@ -257,8 +266,8 @@ private:
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner")
     static FCk_Request_AbilityOwner_RevokeAbility
-    Make_Request_RevokeAbility_ByName(
-        FGameplayTag InAbilityName);
+    Make_Request_RevokeAbility_ByClass(
+        TSubclassOf<UCk_Ability_Script_PDA> InAbilityScriptClass);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Ability|Owner")


### PR DESCRIPTION
… Ability Names

notes: Find_Ability is the only function available that can Find Abilities by name. Because AbilityName is optional, this may return an Invalid Handle (hance 'Find' instead of 'Get'). Get_Ability (by class) is a DevelopmentOnly function.