### PR TITLE
fix: fixed issue where IsValid makes a copy of the incoming variable …

### DIFF
--- a/Source/CkCore/Public/CkCore/Format/CkFormat.h
+++ b/Source/CkCore/Public/CkCore/Format/CkFormat.h
@@ -112,7 +112,7 @@ namespace ck
 #define CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER(_Type_, _LambdaToReturnInvalidObj_)\
 namespace ck { namespace ck_format_detail {                                         \
     inline auto&                                                                    \
-    ForwarderForPointers(const _Type_* InObj)                                       \
+    ForwarderForPointers(const _Type_* InObj)                                      \
     {                                                                               \
         if (ck::IsValid(InObj))                                                     \
         { return *InObj; }                                                          \

--- a/Source/CkCore/Public/CkCore/Validation/CkIsValid_Defaults.h
+++ b/Source/CkCore/Public/CkCore/Validation/CkIsValid_Defaults.h
@@ -118,7 +118,7 @@ CK_DEFINE_CUSTOM_IS_VALID(FGameplayTag, ck::IsValid_Policy_Default, [=](FGamepla
     return InGameplayTag.IsValid();
 });
 
-CK_DEFINE_CUSTOM_IS_VALID(FGameplayTagContainer, ck::IsValid_Policy_Default, [=](FGameplayTagContainer InGameplayTagContainer)
+CK_DEFINE_CUSTOM_IS_VALID(FGameplayTagContainer, ck::IsValid_Policy_Default, [=](const FGameplayTagContainer& InGameplayTagContainer)
 {
     return InGameplayTagContainer.IsValid();
 });


### PR DESCRIPTION
…before validating

notes: copying the incoming type has some repurcussions e.g. Handle validation copies the Handle which in turn can trigger another copy of an Invalid Handle. Normally this would not be an issue but while the Engine is starting, if an ensure is fired we can have infinite recursion. This should also improve performance overall since we are no longer making copies of the Handles just for validation.