### PR TITLE
fix: fixed issue where Get_WorldForEntity might undergo infinite recu…

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -120,7 +120,12 @@ auto
         return InHandle.Get<TWeakObjectPtr<UWorld>>().Get();
     }
 
-    return Get_WorldForEntity(Get_LifetimeOwner(InHandle));
+    const auto& LifeTimeOwner = Get_LifetimeOwner(InHandle);
+
+    if (ck::Is_NOT_Valid(LifeTimeOwner))
+    { return {}; }
+
+    return Get_WorldForEntity(LifeTimeOwner);
 }
 
 auto


### PR DESCRIPTION
…rsion

notes: this can happen if the Entity is invalid. Although an ensure is fired, because we didn't test for the Entity, the function would infinitely recurse