### PR TITLE
refactor, fix: majority of the Registry functions are now made privat…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Processor.cpp
@@ -1,5 +1,8 @@
 #include "CkAbilityCue_Processor.h"
 
+// needed for non-unity builds
+#include <Engine/World.h>
+
 #include "CkAbility/AbilityCue/CkAbilityCue_Subsystem.h"
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -14,7 +17,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -21,7 +21,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkAnimation/Public/CkAnimation/AnimState/CkAnimState_Processor.cpp
+++ b/Source/CkAnimation/Public/CkAnimation/AnimState/CkAnimState_Processor.cpp
@@ -15,11 +15,11 @@ namespace ck
             TimeType InDeltaT)
         -> void
     {
-        _Registry.Clear<FTag_AnimState_Updated>();
+        _TransientEntity.Clear<FTag_AnimState_Updated>();
 
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.h
@@ -450,9 +450,10 @@ namespace ck::detail
     // --------------------------------------------------------------------------------------------------------------------
 
     template <typename T_DerivedProcessor, typename T_DerivedAttributeModifier>
-    class TProcessor_AttributeModifier_ComputeAll
+    class TProcessor_AttributeModifier_ComputeAll : public FProcessor
     {
     public:
+        using Super        = FProcessor;
         using TimeType     = FCk_Time;
         using RegistryType = FCk_Registry;
         using MarkedDirtyBy = typename T_DerivedAttributeModifier::FTag_ComputeResult;
@@ -483,9 +484,6 @@ namespace ck::detail
             TProcessor_AttributeModifier_ComputeAll, T_DerivedAttributeModifier> _RevocableMultiply_Compute;
         TProcessor_AttributeModifier_RevocableDivide_Compute<
             TProcessor_AttributeModifier_ComputeAll, T_DerivedAttributeModifier> _RevocableDivide_Compute;
-
-    private:
-        RegistryType _Registry;
     };
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -324,7 +324,8 @@ namespace ck::detail
     TProcessor_AttributeModifier_ComputeAll<T_DerivedProcessor, T_DerivedAttributeModifier>::
         TProcessor_AttributeModifier_ComputeAll(
             RegistryType InRegistry)
-        : _NotRevocableAdd_Compute(InRegistry)
+        : Super(InRegistry)
+        , _NotRevocableAdd_Compute(InRegistry)
         , _NotRevocableSubtract_Compute(InRegistry)
         , _NotRevocableMultiply_Compute(InRegistry)
         , _NotRevocableDivide_Compute(InRegistry)
@@ -332,7 +333,6 @@ namespace ck::detail
         , _RevocableSubtract_Compute(InRegistry)
         , _RevocableMultiply_Compute(InRegistry)
         , _RevocableDivide_Compute(InRegistry)
-        , _Registry(InRegistry)
     {
     }
 
@@ -353,7 +353,7 @@ namespace ck::detail
         _RevocableMultiply_Compute.Tick(InDeltaT);
         _RevocableDivide_Compute.Tick(InDeltaT);
 
-        this->_Registry.template Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCamera/Public/CkCamera/CameraShake/CkCameraShake_Processor.cpp
+++ b/Source/CkCamera/Public/CkCamera/CameraShake/CkCameraShake_Processor.cpp
@@ -17,7 +17,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
@@ -15,7 +15,7 @@ namespace ck
     FProcessor_EntityLifetime_EntityJustCreated::
         FProcessor_EntityLifetime_EntityJustCreated(
             const FRegistryType& InRegistry)
-        : _Registry(InRegistry)
+        : Super(InRegistry)
     {
     }
 
@@ -25,7 +25,7 @@ namespace ck
             FTimeType)
         -> void
     {
-        _Registry.Clear<FTag_EntityJustCreated>();
+        _TransientEntity.Clear<FTag_EntityJustCreated>();
     }
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -38,7 +38,7 @@ namespace ck
     {
         Super::Tick(InDeltaT);
 
-        _Registry.Clear<FTag_TriggerDestroyEntity>();
+        _TransientEntity.Clear<FTag_TriggerDestroyEntity>();
     }
 
     auto

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.h
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.h
@@ -8,9 +8,10 @@ namespace ck
 {
     // --------------------------------------------------------------------------------------------------------------------
 
-    class CKECS_API FProcessor_EntityLifetime_EntityJustCreated
+    class CKECS_API FProcessor_EntityLifetime_EntityJustCreated : public FProcessor
     {
     public:
+        using Super = FProcessor;
         using FTimeType = FCk_Time;
         using FRegistryType = FCk_Registry;
 
@@ -19,9 +20,6 @@ namespace ck
 
     public:
         auto Tick(FTimeType) -> void;
-
-    private:
-        FCk_Registry _Registry;
     };
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
+++ b/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
@@ -43,6 +43,8 @@ public:
     friend class UCk_Utils_EntityLifetime_UE;
     friend class ck::FProcessor_EntityLifetime_PendingDestroyEntity;
 
+    friend struct FCk_Handle;
+
 public:
     using EntityType = FCk_Entity;
 
@@ -136,14 +138,18 @@ public:
     FCk_Registry();
 
 public:
+    template <typename T_Fragment, typename T_Compare>
+    auto Sort(T_Compare InCompare) -> void;
+
+    template <typename T_FragmentType, typename T_Func>
+    auto Try_Transform(EntityType InEntity, T_Func InFunc) -> void;
+
+private:
     template <typename T_FragmentType, typename... T_Args>
     auto Add(EntityType InEntity, T_Args&&... InArgs) -> T_FragmentType&;
 
     template <typename T_FragmentType, typename... T_Args>
     auto AddOrGet(EntityType InEntity, T_Args&&... InArgs) -> T_FragmentType&;
-
-    template <typename T_FragmentType, typename T_Func>
-    auto Try_Transform(EntityType InEntity, T_Func InFunc) -> void;
 
     template <typename T_FragmentType, typename... T_Args>
     auto Replace(EntityType InEntity, T_Args&&... InArgs) -> T_FragmentType&;
@@ -157,16 +163,14 @@ public:
     template <typename... T_Fragments>
     auto Clear() -> void;
 
+public:
     template <typename... T_Fragments>
     auto View() -> RegistryViewType<T_Fragments...>;
 
     template <typename... T_Fragments>
     auto View() const -> ConstRegistryViewType<T_Fragments...>;
 
-    template <typename T_Fragment, typename T_Compare>
-    auto Sort(T_Compare InCompare) -> void;
-
-public:
+private:
     template <typename T_Fragment>
     auto Has(EntityType InEntity) const -> bool;
 
@@ -195,7 +199,7 @@ public:
 public:
     friend auto CKECS_API GetTypeHash(const ThisType& InRegistry) -> uint32;
 
-public:
+private:
     ck::TPtrWrapper<InternalRegistryPtrType> _InternalRegistry;
     EntityType _TransientEntity;
 

--- a/Source/CkEcsBasics/Public/CkEcsBasics/Transform/CkTransform_Processor.cpp
+++ b/Source/CkEcsBasics/Public/CkEcsBasics/Transform/CkTransform_Processor.cpp
@@ -18,11 +18,11 @@ namespace ck
         FProcessor_Transform_HandleRequests::
         Tick(TimeType InDeltaT) -> void
     {
-        _Registry.Clear<FTag_Transform_Updated>();
+        _TransientEntity.Clear<FTag_Transform_Updated>();
 
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkEcsTemplate/Public/CkEcsTemplate/CkEcsTemplate_Processor.cpp
+++ b/Source/CkEcsTemplate/Public/CkEcsTemplate/CkEcsTemplate_Processor.cpp
@@ -16,11 +16,11 @@ namespace ck
             TimeType InDeltaT)
         -> void
     {
-        _Registry.Clear<FTag_EcsTemplate_Updated>();
+        _TransientEntity.Clear<FTag_EcsTemplate_Updated>();
 
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkGraphics/Public/CkGraphics/RenderStatus/CkRenderStatus_Processor.cpp
+++ b/Source/CkGraphics/Public/CkGraphics/RenderStatus/CkRenderStatus_Processor.cpp
@@ -21,7 +21,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkNet/Public/CkNet/TimeSync/CkNetTimeSync_Processor.cpp
+++ b/Source/CkNet/Public/CkNet/TimeSync/CkNetTimeSync_Processor.cpp
@@ -51,7 +51,7 @@ auto
         float RoundTripTime)
     -> void
 {
-    _Registry.View<TObjectPtr<UCk_Fragment_NetTimeSync_Rep>>().ForEach(
+    _TransientEntity.View<TObjectPtr<UCk_Fragment_NetTimeSync_Rep>>().ForEach(
     [&](EntityType InEntity, TObjectPtr<UCk_Fragment_NetTimeSync_Rep> InRep)
     {
         InRep->DoBroadcast_NetTimeSync(FCk_Time{RoundTripTime});
@@ -68,7 +68,7 @@ auto
 {
     TProcessor::Tick(InDeltaT);
 
-    _Registry.Clear<MarkedDirtyBy>();
+    _TransientEntity.Clear<MarkedDirtyBy>();
 }
 
 auto
@@ -82,13 +82,13 @@ auto
     ck::algo::ForEachRequest(InRequests._NetTimeSyncRequests,
     [&](const FCk_Request_NetTimeSync_NewSync& InNewSync)
     {
-        const auto& isNetTimeSyncEnabled = UCk_Utils_NetTimeSync_Settings_UE::Get_EnableNetTimeSynchronization();
-        const auto& roundTripTime = isNetTimeSyncEnabled ? InNewSync.Get_RoundTripTime() : FCk_Time::ZeroSecond();
+        const auto& IsNetTimeSyncEnabled = UCk_Utils_NetTimeSync_Settings_UE::Get_EnableNetTimeSynchronization();
+        const auto& RoundTripTime = IsNetTimeSyncEnabled ? InNewSync.Get_RoundTripTime() : FCk_Time::ZeroSecond();
 
-        _Registry.View<FFragment_NetTimeSync>().ForEach([&](EntityType InEntity, FFragment_NetTimeSync& InTimeSync)
+        _TransientEntity.View<FFragment_NetTimeSync>().ForEach([&](EntityType InEntity, FFragment_NetTimeSync& InTimeSync)
         {
-            InTimeSync._RoundTripTime = roundTripTime;
-            InTimeSync._PlayerRoundTripTimes.FindOrAdd(InNewSync.Get_PlayerController(), roundTripTime);
+            InTimeSync._RoundTripTime = RoundTripTime;
+            InTimeSync._PlayerRoundTripTimes.FindOrAdd(InNewSync.Get_PlayerController(), RoundTripTime);
         });
     });
 }
@@ -109,10 +109,10 @@ auto
      * almost no resources if there are no Entities that have not at least synced once
      */
 
-    _Registry.View<FFragment_NetTimeSync, ck::TExclude<FTag_NetTimeSync_SyncedAtleastOnce>>().ForEach(
+    _TransientEntity.View<FFragment_NetTimeSync, ck::TExclude<FTag_NetTimeSync_SyncedAtleastOnce>>().ForEach(
     [&](EntityType InEntity, FFragment_NetTimeSync& InTimeSync)
     {
-        _Registry.Add<ck::FTag_NetTimeSync_SyncedAtleastOnce>(InEntity);
+        _TransientEntity.Add<ck::FTag_NetTimeSync_SyncedAtleastOnce>(InEntity);
         InTimeSync = InTimeToSyncFrom;
     });
 }

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.cpp
@@ -25,7 +25,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
@@ -25,7 +25,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto

--- a/Source/CkPhysics/Public/CkPhysics/Acceleration/CkAcceleration_Processor.cpp
+++ b/Source/CkPhysics/Public/CkPhysics/Acceleration/CkAcceleration_Processor.cpp
@@ -16,7 +16,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto
@@ -146,7 +146,7 @@ namespace ck
             const FFragment_RecordOfAccelerationChannels& InAccelerationChannels) const
         -> void
     {
-        InHandle.Get_Registry().View<FFragment_BulkAccelerationModifier_Params, FTag_BulkAccelerationModifier_GlobalScope>().ForEach(
+        InHandle.View<FFragment_BulkAccelerationModifier_Params, FTag_BulkAccelerationModifier_GlobalScope>().ForEach(
         [&](FCk_Entity InModifierEntity, const FFragment_BulkAccelerationModifier_Params& InMultiTargetAccelerationModifierParams)
         {
             if (NOT UCk_Utils_AccelerationChannel_UE::Get_IsAffectedByAnyOtherChannel(InHandle, InMultiTargetAccelerationModifierParams.Get_Params().Get_TargetChannels()))

--- a/Source/CkPhysics/Public/CkPhysics/Acceleration/CkAcceleration_Utils.cpp
+++ b/Source/CkPhysics/Public/CkPhysics/Acceleration/CkAcceleration_Utils.cpp
@@ -256,10 +256,10 @@ auto
 auto
     UCk_Utils_AccelerationModifier_UE::
     Has(
-        FCk_Handle InHandle)
+        const FCk_Handle& InHandle)
     -> bool
 {
-    return InHandle->Has<ck::FTag_AccelerationModifier>(InHandle.Get_Entity()) &&
+    return InHandle.Has<ck::FTag_AccelerationModifier>() &&
         UCk_Utils_Acceleration_UE::AccelerationTarget_Utils::Has(InHandle) &&
         UCk_Utils_Acceleration_UE::Has(InHandle);
 }

--- a/Source/CkPhysics/Public/CkPhysics/Acceleration/CkAcceleration_Utils.h
+++ b/Source/CkPhysics/Public/CkPhysics/Acceleration/CkAcceleration_Utils.h
@@ -205,7 +205,7 @@ public:
 private:
     static auto
     Has(
-        FCk_Handle InHandle) -> bool;
+        const FCk_Handle& InHandle) -> bool;
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkPhysics/Public/CkPhysics/EulerIntegrator/CkEulerIntegrator_Processor.cpp
+++ b/Source/CkPhysics/Public/CkPhysics/EulerIntegrator/CkEulerIntegrator_Processor.cpp
@@ -13,7 +13,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<FTag_EulerIntegrator_DoOnePredictiveUpdate>();
+        _TransientEntity.Clear<FTag_EulerIntegrator_DoOnePredictiveUpdate>();
     }
 
     auto

--- a/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Processor.cpp
+++ b/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Processor.cpp
@@ -18,7 +18,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto
@@ -168,7 +168,7 @@ namespace ck
             const FFragment_RecordOfVelocityChannels& InVelocityChannels) const
         -> void
     {
-        InHandle.Get_Registry().View<FFragment_BulkVelocityModifier_Params, FTag_BulkVelocityModifier_GlobalScope>().ForEach(
+        InHandle.View<FFragment_BulkVelocityModifier_Params, FTag_BulkVelocityModifier_GlobalScope>().ForEach(
         [&](FCk_Entity InModifierEntity, const FFragment_BulkVelocityModifier_Params& InMultiTargetVelocityModifierParams)
         {
             if (NOT UCk_Utils_VelocityChannel_UE::Get_IsAffectedByAnyOtherChannel(InHandle, InMultiTargetVelocityModifierParams.Get_Params().Get_TargetChannels()))
@@ -188,7 +188,7 @@ namespace ck
         FProcessor_BulkVelocityModifier_HandleRequests::
         ForEachEntity(
             TimeType InDeltaT,
-            HandleType InHandle,
+            HandleType& InHandle,
             const FFragment_BulkVelocityModifier_Params& InParams,
             FFragment_BulkVelocityModifier_Requests& InRequests) const
         -> void
@@ -216,7 +216,7 @@ namespace ck
     auto
         FProcessor_BulkVelocityModifier_HandleRequests::
         DoHandleRequest(
-            HandleType InHandle,
+            const HandleType& InHandle,
             const FFragment_BulkVelocityModifier_Params& InParams,
             const FCk_Request_BulkVelocityModifier_AddTarget& InRequest)
         -> void
@@ -237,7 +237,7 @@ namespace ck
     auto
         FProcessor_BulkVelocityModifier_HandleRequests::
         DoHandleRequest(
-            HandleType InHandle,
+            const HandleType& InHandle,
             const FFragment_BulkVelocityModifier_Params& InParams,
             const FCk_Request_BulkVelocityModifier_RemoveTarget& InRequest)
         -> void

--- a/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Processor.h
+++ b/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Processor.h
@@ -171,19 +171,19 @@ namespace ck
         auto
         ForEachEntity(
             TimeType InDeltaT,
-            HandleType InHandle,
+            HandleType& InHandle,
             const FFragment_BulkVelocityModifier_Params& InParams,
             FFragment_BulkVelocityModifier_Requests& InRequests) const -> void;
 
     private:
         static auto DoHandleRequest(
-            HandleType InHandle,
+            const HandleType& InHandle,
             const FFragment_BulkVelocityModifier_Params& InParams,
             const FCk_Request_BulkVelocityModifier_AddTarget& InRequest) -> void;
 
         static auto DoHandleRequest(
-            HandleType InHandle,
-            const FFragment_BulkVelocityModifier_Params& InParams,
+            const HandleType&                                    InHandle,
+            const FFragment_BulkVelocityModifier_Params&         InParams,
             const FCk_Request_BulkVelocityModifier_RemoveTarget& InRequest) -> void;
     };
 

--- a/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Utils.cpp
+++ b/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Utils.cpp
@@ -268,10 +268,10 @@ auto
 auto
     UCk_Utils_VelocityModifier_UE::
     Has(
-        FCk_Handle InHandle)
+        const FCk_Handle& InHandle)
     -> bool
 {
-    return InHandle->Has<ck::FTag_VelocityModifier>(InHandle.Get_Entity()) &&
+    return InHandle.Has<ck::FTag_VelocityModifier>() &&
         UCk_Utils_Velocity_UE::VelocityTarget_Utils::Has(InHandle) &&
         UCk_Utils_Velocity_UE::Has(InHandle);
 }

--- a/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Utils.h
+++ b/Source/CkPhysics/Public/CkPhysics/Velocity/CkVelocity_Utils.h
@@ -205,7 +205,7 @@ public:
 private:
     static auto
     Has(
-        FCk_Handle InHandle) -> bool;
+        const FCk_Handle& InHandle) -> bool;
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Processor.cpp
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Processor.cpp
@@ -22,7 +22,7 @@ namespace ck
     {
         TProcessor::Tick(InDeltaT);
 
-        _Registry.Clear<MarkedDirtyBy>();
+        _TransientEntity.Clear<MarkedDirtyBy>();
     }
 
     auto


### PR DESCRIPTION
…e to force client code to go through the Handle

notes: this commit ensures that we go through the Handle's debugging pipeline before accessing Registry functions and fixes an issue where the Handle debugging would have duplicate entries of fragments/tags that were removed by calling `Clear<T...>()` on the Registry.