### PR TITLE
fix: Record no longer lazily removes Handles that are pending destruc…

### DIFF
--- a/Source/CkRecord/Public/CkRecord/Record/CkRecord_Utils.h
+++ b/Source/CkRecord/Public/CkRecord/Record/CkRecord_Utils.h
@@ -525,7 +525,7 @@ namespace ck
         {
             const auto RecordEntryHandle = ck::MakeHandle(RecordEntries[Index], InHandle);
 
-            if (ck::Is_NOT_Valid(RecordEntryHandle, T_ValidationPolicy{}))
+            if (ck::Is_NOT_Valid(RecordEntryHandle, ck::IsValid_Policy_IncludePendingKill{}))
             {
                 RecordEntries.RemoveAtSwap(Index);
                 --Index;
@@ -563,7 +563,7 @@ namespace ck
         {
             const auto RecordEntryHandle = ck::StaticCast<const MaybeTypeSafeHandle>(ck::MakeHandle(RecordEntries[Index], InHandle));
 
-            if (ck::Is_NOT_Valid(RecordEntryHandle, T_ValidationPolicy{}))
+            if (ck::Is_NOT_Valid(RecordEntryHandle, ck::IsValid_Policy_IncludePendingKill{}))
             {
                 // not using RecordEntries local variable to keep mutability
                 Fragment._RecordEntries.RemoveAtSwap(Index);


### PR DESCRIPTION
…tion

notes: our Records lazily remove Handles that are Invalid. However, in a Records, it is well-defined behavior to iterate over Handles that are pending kill. This change makes it so that those Handles are not removed from the Record.