### PR TITLE
feat: Sensor interface now requires the Sensor Entity explicitly (ins…

### DIFF
--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Fragment.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Fragment.h
@@ -109,7 +109,7 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    CK_DEFINE_RECORD_OF_ENTITIES(FFragment_RecordOfSensors, FCk_Handle);
+    CK_DEFINE_RECORD_OF_ENTITIES(FFragment_RecordOfSensors, FCk_Handle_Sensor);
 
     // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Fragment_Data.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Fragment_Data.h
@@ -33,6 +33,12 @@ CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_Sensor_AttachmentPolicy);
 
 // --------------------------------------------------------------------------------------------------------------------
 
+USTRUCT(BlueprintType, meta=(HasNativeMake, HasNativeBreak="/Script/CkEcs.Ck_Utils_Handle_UE:Conv_HandleTypeSafeToHandle"))
+struct CKOVERLAPBODY_API FCk_Handle_Sensor : public FCk_Handle_TypeSafe { GENERATED_BODY()  CK_GENERATED_BODY_HANDLE_TYPESAFE(FCk_Handle_Sensor); };
+CK_DEFINE_CUSTOM_ISVALID_AND_FORMATTER_HANDLE_TYPESAFE(FCk_Handle_Sensor);
+
+// --------------------------------------------------------------------------------------------------------------------
+
 USTRUCT(BlueprintType)
 struct CKOVERLAPBODY_API FCk_Sensor_BeginOverlap_UnrealDetails
 {
@@ -199,7 +205,7 @@ public:
 public:
     FCk_Sensor_NonMarkerOverlapInfo() = default;
     explicit FCk_Sensor_NonMarkerOverlapInfo(
-        FCk_Sensor_BeginOverlap_UnrealDetails InOverlapDetails);
+        const FCk_Sensor_BeginOverlap_UnrealDetails& InOverlapDetails);
 
 public:
     auto operator==(const ThisType& InOther) const -> bool;
@@ -233,7 +239,7 @@ public:
 public:
     FCk_Sensor_MarkerOverlaps() = default;
     explicit FCk_Sensor_MarkerOverlaps(
-        SensorOverlapInfoList InOverlaps);
+        const SensorOverlapInfoList& InOverlaps);
 
 public:
     auto Process_Add(
@@ -274,7 +280,7 @@ public:
 public:
     FCk_Sensor_NonMarkerOverlaps() = default;
     explicit FCk_Sensor_NonMarkerOverlaps(
-        SensorOverlapInfoList InOverlaps);
+        const SensorOverlapInfoList& InOverlaps);
 
 public:
     auto Process_Add(
@@ -409,7 +415,7 @@ public:
 public:
     FCk_Sensor_ShapeInfo() = default;
     explicit FCk_Sensor_ShapeInfo(
-        FCk_ShapeDimensions InShapeDimensions);
+        const FCk_ShapeDimensions& InShapeDimensions);
 
 private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
@@ -432,7 +438,8 @@ public:
 
 public:
     FCk_Sensor_FilteringInfo() = default;
-    explicit FCk_Sensor_FilteringInfo(TArray<FGameplayTag> InMarkerNames);
+    explicit FCk_Sensor_FilteringInfo(
+        const TArray<FGameplayTag>& InMarkerNames);
 
 private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite,

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
@@ -503,10 +503,9 @@ namespace ck
             if (ck::Is_NOT_Valid(InSensorCurrent.Get_Sensor()))
             { return; }
 
-            const auto& SensorName = InSensorParams.Get_Params().Get_SensorName();
             const auto& OuterForDebugDraw = InSensorCurrent.Get_AttachedEntityAndActor().Get_Actor().Get();
 
-            UCk_Utils_Sensor_UE::Preview(OuterForDebugDraw, FCk_Handle{ InSensorEntity, _Registry } ,SensorName);
+            UCk_Utils_Sensor_UE::Preview(OuterForDebugDraw, FCk_Handle_Sensor{ InSensorEntity, _Registry });
         });
     }
 }

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.h
@@ -9,8 +9,9 @@
 
 namespace ck
 {
-    class CKOVERLAPBODY_API FProcessor_Sensor_Setup : public TProcessor<
+    class CKOVERLAPBODY_API FProcessor_Sensor_Setup : public ck_exp::TProcessor<
             FProcessor_Sensor_Setup,
+            FCk_Handle_Sensor,
             FFragment_Sensor_Current,
             FFragment_Sensor_Params,
             FTag_Sensor_NeedsSetup,
@@ -35,8 +36,9 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    class CKOVERLAPBODY_API FProcessor_Sensor_HandleRequests : public TProcessor<
+    class CKOVERLAPBODY_API FProcessor_Sensor_HandleRequests : public ck_exp::TProcessor<
             FProcessor_Sensor_HandleRequests,
+            FCk_Handle_Sensor,
             FFragment_Sensor_Current,
             FFragment_Sensor_Params,
             FFragment_Sensor_Requests,
@@ -90,8 +92,9 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    class CKOVERLAPBODY_API FProcessor_Sensor_UpdateTransform : public TProcessor<
+    class CKOVERLAPBODY_API FProcessor_Sensor_UpdateTransform : public ck_exp::TProcessor<
             FProcessor_Sensor_UpdateTransform,
+            FCk_Handle_Sensor,
             FFragment_Sensor_Current,
             FFragment_Sensor_Params,
             FTag_Sensor_UpdateTransform,

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Utils.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Utils.h
@@ -40,19 +40,19 @@ public:
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
-              DisplayName="[Ck][Sensor] Add New Sensor")
-    static void
+              DisplayName="[Ck][Sensor] Try Add New Sensor")
+    static FCk_Handle_Sensor
     Add(
-        FCk_Handle InHandle,
+        FCk_Handle& InHandle,
         const FCk_Fragment_Sensor_ParamsData& InParams,
         ECk_Net_ReplicationType InReplicationType = ECk_Net_ReplicationType::All);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName="[Ck][Sensor] Add Multiple New Sensors")
-    static void
+    static TArray<FCk_Handle_Sensor>
     AddMultiple(
-        FCk_Handle InHandle,
+        FCk_Handle& InHandle,
         const FCk_Fragment_MultipleSensor_ParamsData& InParams,
         ECk_Net_ReplicationType InReplicationType = ECk_Net_ReplicationType::All);
 
@@ -63,7 +63,7 @@ public:
     static void
     PreviewAll(
         UObject* InOuter,
-        FCk_Handle InHandle);
+        const FCk_Handle& InHandle);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
@@ -72,47 +72,49 @@ public:
     static void
     Preview(
         UObject* InOuter,
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
+
+public:
+    UFUNCTION(BlueprintPure,
+        Category = "Ck|Utils|Sensor",
+        DisplayName="[Ck][Sensor] Has Sensor")
+    static bool
+    Has(
+        const FCk_Handle& InHandle);
+
+    UFUNCTION(BlueprintPure,
+        Category = "Ck|Utils|Sensor",
+        DisplayName="[Ck][Sensor] Cast",
+        meta = (ExpandEnumAsExecs = "OutResult"))
+    static FCk_Handle_Sensor
+    Cast(
+        const FCk_Handle&    InHandle,
+        ECk_SucceededFailed& OutResult);
+
+    UFUNCTION(BlueprintPure,
+        Category = "Ck|Utils|Sensor",
+        DisplayName="[Ck][Sensor] Handle -> Sensor Handle",
+        meta = (CompactNodeTitle = "As SensorHandle", BlueprintAutocast))
+    static FCk_Handle_Sensor
+    Conv_HandleToSensor(
+        const FCk_Handle& InHandle);
 
 public:
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
-              DisplayName="[Ck][Sensor] Has Sensor")
-    static bool
-    Has(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
-
-    UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|Sensor",
-              DisplayName="[Ck][Sensor] Has Any Sensor")
-    static bool
-    Has_Any(
-        FCk_Handle InSensorOwnerEntity);
-
-    UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|Sensor",
-              DisplayName="[Ck][Sensor] Ensure Has Sensor")
-    static bool
-    Ensure(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
-
-    UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|Sensor",
-              DisplayName="[Ck][Sensor] Ensure Has Any Sensor")
-    static bool
-    Ensure_Any(
-        FCk_Handle InSensorOwnerEntity);
+              DisplayName="[Ck][Sensor] Get Handle")
+    static FCk_Handle_Sensor
+    TryGet_Sensor(
+        const FCk_Handle& InSensorOwnerEntity,
+        FGameplayTag      InSensorName);
 
 public:
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName="[Ck][Sensor] Get All Sensors")
-    static TArray<FGameplayTag>
+    static TArray<FCk_Handle_Sensor>
     Get_All(
-        FCk_Handle InSensorOwnerEntity);
+        const FCk_Handle& InSensorOwnerEntity);
 
 public:
     UFUNCTION(BlueprintPure,
@@ -120,228 +122,203 @@ public:
               DisplayName = "[Ck][Sensor] Get Replication Type")
     static ECk_Net_ReplicationType
     Get_ReplicationType(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Physics Info")
     static FCk_Sensor_PhysicsInfo
     Get_PhysicsInfo(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Shape Info")
     static FCk_Sensor_ShapeInfo
     Get_ShapeInfo(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Debug Info")
     static FCk_Sensor_DebugInfo
     Get_DebugInfo(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Enable Disable")
     static ECk_EnableDisable
     Get_EnableDisable(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Shape Component")
     static UShapeComponent*
     Get_ShapeComponent(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Attached Entity And Actor")
     static FCk_EntityOwningActor_BasicDetails
     Get_AttachedEntityAndActor(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Has Any Marker Overlaps")
     static bool
     Get_HasMarkerOverlaps(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get All Marker Overlaps")
     static FCk_Sensor_MarkerOverlaps
     Get_AllMarkerOverlaps(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get Has Any Non-Marker Overlaps")
     static bool
     Get_HasNonMarkerOverlaps(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Get All Non-Marker Overlaps")
     static FCk_Sensor_NonMarkerOverlaps
     Get_AllNonMarkerOverlaps(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName);
+        const FCk_Handle_Sensor& InSensorEntity);
 
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Request Enable/Disable")
-    static void
+    static FCk_Handle_Sensor
     Request_EnableDisable(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Request_Sensor_EnableDisable& InRequest);
 
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Bind To OnEnableDisable")
-    static void
+    static FCk_Handle_Sensor
     BindTo_OnEnableDisable(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         ECk_Signal_BindingPolicy InBindingPolicy,
         const FCk_Delegate_Sensor_OnEnableDisable& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Unbind From OnEnableDisable")
-    static void
+    static FCk_Handle_Sensor
     UnbindFrom_OnEnableDisable(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Delegate_Sensor_OnEnableDisable& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Bind To OnBeginOverlap")
-    static void
+    static FCk_Handle_Sensor
     BindTo_OnBeginOverlap(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         ECk_Signal_BindingPolicy InBindingPolicy,
         const FCk_Delegate_Sensor_OnBeginOverlap& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Unbind From OnBeginOverlap")
-    static void
+    static FCk_Handle_Sensor
     UnbindFrom_OnBeginOverlap(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Delegate_Sensor_OnBeginOverlap& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Bind To OnEndOverlap")
-    static void
+    static FCk_Handle_Sensor
     BindTo_OnEndOverlap(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         ECk_Signal_BindingPolicy InBindingPolicy,
         const FCk_Delegate_Sensor_OnEndOverlap& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Unbind From OnEndOverlap")
-    static void
+    static FCk_Handle_Sensor
     UnbindFrom_OnEndOverlap(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Delegate_Sensor_OnEndOverlap& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Bind To OnBeginOverlap_NonMarker")
-    static void
+    static FCk_Handle_Sensor
     BindTo_OnBeginOverlap_NonMarker(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         ECk_Signal_BindingPolicy InBindingPolicy,
         const FCk_Delegate_Sensor_OnBeginOverlap_NonMarker& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Unbind From OnBeginOverlap_NonMarker")
-    static void
+    static FCk_Handle_Sensor
     UnbindFrom_OnBeginOverlap_NonMarker(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Delegate_Sensor_OnBeginOverlap_NonMarker& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Bind To OnEndOverlap_NonMarker")
-    static void
+    static FCk_Handle_Sensor
     BindTo_OnEndOverlap_NonMarker(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         ECk_Signal_BindingPolicy InBindingPolicy,
         const FCk_Delegate_Sensor_OnEndOverlap_NonMarker& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Sensor",
               DisplayName = "[Ck][Sensor] Unbind From OnEndOverlap_NonMarker")
-    static void
+    static FCk_Handle_Sensor
     UnbindFrom_OnEndOverlap_NonMarker(
-        FCk_Handle InSensorOwnerEntity,
-        FGameplayTag InSensorName,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Delegate_Sensor_OnEndOverlap_NonMarker& InDelegate);
 
 public:
     static auto
     Request_OnBeginOverlap(
-        FCk_Handle InSensorHandle,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Request_Sensor_OnBeginOverlap& InRequest) -> void;
 
     static auto
     Request_OnEndOverlap(
-        FCk_Handle InSensorHandle,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Request_Sensor_OnEndOverlap& InRequest) -> void;
 
     static auto
     Request_OnBeginOverlap_NonMarker(
-        FCk_Handle InSensorHandle,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Request_Sensor_OnBeginOverlap_NonMarker& InRequest) -> void;
 
     static auto
     Request_OnEndOverlap_NonMarker(
-        FCk_Handle InSensorHandle,
+        FCk_Handle_Sensor& InSensorEntity,
         const FCk_Request_Sensor_OnEndOverlap_NonMarker& InRequest) -> void;
 
 private:
     static auto
-    Has(
-        FCk_Handle InSensorHandle) -> bool;
-    static auto
     DoPreviewSensor(
         UObject* InOuter,
-        FCk_Handle InHandle) -> void;
+        const FCk_Handle_Sensor& InHandle) -> void;
 
     static auto
     Request_MarkSensor_AsNeedToUpdateTransform(
-        FCk_Handle InSensorHandle) -> void;
+        FCk_Handle_Sensor& InSensorHandle) -> void;
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…tead of requiring the owning Entity and a GameplayTag) - Sensor is now using type-safe handles

notes: requiring the Sensor Entity only greatly reduces the complexity of the interface. This is a similar treatment we gave the Timer some time ago.