### PR TITLE
fix: Ability teardown now correctly handles Revoke - Fixed validation…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Processor.cpp
@@ -16,9 +16,6 @@ namespace ck
             const FFragment_Ability_Current& InCurrent) const
         -> void
     {
-        // there is nothing to teardown if the Ability is already Inactive
-        if (InCurrent.Get_Status() == ECk_Ability_Status::NotActive)
-        { return; }
 
         auto LifetimeOwner = UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InHandle);
         auto AbilityOwner = UCk_Utils_AbilityOwner_UE::CastChecked(LifetimeOwner);
@@ -31,6 +28,7 @@ namespace ck
         );
 
         UCk_Utils_Ability_UE::DoDeactivate(AbilityOwner, InHandle);
+        UCk_Utils_Ability_UE::DoRevoke(AbilityOwner, InHandle);
     }
 }
 

--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.cpp
@@ -433,7 +433,9 @@ auto
         return;
     }
 
-    RecordOfAbilities_Utils::Request_Disconnect(InAbilityOwner, InAbility);
+    if (RecordOfAbilities_Utils::Has(InAbility))
+    { RecordOfAbilities_Utils::Request_Disconnect(InAbilityOwner, InAbility); }
+
     UCk_Utils_EntityLifetime_UE::Request_DestroyEntity(InAbility);
 
     const auto Script = Current.Get_AbilityScript();


### PR DESCRIPTION
… with Record Disconnect when Revoking abilities during teardown

notes: Revoke also Deactivates, so it's technically redundant to call both (this will be improved in a subsequent PR).