### PR TITLE
feat: Handle's Remove function now also supports optional validation …

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -95,7 +95,13 @@ public:
     template <typename T_Fragment>
     auto Remove() -> void;
 
+    template <typename T_Fragment, typename T_ValidationPolicy>
+    auto Remove() -> void;
+
     template <typename T_Fragment>
+    auto Try_Remove() -> void;
+
+    template <typename T_Fragment, typename T_ValidationPolicy>
     auto Try_Remove() -> void;
 
     template <typename... T_Fragments>
@@ -505,7 +511,16 @@ auto
     Remove()
     -> void
 {
-    CK_ENSURE_IF_NOT(IsValid(ck::IsValid_Policy_Default{}),
+    Remove<T_Fragment, ck::IsValid_Policy_Default>();
+}
+
+template <typename T_Fragment, typename T_ValidationPolicy>
+auto
+    FCk_Handle::
+    Remove()
+    -> void
+{
+    CK_ENSURE_IF_NOT(IsValid(T_ValidationPolicy{}),
         TEXT("Unable to Remove Fragment [{}]. Handle [{}] {}."),
         ck::Get_RuntimeTypeToString<T_Fragment>(), *this,
         [&]
@@ -532,7 +547,16 @@ auto
     Try_Remove()
     -> void
 {
-    CK_ENSURE_IF_NOT(IsValid(ck::IsValid_Policy_Default{}),
+    Try_Remove<T_Fragment, ck::IsValid_Policy_Default>();
+}
+
+template <typename T_Fragment, typename T_ValidationPolicy>
+auto
+    FCk_Handle::
+    Try_Remove()
+    -> void
+{
+    CK_ENSURE_IF_NOT(IsValid(T_ValidationPolicy{}),
         TEXT("Unable to Remove Fragment [{}]. Handle [{}] {}."),
         ck::Get_RuntimeTypeToString<T_Fragment>(), *this,
         [&]


### PR DESCRIPTION
…policy

notes: this is mainly to help resolve issues where we may be removing Fragments as part of a teardown where the helper function that is called does not necessarily know that the Handle is tearing down. In such cases, we would like to remove Fragments even if the Handle is pending kill (but NOT finalized for destruction). For example, Revoking Abilities and the utility functions for it.