### PR TITLE
feat: utils with type-safe handles now have C++ Cast/CastChecked func…

### DIFF
--- a/Config/DefaultCkFoundation.ini
+++ b/Config/DefaultCkFoundation.ini
@@ -84,3 +84,19 @@
 +PropertyRedirects=(OldName="/Script/CkAbility.Ck_Request_AbilityOwner_ActivateAbility._ActivationPayload",NewName="/Script/CkAbility.Ck_Request_AbilityOwner_ActivateAbility._OptionalPayload")
 
 +StructRedirects=(OldName="/Script/CkAbility.Ck_Ability_ActivationPayload",NewName="/Script/CkAbility.Ck_Ability_Payload_OnActivate")
+
++FunctionRedirects=(OldName="/Script/CkTimer.Ck_Utils_Timer_UE.Cast",NewName="/Script/CkTimer.Ck_Utils_Timer_UE.DoCast")
++FunctionRedirects=(OldName="/Script/CkOverlapBody.Ck_Utils_Sensor_UE.Cast",NewName="/Script/CkOverlapBody.Ck_Utils_Sensor_UE.DoCast")
++FunctionRedirects=(OldName="/Script/CkOverlapBody.Ck_Utils_Marker_UE.Cast",NewName="/Script/CkOverlapBody.Ck_Utils_Marker_UE.DoCast")
++FunctionRedirects=(OldName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.Cast",NewName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.DoCast")
++FunctionRedirects=(OldName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.Cast",NewName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.DoCast")
++FunctionRedirects=(OldName="/Script/CkAbility.Ck_Utils_AbilityOwner_UE.Cast",NewName="/Script/CkAbility.Ck_Utils_AbilityOwner_UE.DoCast")
++FunctionRedirects=(OldName="/Script/CkAbility.Ck_Utils_Ability_UE.Cast",NewName="/Script/CkAbility.Ck_Utils_Ability_UE.DoCast")
+
++FunctionRedirects=(OldName="/Script/CkTimer.Ck_Utils_Timer_UE.Conv_HandleToTimer",NewName="/Script/CkTimer.Ck_Utils_Timer_UE.DoCastChecked")
++FunctionRedirects=(OldName="/Script/CkOverlapBody.Ck_Utils_Sensor_UE.Conv_HandleToSensor",NewName="/Script/CkOverlapBody.Ck_Utils_Sensor_UE.DoCastChecked")
++FunctionRedirects=(OldName="/Script/CkOverlapBody.Ck_Utils_Marker_UE.Conv_HandleToMarker",NewName="/Script/CkOverlapBody.Ck_Utils_Marker_UE.DoCastChecked")
++FunctionRedirects=(OldName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.Conv_HandleToAnimAsset",NewName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.DoCastChecked")
++FunctionRedirects=(OldName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.Conv_HandleToAnimAsset",NewName="/Script/CkAnimation.Ck_Utils_AnimAsset_UE.DoCastChecked")
++FunctionRedirects=(OldName="/Script/CkAbility.Ck_Utils_AbilityOwner_UE.Conv_HandleToAbilityOwner",NewName="/Script/CkAbility.Ck_Utils_AbilityOwner_UE.DoCastChecked")
++FunctionRedirects=(OldName="/Script/CkAbility.Ck_Utils_Ability_UE.Conv_HandleToAbility",NewName="/Script/CkAbility.Ck_Utils_Ability_UE.DoCastChecked")

--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.cpp
@@ -163,7 +163,7 @@ auto
         Get_AbilityHandle(), this)
     { return; }
 
-    auto AbilityAsAbilityOwner = UCk_Utils_AbilityOwner_UE::Conv_HandleToAbilityOwner(_AbilityHandle);
+    auto AbilityAsAbilityOwner = UCk_Utils_AbilityOwner_UE::CastChecked(_AbilityHandle);
     UCk_Utils_AbilityOwner_UE::Request_SendAbilityEvent
     (
         AbilityAsAbilityOwner,
@@ -219,7 +219,7 @@ auto
         Get_AbilityHandle(), this)
     { return; }
 
-    auto AbilityAsAbilityOwner = UCk_Utils_AbilityOwner_UE::Conv_HandleToAbilityOwner(_AbilityHandle);
+    auto AbilityAsAbilityOwner = UCk_Utils_AbilityOwner_UE::CastChecked(_AbilityHandle);
     UCk_Utils_AbilityOwner_UE::Request_SendAbilityEvent
     (
         AbilityAsAbilityOwner,

--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.h
@@ -48,23 +48,25 @@ public:
     Has(
         const FCk_Handle& InAbilityEntity);
 
+private:
     UFUNCTION(BlueprintCallable,
         Category = "Ck|Utils|Ability",
         DisplayName="[Ck][Ability] Cast",
         meta = (ExpandEnumAsExecs = "OutResult"))
     static FCk_Handle_Ability
-    Cast(
+    DoCast(
         FCk_Handle InHandle,
         ECk_SucceededFailed& OutResult);
 
     UFUNCTION(BlueprintPure,
         Category = "Ck|Utils|Ability",
         DisplayName="[Ck][Ability] Handle -> Ability Handle",
-        meta = (CompactNodeTitle = "As AbilityHandle", BlueprintAutocast))
+        meta = (CompactNodeTitle = "<AsAbility>", BlueprintAutocast))
     static FCk_Handle_Ability
-    Conv_HandleToAbility(
+    DoCastChecked(
         FCk_Handle InHandle);
 
+public:
     CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_Ability);
 
 public:

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -153,9 +153,9 @@ namespace ck
         const auto& OptionalPayload = InRequest.Get_OptionalPayload();
 
         const auto PostAbilityCreationFunc =
-        [InAbilityOwnerEntity, AbilityScriptClass, AbilityParams, OptionalPayload](FCk_Handle& InAbilityEntity) -> void
+        [InAbilityOwnerEntity, AbilityScriptClass, AbilityParams, OptionalPayload](FCk_Handle& InEntity) -> void
         {
-            auto AbilityEntity = UCk_Utils_Ability_UE::Conv_HandleToAbility(InAbilityEntity);
+            auto AbilityEntity = UCk_Utils_Ability_UE::CastChecked(InEntity);
 
             auto AbilityOwnerEntity = InAbilityOwnerEntity;
 
@@ -170,7 +170,7 @@ namespace ck
             UCk_Utils_Handle_UE::Set_DebugName(AbilityEntity,
                 UCk_Utils_Debug_UE::Get_DebugName(AbilityParams.Get_AbilityScriptClass(), ECk_DebugNameVerbosity_Policy::Compact));
 
-            auto AbilityHandle = UCk_Utils_Ability_UE::Conv_HandleToAbility(AbilityEntity);
+            auto AbilityHandle = UCk_Utils_Ability_UE::CastChecked(AbilityEntity);
             UCk_Utils_Ability_UE::DoGive(AbilityOwnerEntity, AbilityHandle, OptionalPayload);
 
             if (const auto& ActivationPolicy = UCk_Utils_Ability_UE::Get_ActivationSettings(AbilityHandle).Get_ActivationPolicy();
@@ -343,7 +343,7 @@ namespace ck
                 {
                     auto MyOwner = UCk_Utils_AbilityOwner_UE::CastChecked(UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAbilityOwnerEntity));
 
-                    const auto AbilityOwnerAsAbility = UCk_Utils_Ability_UE::Conv_HandleToAbility(InAbilityOwnerEntity);
+                    const auto AbilityOwnerAsAbility = UCk_Utils_Ability_UE::CastChecked(InAbilityOwnerEntity);
                     UCk_Utils_AbilityOwner_UE::Request_DeactivateAbility(MyOwner,
                         FCk_Request_AbilityOwner_DeactivateAbility{AbilityOwnerAsAbility});
                 }
@@ -355,7 +355,7 @@ namespace ck
                 InAbilityOwnerEntity,
                 [&](const FCk_Handle& InAbilityEntityToCancel)
                 {
-                    const auto AbilityEntityToCancel = UCk_Utils_Ability_UE::Conv_HandleToAbility(InAbilityOwnerEntity);
+                    const auto AbilityEntityToCancel = UCk_Utils_Ability_UE::CastChecked(InAbilityOwnerEntity);
 
                     ability::Verbose
                     (

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
@@ -20,7 +20,7 @@ auto
 
     UCk_Utils_Ability_UE::RecordOfAbilities_Utils::AddIfMissing(InHandle);
 
-    return Conv_HandleToAbilityOwner(InHandle);
+    return Cast(InHandle);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
@@ -27,6 +27,7 @@ public:
 
 public:
     CK_GENERATED_BODY(UCk_Utils_AbilityOwner_UE);
+    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_AbilityOwner);
 
 public:
     UFUNCTION(BlueprintCallable,
@@ -45,24 +46,23 @@ public:
     Has(
         const FCk_Handle& InHandle);
 
+private:
     UFUNCTION(BlueprintCallable,
         Category = "Ck|Utils|AbilityOwner",
         DisplayName="[Ck][AbilityOwner] Cast",
         meta = (ExpandEnumAsExecs = "OutResult"))
     static FCk_Handle_AbilityOwner
-    Cast(
+    DoCast(
         FCk_Handle InHandle,
         ECk_SucceededFailed& OutResult);
 
     UFUNCTION(BlueprintPure,
         Category = "Ck|Utils|AbilityOwner",
         DisplayName="[Ck][AbilityOwner] Handle -> AbilityOwner Handle",
-        meta = (CompactNodeTitle = "AsAbilityOwner", BlueprintAutocast))
+        meta = (CompactNodeTitle = "<AsAbilityOwner>", BlueprintAutocast))
     static FCk_Handle_AbilityOwner
-    Conv_HandleToAbilityOwner(
+    DoCastChecked(
         FCk_Handle InHandle);
-
-    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_AbilityOwner);
 
 public:
     UFUNCTION(BlueprintPure,

--- a/Source/CkAnimation/Public/CkAnimation/AnimAsset/CkAnimAsset_Utils.cpp
+++ b/Source/CkAnimation/Public/CkAnimation/AnimAsset/CkAnimAsset_Utils.cpp
@@ -28,14 +28,13 @@ auto
     AddMultiple(
         FCk_Handle& InHandle,
         const FCk_Fragment_MultipleAnimAsset_ParamsData& InParams)
-    -> FCk_Handle_AnimAsset
+    -> TArray<FCk_Handle_AnimAsset>
 {
-    for (const auto& Params : InParams.Get_AnimAssetParams())
+    return ck::algo::Transform<TArray<FCk_Handle_AnimAsset>>(InParams.Get_AnimAssetParams(),
+    [&](const FCk_Fragment_AnimAsset_ParamsData& InAnimAssetParams)
     {
-        Add(InHandle, Params);
-    }
-
-    return Conv_HandleToAnimAsset(InHandle);
+        return Add(InHandle, InAnimAssetParams);
+    });
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAnimation/Public/CkAnimation/AnimAsset/CkAnimAsset_Utils.h
+++ b/Source/CkAnimation/Public/CkAnimation/AnimAsset/CkAnimAsset_Utils.h
@@ -19,6 +19,7 @@ class CKANIMATION_API UCk_Utils_AnimAsset_UE : public UCk_Utils_Ecs_Base_UE
 
 public:
     CK_GENERATED_BODY(UCk_Utils_AnimAsset_UE);
+    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_AnimAsset);
 
 private:
     struct RecordOfAnimAssets_Utils : public ck::TUtils_RecordOfEntities<ck::FFragment_RecordOfAnimAssets> {};
@@ -38,7 +39,7 @@ public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|AnimAsset",
               DisplayName="[Ck][AnimAsset] Add Multiple New Animations")
-    static FCk_Handle_AnimAsset
+    static TArray<FCk_Handle_AnimAsset>
     AddMultiple(
         FCk_Handle& InHandle,
         const FCk_Fragment_MultipleAnimAsset_ParamsData& InParams);
@@ -51,24 +52,23 @@ public:
     Has(
         const FCk_Handle& InHandle);
 
+private:
     UFUNCTION(BlueprintCallable,
         Category = "Ck|Utils|AnimAsset",
         DisplayName="[Ck][AnimAsset] Cast",
         meta = (ExpandEnumAsExecs = "OutResult"))
     static FCk_Handle_AnimAsset
-    Cast(
+    DoCast(
         FCk_Handle InHandle,
         ECk_SucceededFailed& OutResult);
 
     UFUNCTION(BlueprintPure,
         Category = "Ck|Utils|AnimAsset",
         DisplayName="[Ck][AnimAsset] Handle -> AnimAsset Handle",
-        meta = (CompactNodeTitle = "As AnimAssetHandle", BlueprintAutocast))
+        meta = (CompactNodeTitle = "<AsAnimAsset>", BlueprintAutocast))
     static FCk_Handle_AnimAsset
-    Conv_HandleToAnimAsset(
+    DoCastChecked(
         FCk_Handle InHandle);
-
-    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_AnimAsset);
 
 public:
     UFUNCTION(BlueprintPure,

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -29,7 +29,7 @@ public:
 
 // --------------------------------------------------------------------------------------------------------------------
 
-USTRUCT(BlueprintType, meta=(HasNativeMake, HasNativeBreak="/Script/CkEcs.Ck_Utils_Handle_UE:Break_Handle"))
+USTRUCT(BlueprintType, meta=(NoImplicitConversion, HasNativeMake, HasNativeBreak="/Script/CkEcs.Ck_Utils_Handle_UE:Break_Handle"))
 struct CKECS_API FCk_Handle
 {
     GENERATED_BODY()

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_TypeSafe.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_TypeSafe.h
@@ -92,6 +92,33 @@ static_assert
 #define CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(_HandleType_)                                                 \
 static auto                                                                                              \
     CastChecked(                                                                                         \
+        FCk_Handle& InHandle)                                                                            \
+    -> _HandleType_&                                                                                     \
+{                                                                                                        \
+    if (ck::Is_NOT_Valid(InHandle))                                                                      \
+    { static _HandleType_ Invalid; return Invalid; }                                                     \
+                                                                                                         \
+    CK_ENSURE_IF_NOT(Has(InHandle), TEXT("Handle [{}] does NOT have a [{}]. Unable to convert Handle."), \
+        InHandle, ck::Get_RuntimeTypeToString<_HandleType_>())                                           \
+    { static _HandleType_ Invalid; return Invalid; }                                                     \
+                                                                                                         \
+    return ck::StaticCast<_HandleType_>(InHandle);                                                       \
+}                                                                                                        \
+static auto                                                                                              \
+    Cast(                                                                                                \
+        FCk_Handle& InHandle)                                                                            \
+    -> _HandleType_&                                                                                     \
+{                                                                                                        \
+    if (ck::Is_NOT_Valid(InHandle))                                                                      \
+    { static _HandleType_ Invalid; return Invalid; }                                                     \
+                                                                                                         \
+    if (NOT Has(InHandle))                                                                               \
+    { static _HandleType_ Invalid; return Invalid; }                                                     \
+                                                                                                         \
+    return ck::StaticCast<_HandleType_>(InHandle);                                                       \
+}                                                                                                        \
+static auto                                                                                              \
+    CastChecked(                                                                                         \
         const FCk_Handle& InHandle)                                                                      \
     -> const _HandleType_&                                                                               \
 {                                                                                                        \
@@ -133,7 +160,7 @@ auto                                                                            
                                                                                                          \
 auto                                                                                                     \
     _ClassType_::                                                                                        \
-    Cast(                                                                                                \
+    DoCast(                                                                                              \
         FCk_Handle InHandle,                                                                             \
         ECk_SucceededFailed& OutResult)                                                                  \
     -> _HandleType_                                                                                      \
@@ -156,7 +183,7 @@ auto                                                                            
                                                                                                          \
 auto                                                                                                     \
     _ClassType_::                                                                                        \
-    Conv_HandleTo ##_FeatureName_(                                                                       \
+    DoCastChecked(                                                                                       \
         FCk_Handle InHandle)                                                                             \
     -> _HandleType_                                                                                      \
 {                                                                                                        \

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Utils.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Utils.h
@@ -30,6 +30,7 @@ class CKOVERLAPBODY_API UCk_Utils_Marker_UE : public UCk_Utils_Ecs_Base_UE
 
 public:
     CK_GENERATED_BODY(UCk_Utils_Marker_UE);
+    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_Marker);
 
 private:
     struct RecordOfMarkers_Utils : public ck::TUtils_RecordOfEntities<ck::FFragment_RecordOfMarkers> {};
@@ -90,24 +91,23 @@ public:
     Has(
         const FCk_Handle& InHandle);
 
+private:
     UFUNCTION(BlueprintCallable,
         Category = "Ck|Utils|Marker",
         DisplayName="[Ck][Marker] Cast",
         meta = (ExpandEnumAsExecs = "OutResult"))
     static FCk_Handle_Marker
-    Cast(
+    DoCast(
         FCk_Handle InHandle,
         ECk_SucceededFailed& OutResult);
 
     UFUNCTION(BlueprintPure,
         Category = "Ck|Utils|Marker",
         DisplayName="[Ck][Marker] Handle -> Marker Handle",
-        meta = (CompactNodeTitle = "As MarkerHandle", BlueprintAutocast))
+        meta = (CompactNodeTitle = "<AsMarker>", BlueprintAutocast))
     static FCk_Handle_Marker
-    Conv_HandleToMarker(
+    DoCastChecked(
         FCk_Handle InHandle);
-
-    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_Marker);
 
 public:
     UFUNCTION(BlueprintPure,

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Utils.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Utils.h
@@ -29,6 +29,7 @@ class CKOVERLAPBODY_API UCk_Utils_Sensor_UE : public UCk_Utils_Ecs_Base_UE
 
 public:
     CK_GENERATED_BODY(UCk_Utils_Sensor_UE);
+    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_Sensor);
 
 private:
     struct RecordOfSensors_Utils : public ck::TUtils_RecordOfEntities<ck::FFragment_RecordOfSensors> {};
@@ -89,24 +90,23 @@ public:
     Has(
         const FCk_Handle& InHandle);
 
+private:
     UFUNCTION(BlueprintCallable,
         Category = "Ck|Utils|Sensor",
         DisplayName="[Ck][Sensor] Cast",
         meta = (ExpandEnumAsExecs = "OutResult"))
     static FCk_Handle_Sensor
-    Cast(
+    DoCast(
         FCk_Handle InHandle,
         ECk_SucceededFailed& OutResult);
 
     UFUNCTION(BlueprintPure,
         Category = "Ck|Utils|Sensor",
         DisplayName="[Ck][Sensor] Handle -> Sensor Handle",
-        meta = (CompactNodeTitle = "As SensorHandle", BlueprintAutocast))
+        meta = (CompactNodeTitle = "<AsSensor>", BlueprintAutocast))
     static FCk_Handle_Sensor
-    Conv_HandleToSensor(
+    DoCastChecked(
         FCk_Handle InHandle);
-
-    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_Sensor);
 
 public:
     UFUNCTION(BlueprintPure,

--- a/Source/CkTimer/Public/CkTimer/CkTimer_Utils.cpp
+++ b/Source/CkTimer/Public/CkTimer/CkTimer_Utils.cpp
@@ -38,7 +38,7 @@ auto
     RecordOfTimers_Utils::AddIfMissing(InHandle, ECk_Record_EntryHandlingPolicy::DisallowDuplicateNames);
     RecordOfTimers_Utils::Request_Connect(InHandle, NewTimerEntity);
 
-    return Conv_HandleToTimer(NewTimerEntity);
+    return Cast(NewTimerEntity);
 }
 
 auto
@@ -67,7 +67,7 @@ auto
         TimerEntity.AddOrGet<ck::FTag_Timer_NeedsUpdate>();
     }
 
-    return Conv_HandleToTimer(TimerEntity);
+    return Cast(TimerEntity);
 }
 
 auto

--- a/Source/CkTimer/Public/CkTimer/CkTimer_Utils.h
+++ b/Source/CkTimer/Public/CkTimer/CkTimer_Utils.h
@@ -21,6 +21,7 @@ class CKTIMER_API UCk_Utils_Timer_UE : public UCk_Utils_Ecs_Base_UE
 
 public:
     CK_GENERATED_BODY(UCk_Utils_Timer_UE);
+    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_Timer);
 
 private:
     struct RecordOfTimers_Utils : public ck::TUtils_RecordOfEntities<ck::FFragment_RecordOfTimers> {};
@@ -72,24 +73,23 @@ public:
     Has(
         const FCk_Handle& InHandle);
 
+private:
     UFUNCTION(BlueprintCallable,
         Category = "Ck|Utils|Timer",
         DisplayName="[Ck][Timer] Cast",
         meta = (ExpandEnumAsExecs = "OutResult"))
     static FCk_Handle_Timer
-    Cast(
+    DoCast(
         FCk_Handle InHandle,
         ECk_SucceededFailed& OutResult);
 
     UFUNCTION(BlueprintPure,
         Category = "Ck|Utils|Timer",
         DisplayName="[Ck][Timer] Handle -> Timer Handle",
-        meta = (CompactNodeTitle = "As TimerHandle", BlueprintAutocast))
+        meta = (CompactNodeTitle = "<AsTimer>", BlueprintAutocast))
     static FCk_Handle_Timer
-    Conv_HandleToTimer(
+    DoCastChecked(
         FCk_Handle InHandle);
-
-    CK_DEFINE_CPP_CASTCHECKED_TYPESAFE(FCk_Handle_Timer);
 
 public:
     UFUNCTION(BlueprintPure,


### PR DESCRIPTION
…tions - Blueprint Conv_xxxxx function renamed to DoCastChecked

- blueprint cast functions are now private, this is mainly because we cannot have a handle param by ref AND have auto-cast at the same time; instead, the functions are private and we now have C++ versions that are auto-defined by our macro
- C++ Cast/CastChecked follow Unreal naming convention and retain const-correctness of a Handle