### PR TITLE
fix: The Attribute (lifetime) owner entity is now correctly sent in t…

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
@@ -273,7 +273,7 @@ namespace ck
     template<typename T_DerivedAttribute>
     struct TFragment_Signal_OnAttributeValueChanged : public TFragment_Signal
     <
-        typename T_DerivedAttribute::HandleType,
+        FCk_Handle,
         TPayload_Attribute_OnValueChanged<T_DerivedAttribute>
     > {};
 

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -33,7 +33,7 @@ namespace ck::detail
             InHandle,
             ck::MakePayload
             (
-                InHandle,
+                AttributeLifetimeOwner,
                 TPayload_Attribute_OnValueChanged<T_DerivedAttribute>
                 {
                     InHandle,


### PR DESCRIPTION
…he ValueChanged payload instead of sending the attribute entity