### PR TITLE
feat: heavily refactored template Attribute base with support for opt…

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.inl.h
@@ -6,8 +6,8 @@
 
 namespace ck
 {
-    template <typename T_AttributeType>
-    TFragment_Attribute<T_AttributeType>::
+    template <typename T_HandleType, typename T_AttributeType, ECk_MinMaxCurrent T_ComponentTag>
+    TFragment_Attribute<T_HandleType, T_AttributeType, T_ComponentTag>::
         TFragment_Attribute(
             AttributeDataType InBase)
         : _Base(InBase)
@@ -17,8 +17,8 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    template <typename T_DerivedAttribute>
-    TFragment_AttributeModifier<T_DerivedAttribute>::
+    template <typename T_HandleType, typename T_DerivedAttribute>
+    TFragment_AttributeModifier<T_HandleType, T_DerivedAttribute>::
         TFragment_AttributeModifier(
             AttributeDataType InModifierDelta)
         : _ModifierDelta(InModifierDelta)

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
@@ -24,23 +24,23 @@ namespace ck
         template <typename>
         friend class TUtils_AttributeModifier;
 
-        template <typename, typename>
-        friend class TProcessor_Attribute_OverrideBaseValue;
+        template <typename, typename, typename>
+        friend class detail::TProcessor_Attribute_OverrideBaseValue;
 
         template <typename, typename>
-        friend class TProcessor_Attribute_RecomputeAll;
+        friend class detail::TProcessor_Attribute_RecomputeAll;
 
         template <typename, typename>
-        friend class TProcessor_AttributeModifier_Additive_Teardown;
+        friend class detail::TProcessor_AttributeModifier_Additive_Teardown;
 
         template <typename, typename>
-        friend class TProcessor_AttributeModifier_Multiplicative_Teardown;
+        friend class detail::TProcessor_AttributeModifier_Multiplicative_Teardown;
 
     public:
         static auto
         Add(
             HandleType InHandle,
-            AttributeDataType InBaseValue) -> void;
+            const AttributeDataType& InBaseValue) -> void;
 
         static auto
         Has(
@@ -77,28 +77,26 @@ namespace ck
         using AttributeModifierFragmentType = T_DerivedAttributeModifier;
         using AttributeFragmentType         = typename AttributeModifierFragmentType::AttributeFragmentType;
         using AttributeDataType             = typename AttributeFragmentType::AttributeDataType;
-        using HandleType                    = FCk_Handle;
+        using HandleType                    = typename AttributeModifierFragmentType::HandleType;
 
     public:
         template <typename, typename>
-        friend class TProcessor_Attribute_RecomputeAll;
+        friend class detail::TProcessor_Attribute_RecomputeAll;
 
         template <typename, typename>
-        friend class TProcessor_AttributeModifier_Additive_Teardown;
+        friend class detail::TProcessor_AttributeModifier_Additive_Teardown;
 
         template <typename, typename>
-        friend class TProcessor_AttributeModifier_Multiplicative_Teardown;
+        friend class detail::TProcessor_AttributeModifier_Multiplicative_Teardown;
 
     public:
-        struct AttributeModifierTarget_Utils : TUtils_EntityHolder<FFragment_AttributeModifierTarget> {};
-        struct RecordOfAttributeModifiers_Utils : TUtils_RecordOfEntities<FFragment_RecordOfAttributeModifiers>{};
+        struct RecordOfAttributeModifiers_Utils : TUtils_RecordOfEntities<TFragment_RecordOfAttributeModifiers<HandleType>>{};
 
     public:
         static auto
         Add(
             HandleType InHandle,
             AttributeDataType InModifierDelta,
-            HandleType InTarget,
             ECk_ModifierOperation InModifierOperation,
             ECk_ModifierOperation_RevocablePolicy InModifierOperationRevokablePolicy) -> void;
 


### PR DESCRIPTION
…ional min/max including the existing current Base/Final values

notes: Attribute base now supports adding min/max values to Attributes optionally (e.g. for Arithmetic types). The processors of the templated Attribute base were refactored and put under ck::detail namespace. Additional processors that consolidate the many granular processors were added which are designed to be used by the derived Attribute Processors. This has been tested with FloatAttributes, which along with other Attribute types, is being refactored and submitting in the upcoming commits