### PR TITLE
fix: added Ensures to Bind/Unbind value changed functions to catch At…

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
@@ -279,6 +279,11 @@ auto
     const auto& AttributeEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel
         <ByteAttribute_Utils, RecordOfByteAttributes_Utils>(InAttributeOwnerEntity, InAttributeName);
 
+    CK_ENSURE_IF_NOT(ck::IsValid(AttributeEntity),
+        TEXT("Could NOT find Attribute [{}] in Entity [{}]. Unable to BIND on ValueChanged the Delegate [{}]"),
+        InAttributeName, InAttributeOwnerEntity, InDelegate.GetFunctionName())
+    { return; }
+
     if (InPostFireBehavior == ECk_Signal_PostFireBehavior::DoNothing)
     { ck::UUtils_Signal_OnByteAttributeValueChanged::Bind(AttributeEntity, InDelegate, InBehavior); }
     else
@@ -295,6 +300,11 @@ auto
 {
     const auto& AttributeEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel
         <ByteAttribute_Utils, RecordOfByteAttributes_Utils>(InAttributeOwnerEntity, InAttributeName);
+
+    CK_ENSURE_IF_NOT(ck::IsValid(AttributeEntity),
+        TEXT("Could NOT find Attribute [{}] in Entity [{}]. Unable to BIND on ValueChanged the Delegate [{}]"),
+        InAttributeName, InAttributeOwnerEntity, InDelegate.GetFunctionName())
+    { return; }
 
     ck::UUtils_Signal_OnByteAttributeValueChanged::Unbind(AttributeEntity, InDelegate);
 }

--- a/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Utils.cpp
@@ -279,6 +279,11 @@ auto
     const auto& AttributeEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel
         <VectorAttribute_Utils, RecordOfVectorAttributes_Utils>(InAttributeOwnerEntity, InAttributeName);
 
+    CK_ENSURE_IF_NOT(ck::IsValid(AttributeEntity),
+        TEXT("Could NOT find Attribute [{}] in Entity [{}]. Unable to BIND on ValueChanged the Delegate [{}]"),
+        InAttributeName, InAttributeOwnerEntity, InDelegate.GetFunctionName())
+    { return; }
+
     if (InPostFireBehavior == ECk_Signal_PostFireBehavior::DoNothing)
     { ck::UUtils_Signal_OnVectorAttributeValueChanged::Bind(AttributeEntity, InDelegate, InBehavior); }
     else
@@ -295,6 +300,11 @@ auto
 {
     const auto& AttributeEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel
         <VectorAttribute_Utils, RecordOfVectorAttributes_Utils>(InAttributeOwnerEntity, InAttributeName);
+
+    CK_ENSURE_IF_NOT(ck::IsValid(AttributeEntity),
+        TEXT("Could NOT find Attribute [{}] in Entity [{}]. Unable to BIND on ValueChanged the Delegate [{}]"),
+        InAttributeName, InAttributeOwnerEntity, InDelegate.GetFunctionName())
+    { return; }
 
     ck::UUtils_Signal_OnVectorAttributeValueChanged::Unbind(AttributeEntity, InDelegate);
 }


### PR DESCRIPTION
…tribute related issues early in the call stack

notes: without this ensure, we go too deep into the call hierarchy before we encounter invalid Entities making it difficult to immediately know that the original problem was the Attribute was missing from the Owning Entity up the call chain