### PR TITLE
fix: Targeter_BasicInfo and Tartetable_BasicInfo no longer use the Ow…

### DIFF
--- a/Source/CkTargeting/Public/Targetable/CkTargetable_Fragment_Data.cpp
+++ b/Source/CkTargeting/Public/Targetable/CkTargetable_Fragment_Data.cpp
@@ -61,7 +61,7 @@ auto
         const ThisType& InOther) const
     -> bool
 {
-    return Get_Owner() < InOther.Get_Owner() && Get_Targetable() < InOther.Get_Targetable();
+    return Get_Targetable() < InOther.Get_Targetable();
 }
 
 auto

--- a/Source/CkTargeting/Public/Targeter/CkTargeter_Fragment_Data.cpp
+++ b/Source/CkTargeting/Public/Targeter/CkTargeter_Fragment_Data.cpp
@@ -50,7 +50,7 @@ auto
         const ThisType& InOther) const
     -> bool
 {
-    return Get_Owner() < InOther.Get_Owner() && Get_Targeter() < InOther.Get_Targeter();
+    return Get_Targeter() < InOther.Get_Targeter();
 }
 
 auto


### PR DESCRIPTION
…ner as part of the operator< definition, only the Targeter/Targetable handle

By using the Owner, it was possible for the sorting of various algos (e.g. Except/Intersect) to NOT return the correct values, because a list of BasicInfo would NOT be sorted correctly