### PR TITLE
feat: added a dedicated Ability teardown processor

### DIFF
--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.cpp
@@ -240,8 +240,8 @@ auto
         FCk_Handle_Ability& InAbilityEntity)
     -> void
 {
-    auto& AbilityCurrent = InAbilityEntity.Get<ck::FFragment_Ability_Current>();
-    const auto& AbilityParams = InAbilityEntity.Get<ck::FFragment_Ability_Params>().Get_Params();
+    auto& AbilityCurrent = InAbilityEntity.Get<ck::FFragment_Ability_Current, ck::IsValid_Policy_IncludePendingKill>();
+    const auto& AbilityParams = InAbilityEntity.Get<ck::FFragment_Ability_Params, ck::IsValid_Policy_IncludePendingKill>().Get_Params();
     auto Script = AbilityCurrent.Get_AbilityScript();
 
     CK_ENSURE_IF_NOT(ck::IsValid(Script),

--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.h
@@ -19,6 +19,7 @@ namespace ck
 {
     class FProcessor_AbilityOwner_Setup;
     class FProcessor_AbilityOwner_HandleRequests;
+    class FProcessor_AbilityOwner_Teardown;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -39,6 +40,7 @@ public:
     friend class UCk_Ability_ConstructionScript_PDA;
     friend class ck::FProcessor_AbilityOwner_Setup;
     friend class ck::FProcessor_AbilityOwner_HandleRequests;
+    friend class ck::FProcessor_AbilityOwner_Teardown;
 
 public:
     UFUNCTION(BlueprintPure,

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -356,6 +356,7 @@ namespace ck
             }
 
             // Cancel All Abilities that are cancelled by the newly granted tags
+            // TODO: this is repeated multiple times in this file, move to a common function
             UCk_Utils_AbilityOwner_UE::ForEach_Ability_If
             (
                 InAbilityOwnerEntity,
@@ -572,6 +573,40 @@ namespace ck
         { return {}; }
 
         return InAbilityEntity;
+    }
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    auto
+        FProcessor_AbilityOwner_Teardown::
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType& InHandle,
+            const FFragment_Ability_Params&) const
+        -> void
+    {
+        auto LifetimeOwner = UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InHandle);
+        auto AbilityOwner = UCk_Utils_AbilityOwner_UE::CastChecked(LifetimeOwner);
+
+        // TODO: this is repeated multiple times in this file, move to a common function
+        UCk_Utils_Ability_UE::RecordOfAbilities_Utils::ForEach_InvalidEntry
+        (
+            AbilityOwner,
+            [&](FCk_Handle InAbilityEntityToCancel)
+            {
+                auto AbilityEntityToCancel = UCk_Utils_Ability_UE::CastChecked(InAbilityEntityToCancel);
+
+                ability::Verbose
+                (
+                    TEXT("FORCE DEACTIVATING Ability [Name: {} | Entity: {}] because our AbilityOwner [{}] is pending destroy"),
+                    UCk_Utils_GameplayLabel_UE::Get_Label(InAbilityEntityToCancel),
+                    InAbilityEntityToCancel,
+                    AbilityOwner
+                );
+
+                UCk_Utils_Ability_UE::DoDeactivate(AbilityOwner, AbilityEntityToCancel);
+            }
+        );
     }
 }
 

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CkAbility/Ability/CkAbility_Fragment.h"
 #include "CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h"
 
 #include "CkEcs/Processor/CkProcessor.h"
@@ -110,6 +111,28 @@ namespace ck
         DoFindAbilityByHandle(
             const FCk_Handle_AbilityOwner& InAbilityOwnerEntity,
             const FCk_Handle_Ability& InAbilityEntity) -> FCk_Handle_Ability;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    class CKABILITY_API FProcessor_AbilityOwner_Teardown : public ck_exp::TProcessor<
+            FProcessor_AbilityOwner_Teardown,
+            FCk_Handle_Ability,
+            FFragment_Ability_Params,
+            CK_IF_PENDING_KILL>
+    {
+    public:
+        using MarkedDirtyBy = FFragment_AbilityOwner_Requests;
+
+    public:
+        using TProcessor::TProcessor;
+
+    public:
+        auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType& InHandle,
+            const FFragment_Ability_Params&) const -> void;
     };
 }
 

--- a/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbilityProcessorInjector.cpp
+++ b/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbilityProcessorInjector.cpp
@@ -14,6 +14,7 @@ auto
     InWorld.Add<ck::FProcessor_AbilityOwner_Setup>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_HandleRequests>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_HandleEvents>(InWorld.Get_Registry());
+    InWorld.Add<ck::FProcessor_AbilityOwner_Teardown>(InWorld.Get_Registry());
 
     InWorld.Add<ck::FProcessor_AbilityCue_Spawn>(InWorld.Get_Registry());
 }


### PR DESCRIPTION
notes: this required slight changes to the DoDeactivate function, which now allows deactivation of an Ability that is on an Invalid Entity. There is a new Abilities StressTest gym in CkTests for testing Abilities teardown.