### PR TITLE
fix: HandleReplicator now serializes the Entity even if it's invalid

### DIFF
--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.cpp
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.cpp
@@ -14,7 +14,6 @@ auto
         bool& bOutSuccess)
     -> bool
 {
-    auto RepBits = uint16{0};
     if (Ar.IsSaving())
     {
         if (ck::IsValid(_Handle))
@@ -25,6 +24,10 @@ auto
                 Ar << InRepDriver;
             });
         }
+        else
+        {
+            Ar << _Handle_RepObj;
+        }
     }
 
     if (Ar.IsLoading())
@@ -33,6 +36,10 @@ auto
         if (ck::IsValid(_Handle_RepObj))
         {
             _Handle = _Handle_RepObj->Get_AssociatedEntity();
+        }
+        else
+        {
+            _Handle = {};
         }
     }
 


### PR DESCRIPTION
notes: this allows the rep-notify call to go through if a previously valid Entity was set to default-constructed (i.e invalid) Entity where the user would then expect a rep-notify call