### PR TITLE
feat: added additional debugging breadcrumbs in Ability Scripts for A…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.cpp
@@ -58,6 +58,8 @@ auto
         const FCk_Ability_Payload_OnActivate& InActivationPayload)
     -> void
 {
+    DoDebugSet_Activated();
+
     const auto AbilityOwnerEntity = Get_AbilityOwnerHandle();
 
     switch(const auto ExecutionPolicy = Get_Data().Get_NetworkSettings().Get_ExecutionPolicy())
@@ -97,6 +99,8 @@ auto
     OnDeactivateAbility()
     -> void
 {
+    DoDebugSet_Deactivated();
+
     DoOnDeactivateAbility();
 }
 
@@ -116,6 +120,8 @@ auto
         const FCk_Ability_Payload_OnGranted& InOptionalPayload)
     -> void
 {
+    DoDebugSet_Given();
+
     DoOnGiveAbility(InOptionalPayload);
 }
 
@@ -124,6 +130,8 @@ auto
     OnRevokeAbility()
     -> void
 {
+    DoDebugSet_Revoked();
+
     DoOnRevokeAbility();
 }
 
@@ -134,8 +142,8 @@ auto
     -> void
 {
     CK_ENSURE_IF_NOT(ck::IsValid(Get_AbilityHandle()),
-        TEXT("AbilityHandle is INVALID. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
-        ck::Context(this))
+        TEXT("AbilityHandle is [{}]. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
+        Get_AbilityHandle(), ck::Context(this))
     { return; }
 
     UCk_Utils_AbilityOwner_UE::Request_TryActivateAbility(
@@ -150,8 +158,8 @@ auto
     -> void
 {
     CK_ENSURE_IF_NOT(ck::IsValid(Get_AbilityHandle()),
-        TEXT("AbilityHandle is INVALID. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
-        ck::Context(this))
+        TEXT("AbilityHandle is [{}]. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
+        Get_AbilityHandle(), ck::Context(this))
     { return; }
 
     UCk_Utils_AbilityOwner_UE::Request_DeactivateAbility(
@@ -305,8 +313,8 @@ auto
     -> ECk_Ability_Status
 {
     CK_ENSURE_IF_NOT(ck::IsValid(Get_AbilityHandle()),
-        TEXT("AbilityHandle is INVALID. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
-        ck::Context(this))
+        TEXT("AbilityHandle is [{}]. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
+        Get_AbilityHandle(), ck::Context(this))
     { return {}; }
 
     return UCk_Utils_Ability_UE::Get_Status(Get_AbilityHandle());
@@ -318,8 +326,8 @@ auto
     -> FCk_Handle_Ability
 {
     CK_ENSURE_IF_NOT(ck::IsValid(Get_AbilityHandle(), ck::IsValid_Policy_IncludePendingKill{}),
-        TEXT("AbilityHandle is INVALID. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
-        ck::Context(this))
+        TEXT("AbilityHandle is [{}]. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
+        Get_AbilityHandle(), ck::Context(this))
     { return {}; }
 
     return Get_AbilityHandle();
@@ -331,11 +339,53 @@ auto
     -> FCk_Handle_AbilityOwner
 {
     CK_ENSURE_IF_NOT(ck::IsValid(Get_AbilityOwnerHandle(), ck::IsValid_Policy_IncludePendingKill{}),
-        TEXT("AbilityOwnerHandle is INVALID. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
-        ck::Context(this))
+        TEXT("AbilityOwnerHandle is [{}]. It's possible that this was not set correctly by the Processor that Gives the Ability.{}"),
+        Get_AbilityOwnerHandle(), ck::Context(this))
     { return {}; }
 
     return Get_AbilityOwnerHandle();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Ability_Script_PDA::
+    DoDebugSet_Activated()
+    -> void
+{
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
+    _ActivateDeactivate = EActivatedDeactivated::Activated;
+#endif
+}
+
+auto
+    UCk_Ability_Script_PDA::
+    DoDebugSet_Deactivated()
+    -> void
+{
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
+    _ActivateDeactivate = EActivatedDeactivated::Deactivated;
+#endif
+}
+
+auto
+    UCk_Ability_Script_PDA::
+    DoDebugSet_Given()
+    -> void
+{
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
+    _GiveRevoke = EGivenRevoked::Given;
+#endif
+}
+
+auto
+    UCk_Ability_Script_PDA::
+    DoDebugSet_Revoked()
+    -> void
+{
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
+    _GiveRevoke = EGivenRevoked::Revoked;
+#endif
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.h
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.h
@@ -35,7 +35,7 @@ public:
 
     auto
     OnDeactivateAbility() -> void;
-    
+
     auto
     Get_CanBeGiven(
         const FCk_Handle_AbilityOwner& InAbilityOwner,
@@ -209,6 +209,38 @@ private:
 
     UPROPERTY(Transient)
     TArray<TObjectPtr<UObject>> _Tasks;
+
+private:
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
+    enum class EActivatedDeactivated
+    {
+        None,
+        Activated,
+        Deactivated
+    };
+
+    enum class EGivenRevoked
+    {
+        None,
+        Given,
+        Revoked
+    };
+
+    EActivatedDeactivated _ActivateDeactivate = EActivatedDeactivated::None;
+    EGivenRevoked _GiveRevoke = EGivenRevoked::None;
+#endif
+
+    auto
+    DoDebugSet_Activated() -> void;
+
+    auto
+    DoDebugSet_Deactivated() -> void;
+
+    auto
+    DoDebugSet_Given() -> void;
+
+    auto
+    DoDebugSet_Revoked() -> void;
 
 public:
     CK_PROPERTY_GET(_Data);

--- a/Source/CkBuildConfig/CkBuildConfig.Build.cs
+++ b/Source/CkBuildConfig/CkBuildConfig.Build.cs
@@ -17,6 +17,7 @@ public class CkModuleRules : ModuleRules
         // normally, detailed formatting is invoked using {d}, this switch will force detailed formatting (if supported by formatter)
         PublicDefinitions.Add("CK_FORMAT_FORCE_DETAILED=0");
         PublicDefinitions.Add("CK_DEBUG_NAME_FORCE_VERBOSE=0");
+        PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=0");
 
         switch(BuildConfigurationOverride)
         {


### PR DESCRIPTION
…ctivation/Deactivation Give/Revoke

notes: the additional information is useful in cases where a latent node may try to interact with an Ability that is already Deactivated and/or Revoked. Without the additional debug variables, it's not clear whether the Ability was successfully Deactivated/Revoked before the Ability Entity was destroyed and an ensure triggered.