### PR TITLE
fix: CreateEntity now correctly transfers the lifetime owner's destru…

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
@@ -48,7 +48,7 @@ namespace ck
             HandleType InHandle) const
         -> void
     {
-        ecs::VeryVerbose(TEXT("Entity [{}] set to 'Pending Destroy'"), InHandle);
+        ecs::VeryVerbose(TEXT("Entity [{}] set to 'Awaiting Destruction'"), InHandle);
         InHandle.Add<FTag_DestroyEntity_Await>();
     }
 
@@ -72,7 +72,7 @@ namespace ck
             HandleType InHandle) const
         -> void
     {
-        ecs::VeryVerbose(TEXT("Entity [{}] set to 'Pending Destroy'"), InHandle);
+        ecs::VeryVerbose(TEXT("Entity [{}] set to 'Finalizing Destruction'"), InHandle);
         InHandle.Add<FTag_DestroyEntity_Finalize, ck::IsValid_Policy_IncludePendingKill>();
     }
 

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -163,6 +163,10 @@ auto
     const auto NewEntity = Request_CreateEntity(**InHandle, [&](FCk_Handle InNewEntity)
     {
         InNewEntity.Add<ck::FFragment_LifetimeOwner>(InHandle);
+
+        if (InHandle.Has_Any<ck::FTag_DestroyEntity_Initiate>())
+        { InNewEntity.Add<ck::FTag_DestroyEntity_Initiate>(); }
+
         // Not doing something like this because it is undefined behavior: *const_cast<FCk_Handle*>(&InHandle)
         auto NonConstHandle = InHandle;
 


### PR DESCRIPTION
…ction tag

notes: it is possible that while the owning Entity's destruction has initiated that there are requests to create an Entity. These requests are (correctly) fulfilled, but such Entities MUST be marked for Destruction Initiate to ensure that they go through the same destruction steps as their lifetime owner's