### PR TITLE
feat: Ability Processors now pump 5 times to allow for transient requ…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbilityProcessorInjector.cpp
+++ b/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbilityProcessorInjector.cpp
@@ -23,11 +23,14 @@ auto
         -> void
 {
     InWorld.Add<ck::FProcessor_AbilityOwner_Setup>(InWorld.Get_Registry());
-    InWorld.Add<ck::FProcessor_AbilityOwner_HandleRequests>(InWorld.Get_Registry());
-    InWorld.Add<ck::FProcessor_AbilityOwner_HandleEvents>(InWorld.Get_Registry());
-    InWorld.Add<ck::FProcessor_AbilityOwner_TagsUpdated>(InWorld.Get_Registry());
-    // there may be requests to Deactivate after Tags are updated, pump the HandleRequests again
-    InWorld.Add<ck::FProcessor_AbilityOwner_HandleRequests>(InWorld.Get_Registry());
+
+    auto NumPumps = 5;
+    while (NumPumps --> 0)
+    {
+        InWorld.Add<ck::FProcessor_AbilityOwner_HandleRequests>(InWorld.Get_Registry());
+        InWorld.Add<ck::FProcessor_AbilityOwner_HandleEvents>(InWorld.Get_Registry());
+        InWorld.Add<ck::FProcessor_AbilityOwner_TagsUpdated>(InWorld.Get_Registry());
+    }
 
     InWorld.Add<ck::FProcessor_AbilityCue_Spawn>(InWorld.Get_Registry());
 }


### PR DESCRIPTION
…ests to be processed

notes: this is a precursor to 'Processor Pump' which is a feature that will be introduced in the framework at a later date. A 'Processor Pump' continuously ticks Processors where their 'MarkedDirtyBy' Fragment is still available in a view. The pumps happen until a pre-determined number of number of pumps OR no 'MarkedDirtyBy' Fragments are in the Registry.