### PR TITLE
feat: Marker interface now requires the Market Entity explicitly (ins…

### DIFF
--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Fragment.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Fragment.h
@@ -93,7 +93,7 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    CK_DEFINE_RECORD_OF_ENTITIES(FFragment_RecordOfMarkers, FCk_Handle);
+    CK_DEFINE_RECORD_OF_ENTITIES(FFragment_RecordOfMarkers, FCk_Handle_Marker);
 
     // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Fragment_Data.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Fragment_Data.cpp
@@ -5,10 +5,10 @@
 FCk_Marker_BasicDetails::
     FCk_Marker_BasicDetails(
         FGameplayTag InMarkerName,
-        FCk_Handle InMarkerEntity,
+        FCk_Handle_Marker InMarkerEntity,
         FCk_EntityOwningActor_BasicDetails InMarkerAttachedEntityAndActor)
     : _MarkerName(InMarkerName)
-    , _MarkerEntity(InMarkerEntity)
+    , _MarkerEntity(MoveTemp(InMarkerEntity))
     , _MarkerAttachedEntityAndActor(InMarkerAttachedEntityAndActor)
 {
 }

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Fragment_Data.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Fragment_Data.h
@@ -5,6 +5,7 @@
 #include "CkCore/Format/CkFormat.h"
 
 #include "CkEcs/Handle/CkHandle.h"
+#include "CkEcs/Handle/CkHandle_TypeSafe.h"
 #include "CkEcs/OwningActor/CkOwningActor_Fragment_Data.h"
 
 #include "CkNet/CkNet_Common.h"
@@ -37,6 +38,12 @@ CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_Marker_AttachmentPolicy);
 
 // --------------------------------------------------------------------------------------------------------------------
 
+USTRUCT(BlueprintType, meta=(HasNativeMake, HasNativeBreak="/Script/CkEcs.Ck_Utils_Handle_UE:Conv_HandleTypeSafeToHandle"))
+struct CKOVERLAPBODY_API FCk_Handle_Marker : public FCk_Handle_TypeSafe { GENERATED_BODY()  CK_GENERATED_BODY_HANDLE_TYPESAFE(FCk_Handle_Marker); };
+CK_DEFINE_CUSTOM_ISVALID_AND_FORMATTER_HANDLE_TYPESAFE(FCk_Handle_Marker);
+
+// --------------------------------------------------------------------------------------------------------------------
+
 USTRUCT(BlueprintType)
 struct CKOVERLAPBODY_API FCk_Marker_BasicDetails
 {
@@ -49,7 +56,7 @@ public:
     FCk_Marker_BasicDetails() = default;
     FCk_Marker_BasicDetails(
         FGameplayTag InMarkerName,
-        FCk_Handle InMarkerEntity,
+        FCk_Handle_Marker InMarkerEntity,
         FCk_EntityOwningActor_BasicDetails InMarkerAttachedEntityAndActor);
 
 public:
@@ -62,7 +69,7 @@ private:
     FGameplayTag _MarkerName;
 
     UPROPERTY(Transient, meta = (AllowPrivateAccess = true))
-    FCk_Handle _MarkerEntity;
+    FCk_Handle_Marker _MarkerEntity;
 
     // Represents the Entity/Actor that the Marker ActorComp is attached to. Different from the Marker Entity itself
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly,

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.cpp
@@ -124,7 +124,7 @@ namespace ck
             { return; }
 
             InCurrentComp._EnableDisable = NewEnableDisable;
-            const auto& collisionEnabled = NewEnableDisable == ECk_EnableDisable::Enable
+            const auto& CollisionEnabled = NewEnableDisable == ECk_EnableDisable::Enable
                                              ? ECollisionEnabled::QueryOnly
                                              : ECollisionEnabled::NoCollision;
 
@@ -133,7 +133,7 @@ namespace ck
             const auto& Marker     = InCurrentComp.Get_Marker().Get();
 
             UCk_Utils_Physics_UE::Request_SetGenerateOverlapEvents(Marker, NewEnableDisable);
-            UCk_Utils_Physics_UE::Request_SetCollisionEnabled(Marker, collisionEnabled);
+            UCk_Utils_Physics_UE::Request_SetCollisionEnabled(Marker, CollisionEnabled);
 
             UUtils_Signal_OnMarkerEnableDisable::Broadcast(InMarkerEntity, MakePayload(InCurrentComp.Get_AttachedEntityAndActor().Get_Handle(), MarkerName, NewEnableDisable));
         });
@@ -146,10 +146,10 @@ namespace ck
     auto
         FProcessor_Marker_UpdateTransform::
         ForEachEntity(
-            TimeType InDeltaT,
-            HandleType InMarkerEntity,
-            FFragment_Marker_Current& InCurrentComp,
-            const FFragment_Marker_Params& InParamsComp) const
+            TimeType                        InDeltaT,
+            HandleType                      InMarkerEntity,
+            const FFragment_Marker_Current& InCurrentComp,
+            const FFragment_Marker_Params&  InParamsComp) const
         -> void
     {
         // TODO: Extract this in a common function to avoid code duplication between similar system for Sensor
@@ -212,7 +212,7 @@ namespace ck
 
     FProcessor_Marker_DebugPreviewAll::
         FProcessor_Marker_DebugPreviewAll(
-            FCk_Registry& InRegistry)
+        const FCk_Registry& InRegistry)
         : _Registry(InRegistry)
     {
     }
@@ -226,16 +226,15 @@ namespace ck
         if (NOT UCk_Utils_OverlapBody_UserSettings_UE::Get_DebugPreviewAllMarkers())
         { return; }
 
-        _Registry.View<FFragment_Marker_Current, FFragment_Marker_Params>().ForEach(
-        [&](FCk_Entity InMarkerEntity, const FFragment_Marker_Current& InMarkerCurrent, const FFragment_Marker_Params& InMarkerParams)
+        _Registry.View<FFragment_Marker_Current>().ForEach(
+        [&](FCk_Entity InMarkerEntity, const FFragment_Marker_Current& InMarkerCurrent)
         {
             if (ck::Is_NOT_Valid(InMarkerCurrent.Get_Marker()))
             { return; }
 
-            const auto& markerName = InMarkerParams.Get_Params().Get_MarkerName();
-            const auto& outerForDebugDraw = InMarkerCurrent.Get_AttachedEntityAndActor().Get_Actor().Get();
+            const auto& OuterForDebugDraw = InMarkerCurrent.Get_AttachedEntityAndActor().Get_Actor().Get();
 
-            UCk_Utils_Marker_UE::Preview(outerForDebugDraw, FCk_Handle{ InMarkerEntity, _Registry }, markerName);
+            UCk_Utils_Marker_UE::Preview(OuterForDebugDraw, FCk_Handle_Marker{ InMarkerEntity, _Registry });
         });
     }
 }

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.h
@@ -9,8 +9,9 @@
 
 namespace ck
 {
-    class CKOVERLAPBODY_API FProcessor_Marker_Setup : public TProcessor<
+    class CKOVERLAPBODY_API FProcessor_Marker_Setup : public ck_exp::TProcessor<
             FProcessor_Marker_Setup,
+            FCk_Handle_Marker,
             FFragment_Marker_Current,
             FFragment_Marker_Params,
             FTag_Marker_NeedsSetup,
@@ -35,8 +36,9 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    class CKOVERLAPBODY_API FProcessor_Marker_HandleRequests : public TProcessor<
+    class CKOVERLAPBODY_API FProcessor_Marker_HandleRequests : public ck_exp::TProcessor<
             FProcessor_Marker_HandleRequests,
+            FCk_Handle_Marker,
             FFragment_Marker_Current,
             FFragment_Marker_Params,
             FFragment_Marker_Requests,
@@ -59,8 +61,9 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    class CKOVERLAPBODY_API FProcessor_Marker_UpdateTransform : public TProcessor<
+    class CKOVERLAPBODY_API FProcessor_Marker_UpdateTransform : public ck_exp::TProcessor<
             FProcessor_Marker_UpdateTransform,
+            FCk_Handle_Marker,
             FFragment_Marker_Current,
             FFragment_Marker_Params,
             FTag_Marker_UpdateTransform,
@@ -71,10 +74,10 @@ namespace ck
 
     public:
         auto ForEachEntity(
-            TimeType InDeltaT,
-            HandleType InMarkerEntity,
-            FFragment_Marker_Current& InCurrentComp,
-            const FFragment_Marker_Params& InParamsComp) const -> void;
+            TimeType                        InDeltaT,
+            HandleType                      InMarkerEntity,
+            const FFragment_Marker_Current& InCurrentComp,
+            const FFragment_Marker_Params&  InParamsComp) const -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -83,7 +86,7 @@ namespace ck
     {
     public:
         explicit FProcessor_Marker_DebugPreviewAll(
-            FCk_Registry& InRegistry);
+            const FCk_Registry& InRegistry);
 
     public:
         auto Tick(FCk_Time) -> void;

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Utils.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Utils.cpp
@@ -15,13 +15,14 @@
 auto
     UCk_Utils_Marker_UE::
     Add(
-        FCk_Handle InHandle,
+        FCk_Handle& InHandle,
         const FCk_Fragment_Marker_ParamsData& InParams,
         ECk_Net_ReplicationType InReplicationType)
-    -> void
+    -> FCk_Handle_Marker
 {
-    CK_ENSURE_IF_NOT(UCk_Utils_OwningActor_UE::Has(InHandle), TEXT("Cannot Add a Marker to Entity [{}] because it does NOT have an Owning Actor"), InHandle)
-    { return; }
+    CK_ENSURE_IF_NOT(UCk_Utils_OwningActor_UE::Has(InHandle),
+        TEXT("Cannot Add a Marker to Entity [{}] because it does NOT have an Owning Actor"), InHandle)
+    { return {}; }
 
     const auto& MarkerName = InParams.Get_MarkerName();
 
@@ -35,88 +36,81 @@ auto
             InReplicationType
         );
 
-        return;
+        return {};
     }
 
     auto ParamsToUse = InParams;
     ParamsToUse.Set_ReplicationType(InReplicationType);
 
-    auto NewMarkerEntity = UCk_Utils_EntityLifetime_UE::Request_CreateEntity(InHandle, [&](FCk_Handle InMarkerEntity)
+    auto NewMarkerEntity = Conv_HandleToMarker(UCk_Utils_EntityLifetime_UE::Request_CreateEntity(InHandle,
+    [&](FCk_Handle InMarkerEntity)
     {
         InMarkerEntity.Add<ck::FFragment_Marker_Params>(ParamsToUse);
         InMarkerEntity.Add<ck::FFragment_Marker_Current>(ParamsToUse.Get_StartingState());
         InMarkerEntity.Add<ck::FTag_Marker_NeedsSetup>();
 
         UCk_Utils_GameplayLabel_UE::Add(InMarkerEntity, MarkerName);
-    });
+    }));
 
     RecordOfMarkers_Utils::AddIfMissing(InHandle, ECk_Record_EntryHandlingPolicy::DisallowDuplicateNames);
     RecordOfMarkers_Utils::Request_Connect(InHandle, NewMarkerEntity);
+
+    return NewMarkerEntity;
 }
 
 auto
     UCk_Utils_Marker_UE::
     AddMultiple(
-        FCk_Handle InHandle,
+        FCk_Handle& InHandle,
         const FCk_Fragment_MultipleMarker_ParamsData& InParams,
         ECk_Net_ReplicationType InReplicationType)
-    -> void
+    -> TArray<FCk_Handle_Marker>
 {
-    for (const auto& Params : InParams.Get_MarkerParams())
+    return ck::algo::Transform<TArray<FCk_Handle_Marker>>(InParams.Get_MarkerParams(),
+    [&](const FCk_Fragment_Marker_ParamsData& InMarkerParams)
     {
-        Add(InHandle, Params, InReplicationType);
-    }
+        return Add(InHandle, InMarkerParams, InReplicationType);
+    });
 }
+
+// --------------------------------------------------------------------------------------------------------------------
+
+CK_DEFINE_HAS_CAST_CONV_HANDLE_TYPESAFE(Marker, UCk_Utils_Marker_UE, FCk_Handle_Marker, ck::FFragment_Marker_Params, ck::FFragment_Marker_Current);
+
+// --------------------------------------------------------------------------------------------------------------------
 
 auto
     UCk_Utils_Marker_UE::
-    Has(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> bool
+    TryGet_Marker(
+        const FCk_Handle& InMarkerOwnerEntity,
+        FGameplayTag      InMarkerName)
+    -> FCk_Handle_Marker
 {
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
+    return Get_EntityOrRecordEntry_WithFragmentAndLabel<
         UCk_Utils_Marker_UE,
         RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    return ck::IsValid(MarkerEntity);
 }
 
 auto
     UCk_Utils_Marker_UE::
-    Has_Any(
-        FCk_Handle InMarkerOwnerEntity)
-    -> bool
+    Get_Name(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> FGameplayTag
 {
-    return RecordOfMarkers_Utils::Has(InMarkerOwnerEntity);
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Ensure_Any(
-        FCk_Handle InMarkerOwnerEntity)
-    -> bool
-{
-    CK_ENSURE_IF_NOT(Has_Any(InMarkerOwnerEntity), TEXT("Handle [{}] does NOT have any Marker"), InMarkerOwnerEntity)
-    { return false; }
-
-    return true;
+    return UCk_Utils_GameplayLabel_UE::Get_Label(InMarkerEntity);
 }
 
 auto
     UCk_Utils_Marker_UE::
     Get_All(
         FCk_Handle InMarkerOwnerEntity)
-    -> TArray<FGameplayTag>
+    -> TArray<FCk_Handle_Marker>
 {
-    if (NOT Has_Any(InMarkerOwnerEntity))
-    { return {}; }
-
-    auto AllMarkers = TArray<FGameplayTag>{};
+    auto AllMarkers = TArray<FCk_Handle_Marker>{};
 
     RecordOfMarkers_Utils::ForEach_ValidEntry(InMarkerOwnerEntity, [&](FCk_Handle InMarkerEntity)
     {
-        AllMarkers.Emplace(UCk_Utils_GameplayLabel_UE::Get_Label(InMarkerEntity));
+        AllMarkers.Emplace(InMarkerEntity);
     });
 
     return AllMarkers;
@@ -124,28 +118,12 @@ auto
 
 auto
     UCk_Utils_Marker_UE::
-    Ensure(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> bool
-{
-    CK_ENSURE_IF_NOT(Has(InMarkerOwnerEntity ,InMarkerName), TEXT("Handle [{}] does NOT have a Marker with Name [{}]"), InMarkerOwnerEntity, InMarkerName)
-    { return false; }
-
-    return true;
-}
-
-auto
-    UCk_Utils_Marker_UE::
     PreviewAll(
-        UObject*   InOuter,
-        FCk_Handle InHandle)
+        UObject* InOuter,
+        const FCk_Handle& InHandle)
     -> void
 {
-    if (NOT Has_Any(InHandle))
-    { return; }
-
-    RecordOfMarkers_Utils::ForEach_ValidEntry(InHandle, [&](FCk_Handle InMarkerEntity)
+    RecordOfMarkers_Utils::ForEach_ValidEntry(InHandle, [&](const FCk_Handle& InMarkerEntity)
     {
         DoPreviewMarker(InOuter, InMarkerEntity);
     });
@@ -154,26 +132,113 @@ auto
 auto
     UCk_Utils_Marker_UE::
     Preview(
-        UObject*     InOuter,
-        FCk_Handle   InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
+        UObject* InOuter,
+        const FCk_Handle_Marker& InMarkerEntity)
     -> void
 {
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return; }
+    DoPreviewMarker(InOuter, InMarkerEntity);
+}
 
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
+auto
+    UCk_Utils_Marker_UE::
+    Get_PhysicsInfo(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> FCk_Marker_PhysicsInfo
+{
+    return InMarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_PhysicsParams();
+}
 
-    DoPreviewMarker(InOuter, MarkerEntity);
+auto
+    UCk_Utils_Marker_UE::
+    Get_ShapeInfo(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> FCk_Marker_ShapeInfo
+{
+    return InMarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_ShapeParams();
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    Get_DebugInfo(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> FCk_Marker_DebugInfo
+{
+    return InMarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_DebugParams();
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    Get_ReplicationType(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> ECk_Net_ReplicationType
+{
+    return InMarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_ReplicationType();
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    Get_EnableDisable(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> ECk_EnableDisable
+{
+    return InMarkerEntity.Get<ck::FFragment_Marker_Current>().Get_EnableDisable();
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    Get_ShapeComponent(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> UShapeComponent*
+{
+    return InMarkerEntity.Get<ck::FFragment_Marker_Current>().Get_Marker().Get();
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    Get_AttachedEntityAndActor(
+        const FCk_Handle_Marker& InMarkerEntity)
+    -> FCk_EntityOwningActor_BasicDetails
+{
+    return InMarkerEntity.Get<ck::FFragment_Marker_Current>().Get_AttachedEntityAndActor();
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    Request_EnableDisable(
+        FCk_Handle_Marker& InMarkerEntity,
+        const FCk_Request_Marker_EnableDisable& InRequest)
+    -> FCk_Handle_Marker
+{
+    InMarkerEntity.AddOrGet<ck::FFragment_Marker_Requests>()._Requests = InRequest;
+    return InMarkerEntity;
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    BindTo_OnEnableDisable(
+        FCk_Handle_Marker& InMarkerEntity,
+        ECk_Signal_BindingPolicy InBindingPolicy,
+        const FCk_Delegate_Marker_OnEnableDisable& InDelegate)
+    -> void
+{
+    ck::UUtils_Signal_OnMarkerEnableDisable::Bind(InMarkerEntity, InDelegate, InBindingPolicy);
+}
+
+auto
+    UCk_Utils_Marker_UE::
+    UnbindFrom_OnEnableDisable(
+        FCk_Handle_Marker& InMarkerEntity,
+        const FCk_Delegate_Marker_OnEnableDisable& InDelegate)
+    -> void
+{
+    ck::UUtils_Signal_OnMarkerEnableDisable::Unbind(InMarkerEntity, InDelegate);
 }
 
 auto
     UCk_Utils_Marker_UE::
     DoPreviewMarker(
         UObject* InOuter,
-        FCk_Handle InHandle)
+        const FCk_Handle_Marker& InHandle)
     -> void
 {
     const auto& Params = InHandle.Get<ck::FFragment_Marker_Params>();
@@ -184,194 +249,11 @@ auto
 
 auto
     UCk_Utils_Marker_UE::
-    Get_PhysicsInfo(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> FCk_Marker_PhysicsInfo
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return {}; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    return MarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_PhysicsParams();
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Get_ShapeInfo(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> FCk_Marker_ShapeInfo
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return {}; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    return MarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_ShapeParams();
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Get_DebugInfo(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> FCk_Marker_DebugInfo
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return {}; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    return MarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_DebugParams();
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Get_ReplicationType(
-        FCk_Handle   InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> ECk_Net_ReplicationType
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return {}; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    return MarkerEntity.Get<ck::FFragment_Marker_Params>().Get_Params().Get_ReplicationType();
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Get_EnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> ECk_EnableDisable
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return {}; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    return MarkerEntity.Get<ck::FFragment_Marker_Current>().Get_EnableDisable();
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Get_ShapeComponent(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName)
-    -> UShapeComponent*
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return {}; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    return MarkerEntity.Get<ck::FFragment_Marker_Current>().Get_Marker().Get();
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Get_AttachedEntityAndActor(
-        FCk_Handle InHandle,
-        FGameplayTag InMarkerName)
-    -> FCk_EntityOwningActor_BasicDetails
-{
-    if (NOT Ensure(InHandle, InMarkerName))
-    { return {}; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InHandle, InMarkerName);
-
-    return MarkerEntity.Get<ck::FFragment_Marker_Current>().Get_AttachedEntityAndActor();
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Request_EnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName,
-        const FCk_Request_Marker_EnableDisable& InRequest)
-    -> void
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return; }
-
-    auto MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    MarkerEntity.AddOrGet<ck::FFragment_Marker_Requests>()._Requests = InRequest;
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    BindTo_OnEnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName,
-        ECk_Signal_BindingPolicy InBindingPolicy,
-        const FCk_Delegate_Marker_OnEnableDisable& InDelegate)
-    -> void
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    ck::UUtils_Signal_OnMarkerEnableDisable::Bind(MarkerEntity, InDelegate, InBindingPolicy);
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    UnbindFrom_OnEnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName,
-        const FCk_Delegate_Marker_OnEnableDisable& InDelegate)
-    -> void
-{
-    if (NOT Ensure(InMarkerOwnerEntity, InMarkerName))
-    { return; }
-
-    const auto& MarkerEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
-        UCk_Utils_Marker_UE,
-        RecordOfMarkers_Utils>(InMarkerOwnerEntity, InMarkerName);
-
-    ck::UUtils_Signal_OnMarkerEnableDisable::Unbind(MarkerEntity, InDelegate);
-}
-
-auto
-    UCk_Utils_Marker_UE::
-    Has(
-        FCk_Handle InHandle)
-    -> bool
-{
-    return InHandle.Has_All<ck::FFragment_Marker_Params, ck::FFragment_Marker_Current>();
-}
-
-auto
-    UCk_Utils_Marker_UE::
     Request_MarkMarker_AsNeedToUpdateTransform(
-        FCk_Handle InMarkerHandle)
+        FCk_Handle_Marker& InMarkerEntity)
     -> void
 {
-    InMarkerHandle.Add<ck::FTag_Marker_UpdateTransform>();
+    InMarkerEntity.Add<ck::FTag_Marker_UpdateTransform>();
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Utils.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Utils.h
@@ -41,19 +41,19 @@ public:
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Marker",
-              DisplayName="[Ck][Marker] Add New Marker")
-    static void
+              DisplayName="[Ck][Marker] Try Add New Marker")
+    static FCk_Handle_Marker
     Add(
-        FCk_Handle InHandle,
+        FCk_Handle& InHandle,
         const FCk_Fragment_Marker_ParamsData& InParams,
         ECk_Net_ReplicationType InReplicationType = ECk_Net_ReplicationType::All);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Marker",
               DisplayName="[Ck][Marker] Add Multiple New Markers")
-    static void
+    static TArray<FCk_Handle_Marker>
     AddMultiple(
-        FCk_Handle InHandle,
+        FCk_Handle& InHandle,
         const FCk_Fragment_MultipleMarker_ParamsData& InParams,
         ECk_Net_ReplicationType InReplicationType = ECk_Net_ReplicationType::All);
 
@@ -64,7 +64,7 @@ public:
     static void
     PreviewAll(
         UObject* InOuter,
-        FCk_Handle InHandle);
+        const FCk_Handle& InHandle);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Marker",
@@ -73,45 +73,54 @@ public:
     static void
     Preview(
         UObject* InOuter,
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
 public:
     UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|Marker",
-              DisplayName="[Ck][Marker] Has Marker")
+        Category = "Ck|Utils|Marker",
+        DisplayName="[Ck][Marker] Has Marker")
     static bool
     Has(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle& InHandle);
 
     UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|Marker",
-              DisplayName="[Ck][Marker] Has Any Marker")
-    static bool
-    Has_Any(
-        FCk_Handle InMarkerOwnerEntity);
+        Category = "Ck|Utils|Marker",
+        DisplayName="[Ck][Marker] Cast",
+        meta = (ExpandEnumAsExecs = "OutResult"))
+    static FCk_Handle_Marker
+    Cast(
+        const FCk_Handle&    InHandle,
+        ECk_SucceededFailed& OutResult);
 
     UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|Marker",
-              DisplayName="[Ck][Marker] Ensure Has Marker")
-    static bool
-    Ensure(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
-
-    UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|Marker",
-              DisplayName="[Ck][Marker] Ensure Has Any Marker")
-    static bool
-    Ensure_Any(
-        FCk_Handle InMarkerOwnerEntity);
+        Category = "Ck|Utils|Marker",
+        DisplayName="[Ck][Marker] Handle -> Marker Handle",
+        meta = (CompactNodeTitle = "As MarkerHandle", BlueprintAutocast))
+    static FCk_Handle_Marker
+    Conv_HandleToMarker(
+        const FCk_Handle& InHandle);
 
 public:
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Marker",
+              DisplayName="[Ck][Marker] Get Handle")
+    static FCk_Handle_Marker
+    TryGet_Marker(
+        const FCk_Handle& InMarkerOwnerEntity,
+        FGameplayTag      InMarkerName);
+
+public:
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Marker",
+              DisplayName="[Ck][Marker] Get Name")
+    static FGameplayTag
+    Get_Name(
+        const FCk_Handle_Marker& InMarkerEntity);
+
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Marker",
               DisplayName="[Ck][Marker] Get All Markers")
-    static TArray<FGameplayTag>
+    static TArray<FCk_Handle_Marker>
     Get_All(
         FCk_Handle InMarkerOwnerEntity);
 
@@ -121,65 +130,57 @@ public:
               DisplayName = "[Ck][Marker] Get Physics Info")
     static FCk_Marker_PhysicsInfo
     Get_PhysicsInfo(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Marker",
               DisplayName = "[Ck][Marker] Get Shape Info")
     static FCk_Marker_ShapeInfo
     Get_ShapeInfo(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Marker",
               DisplayName = "[Ck][Marker] Get Debug Info")
     static FCk_Marker_DebugInfo
     Get_DebugInfo(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Marker",
               DisplayName = "[Ck][Marker] Get Replication Type")
     static ECk_Net_ReplicationType
     Get_ReplicationType(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Marker",
               DisplayName = "[Ck][Marker] Get Enable Disable")
     static ECk_EnableDisable
     Get_EnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Marker",
               DisplayName = "[Ck][Marker] Get Shape Component")
     static UShapeComponent*
     Get_ShapeComponent(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Marker",
               DisplayName = "[Ck][Marker] Get Attached Entity And Actor")
     static FCk_EntityOwningActor_BasicDetails
     Get_AttachedEntityAndActor(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName);
+        const FCk_Handle_Marker& InMarkerEntity);
 
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Marker",
               DisplayName = "[Ck][Marker] Request Enable/Disable")
-    static void
+    static FCk_Handle_Marker
     Request_EnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName,
+        FCk_Handle_Marker& InMarkerEntity,
         const FCk_Request_Marker_EnableDisable& InRequest);
 
 public:
@@ -188,8 +189,7 @@ public:
               DisplayName = "[Ck][Marker] Bind To OnEnableDisable")
     static void
     BindTo_OnEnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName,
+        FCk_Handle_Marker& InMarkerEntity,
         ECk_Signal_BindingPolicy InBindingPolicy,
         const FCk_Delegate_Marker_OnEnableDisable& InDelegate);
 
@@ -198,23 +198,18 @@ public:
               DisplayName = "[Ck][Marker] Unbind From OnEnableDisable")
     static void
     UnbindFrom_OnEnableDisable(
-        FCk_Handle InMarkerOwnerEntity,
-        FGameplayTag InMarkerName,
+        FCk_Handle_Marker& InMarkerEntity,
         const FCk_Delegate_Marker_OnEnableDisable& InDelegate);
 
 private:
     static auto
-    Has(
-        FCk_Handle InHandle) -> bool;
-
-    static auto
     DoPreviewMarker(
         UObject* InOuter,
-        FCk_Handle InHandle) -> void;
+        const FCk_Handle_Marker& InMarkerEntity) -> void;
 
     static auto
     Request_MarkMarker_AsNeedToUpdateTransform(
-        FCk_Handle InMarkerHandle) -> void;
+        FCk_Handle_Marker& InMarkerEntity) -> void;
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
@@ -235,7 +235,7 @@ namespace ck
         { return; }
 
         const auto& OverlappedMarkerEnableDisable = UCk_Utils_Marker_UE::
-            Get_EnableDisable(OverlappedMarkerEntity, OverlappedMarkerName);
+            Get_EnableDisable(OverlappedMarkerEntity);
 
         CK_ENSURE_IF_NOT(OverlappedMarkerEnableDisable == ECk_EnableDisable::Enable,
             TEXT("Sensor [Name: {} | Entity: {}] received BeginOverlap with Marker [Name: {} | Entity: {}] that is DISABLED"),
@@ -298,7 +298,7 @@ namespace ck
         if (NOT InCurrentComp._CurrentMarkerOverlaps.Get_HasOverlapWithMarker(OverlappedMarkerDetails))
         { return; }
 
-        const auto& OverlappedMarkerEnableDisable = UCk_Utils_Marker_UE::Get_EnableDisable(OverlappedMarkerEntity, OverlappedMarkerName);
+        const auto& OverlappedMarkerEnableDisable = UCk_Utils_Marker_UE::Get_EnableDisable(OverlappedMarkerEntity);
 
         CK_ENSURE_IF_NOT(OverlappedMarkerEnableDisable == ECk_EnableDisable::Enable,
             TEXT("Sensor [Name: {} | Entity: {}] received EndOverlap with Marker [Name: {} | Entity: {}] that is DISABLED"),

--- a/Source/CkTimer/Public/CkTimer/CkTimer_Utils.cpp
+++ b/Source/CkTimer/Public/CkTimer/CkTimer_Utils.cpp
@@ -98,14 +98,9 @@ auto
         FGameplayTag InTimerName)
     -> FCk_Handle_Timer
 {
-    const auto FoundEntity = Get_EntityOrRecordEntry_WithFragmentAndLabel<
+    return Get_EntityOrRecordEntry_WithFragmentAndLabel<
         UCk_Utils_Timer_UE,
         RecordOfTimers_Utils>(InTimerOwnerEntity, InTimerName);
-
-    if (ck::Is_NOT_Valid(FoundEntity))
-    { return {}; }
-
-    return Conv_HandleToTimer(FoundEntity);
 }
 
 auto


### PR DESCRIPTION
…tead of requireing the owning Entity and a GameplayTag) - Marker is now using type-safe handles

notes: requiring the Marker Entity only greatly reduces the complexity of the interface. This is a similar treatment we gave the Timer some time ago.