### PR TITLE
feat: added HandleReplicator custom struct that allows us to replicat…

### DIFF
--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.cpp
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.cpp
@@ -1,3 +1,43 @@
 #include "CkEntityReplicationDriver_Fragment_Data.h"
 
-CK_INTENTIONALLY_EMPTY()
+#include "CkNet/CkNet_Log.h"
+#include "CkNet/CkNet_Utils.h"
+#include "CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_HandleReplicator::
+    NetSerialize(
+        FArchive& Ar,
+        UPackageMap* Map,
+        bool& bOutSuccess)
+    -> bool
+{
+    auto RepBits = uint16{0};
+    if (Ar.IsSaving())
+    {
+        if (ck::IsValid(_Handle))
+        {
+            UCk_Utils_Ecs_Net_UE::TryUpdateReplicatedFragment<UCk_Fragment_EntityReplicationDriver_Rep>(_Handle,
+            [&](UCk_Fragment_EntityReplicationDriver_Rep* InRepDriver)
+            {
+                Ar << InRepDriver;
+            });
+        }
+    }
+
+    if (Ar.IsLoading())
+    {
+        Ar << _Handle_RepObj;
+        if (ck::IsValid(_Handle_RepObj))
+        {
+            _Handle = _Handle_RepObj->Get_AssociatedEntity();
+        }
+    }
+
+    bOutSuccess = true;
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.h
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.h
@@ -9,6 +9,48 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
+// --------------------------------------------------------------------------------------------------------------------
+
+USTRUCT(BlueprintType, meta = (
+    HasNativeMake = "/Script/CkNet.Ck_Utils_EntityReplicationDriver_UE:Make_HandleReplicator",
+    HasNativeBreak = "/Script/CkNet.Ck_Utils_EntityReplicationDriver_UE:Break_HandleReplicator"))
+struct CKNET_API FCk_HandleReplicator
+{
+    GENERATED_BODY()
+
+public:
+    CK_GENERATED_BODY(FCk_HandleReplicator);
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, NotReplicated,
+        meta=(AllowPrivateAccess))
+    FCk_Handle _Handle;
+    UPROPERTY()
+    TWeakObjectPtr<class UCk_Fragment_EntityReplicationDriver_Rep> _Handle_RepObj;
+
+public:
+    auto
+    NetSerialize(
+        FArchive& Ar,
+        class UPackageMap* Map,
+        bool& bOutSuccess) -> bool;
+
+public:
+    CK_PROPERTY_GET(_Handle);
+    CK_PROPERTY_GET(_Handle_RepObj);
+
+    CK_DEFINE_CONSTRUCTORS(FCk_HandleReplicator, _Handle, _Handle_RepObj);
+};
+
+template<>
+struct TStructOpsTypeTraits<FCk_HandleReplicator> : public TStructOpsTypeTraitsBase2<FCk_HandleReplicator>
+{
+    enum
+    { WithNetSerializer = true };
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 USTRUCT(BlueprintType)
 struct CKNET_API FCk_EntityReplicationDriver_ConstructionInfo_ReplicatedActor
 {

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
@@ -2,6 +2,7 @@
 
 #include "CkLabel/CkLabel_Utils.h"
 
+#include "CkNet/CkNet_Log.h"
 #include "CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.h"
 
 #include <numeric>
@@ -224,6 +225,38 @@ auto
 
     ck::UUtils_Signal_OnDependentsReplicationComplete_PostFireUnbind::Bind(
         InEntity, InDelegate, ECk_Signal_BindingPolicy::FireIfPayloadInFlight);
+}
+
+auto
+    UCk_Utils_EntityReplicationDriver_UE::
+    Make_HandleReplicator(
+        FCk_Handle& InHandle)
+    -> FCk_HandleReplicator
+{
+    auto EntityReplicator = FCk_HandleReplicator{};
+
+    TryUpdateReplicatedFragment<UCk_Fragment_EntityReplicationDriver_Rep>(InHandle,
+    [&](UCk_Fragment_EntityReplicationDriver_Rep* InRepDriver)
+    {
+        EntityReplicator = FCk_HandleReplicator{InHandle, InRepDriver};
+    });
+
+    CK_LOG_ERROR_IF_NOT(ck::net, ck::IsValid(EntityReplicator.Get_Handle_RepObj()),
+        TEXT("Entity [{}] CANNOT be replicated since it does NOT have a valid [{}]"), InHandle,
+        ck::Get_RuntimeTypeToString<UCk_Fragment_EntityReplicationDriver_Rep>())
+    { return {}; }
+
+    return EntityReplicator;
+}
+
+auto
+    UCk_Utils_EntityReplicationDriver_UE::
+    Break_HandleReplicator(
+        const FCk_HandleReplicator& InHandleReplicator,
+        FCk_Handle&                 OutHandle)
+    -> void
+{
+    OutHandle = InHandleReplicator.Get_Handle();
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Utils.h
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Utils.h
@@ -91,6 +91,23 @@ public:
     Promise_OnReplicationCompleteAllDependents(
         FCk_Handle InEntity,
         const FCk_Delegate_EntityReplicationDriver_OnReplicationComplete& InDelegate);
+
+private:
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|ReplicationDriver",
+              meta = (NativeMakeFunc))
+    static FCk_HandleReplicator
+    Make_HandleReplicator(
+        UPARAM(ref) FCk_Handle& InHandle);
+
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|ReplicationDriver",
+              meta = (NativeBreakFunc))
+    static void
+    Break_HandleReplicator(
+        const FCk_HandleReplicator& InHandleReplicator,
+        FCk_Handle& OutHandle);
+
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…e Handle IDs

notes: the HandleReplicator requires the Handle to be replicated (i.e. have an EntityReplicationDriver Replicated Object) without which, errors are issued and the Handle ID cannot be replicated (similar to a non-replicated Actor being RPCed or RepVar'ed)