### PR TITLE
fix: Lifetime utils DestroyEntity now ignores Entities that are invalid

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -15,6 +15,9 @@ auto
         ECk_EntityLifetime_DestructionBehavior InDestructionBehavior)
     -> void
 {
+    if (ck::Is_NOT_Valid(InHandle))
+    { return; }
+
     if (Get_IsPendingDestroy(InHandle))
     { return; }
 


### PR DESCRIPTION
notes: this is similar to the behavior of `nullptr` in C++ where deleting a pointer that is `nullptr` is legal and does nothing