### PR TITLE
Bugfix/cue instigator effect causer loading nullptr

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Fragment_Data.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Fragment_Data.cpp
@@ -137,12 +137,16 @@ auto
         Ar << _Instigator_RepObj;
         if (Ar.IsLoading())
         {
-            CK_ENSURE_IF_NOT(ck::IsValid(_Instigator_RepObj),
-                TEXT("Instigator RepObj was [{}] even though RepBits tell us that it WAS replicated. Unable to set the Instigator."),
-                _Instigator_RepObj)
-            { }
+            if (ck::Is_NOT_Valid(_Instigator_RepObj))
+            {
+                ck::ability::Verbose(TEXT("Instigator RepObj was [{}] even though RepBits tell us that it WAS replicated. Unable to set "
+                    "the Instigator. Note that this is always possible if the cue comes in AFTER the Instigator has been destroyed"),
+                    _Instigator_RepObj);
+            }
             else
-            { _Instigator = _Instigator_RepObj->Get_AssociatedEntity(); }
+            {
+                _Instigator = _Instigator_RepObj->Get_AssociatedEntity();
+            }
         }
     }
     if (RepBits & (1 << Rep_EffectCauser))
@@ -150,12 +154,16 @@ auto
         Ar << _EffectCauser_RepObj;
         if (Ar.IsLoading())
         {
-            CK_ENSURE_IF_NOT(ck::IsValid(_EffectCauser_RepObj),
-                TEXT("EffectCauser RepObj was [{}] even though RepBits tell us that it WAS replicated. Unable to set the EffectCauser."),
-                _EffectCauser_RepObj)
-            { }
-
-            _EffectCauser = _EffectCauser_RepObj->Get_AssociatedEntity();
+            if (ck::Is_NOT_Valid(_EffectCauser_RepObj))
+            {
+                ck::ability::Verbose(TEXT("EffectCauser RepObj was [{}] even though RepBits tell us that it WAS replicated. Unable to set "
+                    "the EffectCauser. Note that this is always possible if the cue comes in AFTER the EffectCauser has been destroyed"),
+                    _EffectCauser_RepObj);
+            }
+            else
+            {
+                _EffectCauser = _EffectCauser_RepObj->Get_AssociatedEntity();
+            }
         }
     }
 


### PR DESCRIPTION
commit 37308de3ee30c8a476567078827d4d044aeb1ede (HEAD -> bugfix/cue-instigator-effect-causer-loading-nullptr, origin/bugfix/cue-instigator-effect-causer-loading-nullptr)
Author: sulfur-ck <sulfur@chainkemists.com>
Date:   Mon Mar 4 00:48:46 2024 -0800

    fix: removed the ensure in the cue where an Instigator and/or EffectCauser may be invalid when loading the object

    notes: this is expected behavior and should not be ensure; it's expected because it's possible that by the time we receive the cue, the Instigator and/or the EffectCause are pending kill or destroyed