### PR TITLE
Revert "fix: Attribute base value is no longer clamped which fixes is…

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -56,10 +56,12 @@ namespace ck::detail
             const AttributeFragmentType_Min& InAttributeMin) const
         -> void
     {
+        const auto BaseValue = InAttributeCurrent._Base;
         const auto FinalValue = InAttributeCurrent._Final;
 
         const auto FinalValue_Min = InAttributeMin._Final;
 
+        InAttributeCurrent._Base = TAttributeMinMax<AttributeDataType>::Max(BaseValue, FinalValue_Min);
         InAttributeCurrent._Final = TAttributeMinMax<AttributeDataType>::Max(FinalValue, FinalValue_Min);
     }
 
@@ -75,10 +77,12 @@ namespace ck::detail
             const AttributeFragmentType_Max& InAttributeMax) const
         -> void
     {
+        const auto BaseValue = InAttributeCurrent._Base;
         const auto FinalValue = InAttributeCurrent._Final;
 
         const auto FinalValue_Max = InAttributeMax._Final;
 
+        InAttributeCurrent._Base = TAttributeMinMax<AttributeDataType>::Min(BaseValue, FinalValue_Max);
         InAttributeCurrent._Final = TAttributeMinMax<AttributeDataType>::Min(FinalValue, FinalValue_Max);
     }
 


### PR DESCRIPTION
…sues where a Revokable modifier prevents the final value from going beyond a certain unexpected minimum"

This reverts commit bf56e75825259845550d560fb2aba8820dd3d6f9.

The full conversation on why this was reverted is here: https://chainkemists.slack.com/archives/C06GC7FQPH6/p1710367008359489

tl;dr: when overriding, we add an irrevokable modifier which results in the base values going beyond the min and max which is unexpected. Reverting this _does_ result in the original problem resurfacing. We'll address that problem when it becomes a problem.