### PR TITLE
Ability owner self Ability deactivation Fix

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.h
@@ -24,20 +24,6 @@ CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_AbilityOwner_AbilitySearch_Policy);
 
 // --------------------------------------------------------------------------------------------------------------------
 
-UENUM(BlueprintType)
-enum class ECk_AbilityOwner_ForEachAbility_Policy : uint8
-{
-    // If the AbilityOwner is also an Ability, SKIP it as when iterating over the list of abilities
-    IgnoreSelf,
-
-    // If the AbilityOwner is also an Ability, INCLUDE it as when iterating over the list of abilities
-    IncludeSelfIfApplicable,
-};
-
-CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_AbilityOwner_ForEachAbility_Policy);
-
-// --------------------------------------------------------------------------------------------------------------------
-
 USTRUCT(BlueprintType, meta=(HasNativeMake, HasNativeBreak="/Script/CkEcs.Ck_Utils_Handle_UE:Conv_HandleTypeSafeToHandle"))
 struct CKABILITY_API FCk_Handle_AbilityOwner : public FCk_Handle_TypeSafe { GENERATED_BODY() CK_GENERATED_BODY_HANDLE_TYPESAFE(FCk_Handle_AbilityOwner); };
 CK_DEFINE_CUSTOM_ISVALID_AND_FORMATTER_HANDLE_TYPESAFE(FCk_Handle_AbilityOwner);

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -330,11 +330,24 @@ namespace ck
                 }
             }
 
+            // Try Deactivate our own Ability if we have one
+            if (UCk_Utils_Ability_UE::Has(InAbilityOwnerEntity))
+            {
+                if (const auto Condition = algo::MatchesAnyAbilityActivationCancelledTags{GrantedTags};
+                    Condition(InAbilityOwnerEntity))
+                {
+                    auto MyOwner = UCk_Utils_AbilityOwner_UE::Conv_HandleToAbilityOwner(
+                            UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAbilityOwnerEntity));
+
+                    UCk_Utils_AbilityOwner_UE::Request_DeactivateAbility(MyOwner,
+                        FCk_Request_AbilityOwner_DeactivateAbility{InAbilityOwnerEntity});
+                }
+            }
+
             // Cancel All Abilities that are cancelled by the newly granted tags
             UCk_Utils_AbilityOwner_UE::ForEach_Ability_If
             (
                 InAbilityOwnerEntity,
-                ECk_AbilityOwner_ForEachAbility_Policy::IncludeSelfIfApplicable,
                 [&](const FCk_Handle& InAbilityEntityToCancel)
                 {
                     ability::Verbose
@@ -352,20 +365,6 @@ namespace ck
                 },
                 algo::MatchesAnyAbilityActivationCancelledTags{GrantedTags}
             );
-
-            if (UCk_Utils_Ability_UE::Has(InAbilityOwnerEntity))
-            {
-                const auto Condition = algo::MatchesAnyAbilityActivationCancelledTags{GrantedTags};
-
-                if (Condition(InAbilityOwnerEntity))
-                {
-                    auto MyOwner = UCk_Utils_AbilityOwner_UE::Conv_HandleToAbilityOwner(
-                            UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAbilityOwnerEntity));
-
-                    UCk_Utils_AbilityOwner_UE::Request_DeactivateAbility(MyOwner,
-                        FCk_Request_AbilityOwner_DeactivateAbility{InAbilityOwnerEntity});
-                }
-            }
 
             auto& RequestsComp = InAbilityOwnerEntity.Get<FFragment_AbilityOwner_Requests>();
             const auto NumNewRequests = RequestsComp.Get_Requests().Num();

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
@@ -99,14 +99,13 @@ auto
     UCk_Utils_AbilityOwner_UE::
     ForEach_Ability(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate)
     -> TArray<FCk_Handle_Ability>
 {
     auto Abilities = TArray<FCk_Handle_Ability>{};
 
-    ForEach_Ability(InAbilityOwnerEntity, InForEachAbilityPolicy, [&](FCk_Handle_Ability& InAbility)
+    ForEach_Ability(InAbilityOwnerEntity, [&](FCk_Handle_Ability& InAbility)
     {
         if (InDelegate.IsBound())
         { InDelegate.Execute(InAbility, InOptionalPayload); }
@@ -121,7 +120,6 @@ auto
     UCk_Utils_AbilityOwner_UE::
     ForEach_Ability(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const TFunction<void(FCk_Handle_Ability&)>& InFunc)
     -> void
 {
@@ -133,9 +131,6 @@ auto
         InAbilityOwnerEntity,
         [&](FCk_Handle_Ability InAbilityEntity)
         {
-            if (InForEachAbilityPolicy == ECk_AbilityOwner_ForEachAbility_Policy::IgnoreSelf && InAbilityEntity == InAbilityOwnerEntity)
-            { return; }
-
             InFunc(InAbilityEntity);
         }
     );
@@ -145,7 +140,6 @@ auto
     UCk_Utils_AbilityOwner_UE::
     ForEach_Ability_If(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate,
         const FCk_Predicate_InHandle_OutResult& InPredicate)
@@ -156,7 +150,6 @@ auto
     ForEach_Ability_If
     (
         InAbilityOwnerEntity,
-        InForEachAbilityPolicy,
         [&](const FCk_Handle_Ability& InAbility)
         {
             if (InDelegate.IsBound())
@@ -185,7 +178,6 @@ auto
     UCk_Utils_AbilityOwner_UE::
     ForEach_Ability_If(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const TFunction<void(FCk_Handle_Ability)>& InFunc,
         const TFunction<bool(FCk_Handle_Ability)>& InPredicate)
     -> void
@@ -196,11 +188,8 @@ auto
     RecordOfAbilities_Utils::ForEach_ValidEntry_If
     (
         InAbilityOwnerEntity,
-        [&](FCk_Handle_Ability InAbilityEntity)
+        [&](const FCk_Handle_Ability& InAbilityEntity)
         {
-            if (InForEachAbilityPolicy == ECk_AbilityOwner_ForEachAbility_Policy::IgnoreSelf && InAbilityEntity == InAbilityOwnerEntity)
-            { return; }
-
             InFunc(InAbilityEntity);
         },
         InPredicate
@@ -212,14 +201,13 @@ auto
     ForEach_Ability_WithStatus(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
         ECk_Ability_Status InStatus,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate)
     -> TArray<FCk_Handle_Ability>
 {
     auto Abilities = TArray<FCk_Handle_Ability>{};
 
-    ForEach_Ability_WithStatus(InAbilityOwnerEntity, InStatus, InForEachAbilityPolicy, [&](FCk_Handle_Ability InAbility)
+    ForEach_Ability_WithStatus(InAbilityOwnerEntity, InStatus, [&](FCk_Handle_Ability InAbility)
     {
         if (InDelegate.IsBound())
         { InDelegate.Execute(InAbility, InOptionalPayload); }
@@ -235,18 +223,14 @@ auto
     ForEach_Ability_WithStatus(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
         ECk_Ability_Status InStatus,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const TFunction<void(FCk_Handle_Ability)>& InFunc)
     -> void
 {
     if (NOT Has_Any(InAbilityOwnerEntity))
     { return; }
 
-    ForEach_Ability(InAbilityOwnerEntity, InForEachAbilityPolicy, [&](FCk_Handle_Ability InAbility)
+    ForEach_Ability(InAbilityOwnerEntity, [&](const FCk_Handle_Ability& InAbility)
     {
-        if (InForEachAbilityPolicy == ECk_AbilityOwner_ForEachAbility_Policy::IgnoreSelf && InAbility == InAbilityOwnerEntity)
-        { return; }
-
         if (UCk_Utils_Ability_UE::Get_Status(UCk_Utils_Ability_UE::Conv_HandleToAbility(InAbility)) == InStatus)
         {
             InFunc(InAbility);

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
@@ -119,13 +119,11 @@ public:
     static TArray<FCk_Handle_Ability>
     ForEach_Ability(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate);
     static auto
     ForEach_Ability(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const TFunction<void(UPARAM(ref) FCk_Handle_Ability&)>& InFunc) -> void;
 
     UFUNCTION(BlueprintCallable,
@@ -135,14 +133,12 @@ public:
     static TArray<FCk_Handle_Ability>
     ForEach_Ability_If(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate,
         const FCk_Predicate_InHandle_OutResult& InPredicate);
     static auto
     ForEach_Ability_If(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const TFunction<void(FCk_Handle_Ability)>& InFunc,
         const TFunction<bool(FCk_Handle_Ability)>& InPredicate) -> void;
 
@@ -154,14 +150,12 @@ public:
     ForEach_Ability_WithStatus(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
         ECk_Ability_Status InStatus,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate);
     static auto
     ForEach_Ability_WithStatus(
         const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
         ECk_Ability_Status InStatus,
-        ECk_AbilityOwner_ForEachAbility_Policy InForEachAbilityPolicy,
         const TFunction<void(FCk_Handle_Ability)>& InFunc) -> void;
 
 public:


### PR DESCRIPTION
commit fd6eaee803a9912073434d6ca45f5faa2d2c3cc2 (HEAD -> feature/fire-tags-updated-if-changed-only, origin/feature/fire-tags-updated-if-changed-only)
Author: Sulfur-CK <sulfur@chainkemists.com>
Date:   Thu Feb 8 15:33:59 2024 -0800

    refactor: removed the AbilityOwner ForEachAbility_Policy which creates landmines

    notes: the initial idea was 'clever' in that we allow you to iterate over all Abilities including your own Ability (IF as an AbilityOwner you also own an Ability). However, this creates a landmine where if the programmer does not think through the logic that they put inside ForEach/ForEach_If, they may use incorrect Entities for the On-Self Ability vs the rest of the Abilities that the AbilityOwner owns. This exact scenario was a bug that was fixed in the previous commit in our AbilityOwner Processors.

    side-note: the AbilityOwner Processor logic would have been far simpler if we had Ability Processors Activate/Deactivate instead of the responsibility landing on the AbilityOwner. Iteration usually complicates the logic, and it's no different in this case.

    buddy: Adam

commit 0dda1e290031103ad30be0d5609afbb612b385c6
Author: Sulfur-CK <sulfur@chainkemists.com>
Date:   Thu Feb 8 14:56:19 2024 -0800

    fix: an AbilityOwner which is also an Ability no longer passes in incorrect information when deactivating

    notes: when an Ability, who is also an AbilityOwner, reacts to tags that are added to itself, it would deactivate itself (which is the correct thing to do) BUT would pass in ITSELF as the AbilityOwner, which is incorrect. Due to type-safe handles, this should technically NOT be possible, BUT at an earlier stage of developing this Processor, we made the (incorrect) decision to add an AbilityOwner's own Ability (if there is one) to its list of Abilities to simplify the Processor's logic. This obviously did not work out as intended. Now, the code _can_ be fixed by reasoning about it in the For_Each loop (see changes) BUT that just makes it tribal knowledge and a land mine to step on later. So, we now remove the original logic of adding an AbilityOwner's Ability to it's list of Abilities and then reason about the owned Ability separately.

    buddy: Adam