### PR TITLE
fix: while Revoking an Ability, we check whether the Record (AbilityO…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Utils.cpp
@@ -433,7 +433,9 @@ auto
         return;
     }
 
-    RecordOfAbilities_Utils::Request_Disconnect(InAbilityOwner, InAbility);
+    if (RecordOfAbilities_Utils::Get_ContainsEntry(InAbilityOwner, InAbility))
+    { RecordOfAbilities_Utils::Request_Disconnect(InAbilityOwner, InAbility); }
+
     UCk_Utils_EntityLifetime_UE::Request_DestroyEntity(InAbility);
 
     const auto Script = Current.Get_AbilityScript();


### PR DESCRIPTION
…wner) even has the Ability entry

notes: while tearing down, it's possible that the Entry has already been discarded, in which case we do not attempt to remove the Ability Entry from the AbilityOwner Record which avoids triggering the ensure