### PR TITLE
feat: added user setting to specify ensure 'break-in-blueprints' beha…

### DIFF
--- a/Source/CkCore/Public/CkCore/Debug/CkDebug_Utils.cpp
+++ b/Source/CkCore/Public/CkCore/Debug/CkDebug_Utils.cpp
@@ -247,7 +247,11 @@ auto
     if (ScriptStack.IsEmpty())
     { return; }
 
-    const auto ExceptionInfo = FBlueprintExceptionInfo{EBlueprintExceptionType::AccessViolation, InDescription};
+    const auto ExceptionType = UCk_Utils_Core_UserSettings_UE::Get_EnsureBreakPolicy() == ECk_EnsureBreak_Policy::AlwaysBreak
+        ? EBlueprintExceptionType::Breakpoint
+        : EBlueprintExceptionType::AccessViolation;
+
+    const auto ExceptionInfo = FBlueprintExceptionInfo{ExceptionType, InDescription};
     FBlueprintCoreDelegates::ThrowScriptException(Context, *ScriptStack.Last(), ExceptionInfo);
 #endif
 }

--- a/Source/CkCore/Public/CkCore/Settings/CkCore_Settings.cpp
+++ b/Source/CkCore/Public/CkCore/Settings/CkCore_Settings.cpp
@@ -38,4 +38,12 @@ auto
 #endif
 }
 
+auto
+    UCk_Utils_Core_UserSettings_UE::
+    Get_EnsureBreakPolicy()
+    -> ECk_EnsureBreak_Policy
+{
+    return UCk_Utils_Object_UE::Get_ClassDefaultObject<UCk_Core_UserSettings_UE>()->Get_EnsureBreakPolicy();
+}
+
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCore/Public/CkCore/Settings/CkCore_Settings.h
+++ b/Source/CkCore/Public/CkCore/Settings/CkCore_Settings.h
@@ -35,6 +35,16 @@ enum class ECk_EnsureDetails_Policy : uint8
 
 // --------------------------------------------------------------------------------------------------------------------
 
+UENUM(BlueprintType)
+enum class ECk_EnsureBreak_Policy : uint8
+{
+    AlwaysBreak,
+    // Unreal 'Break on Exception' is disabled by default in Editor Settings
+    UseUnrealExceptionBehavior
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 UCLASS(meta = (DisplayName = "Core"))
 class CKCORE_API UCk_Core_ProjectSettings_UE : public UCk_Plugin_ProjectSettings_UE
 {
@@ -67,10 +77,15 @@ private:
               meta = (AllowPrivateAccess = true))
     ECk_EnsureDetails_Policy _EnsureDetailsPolicy = ECk_EnsureDetails_Policy::MessageAndStackTrace;
 
+    UPROPERTY(Config, VisibleAnywhere, BlueprintReadOnly, Category = "Ensures",
+              meta = (AllowPrivateAccess = true))
+    ECk_EnsureBreak_Policy _EnsureBreakPolicy = ECk_EnsureBreak_Policy::AlwaysBreak;
+
 public:
     CK_PROPERTY_GET(_DefaultDebugNameVerbosity);
     CK_PROPERTY_GET(_EnsureDisplayPolicy);
     CK_PROPERTY_GET(_EnsureDetailsPolicy);
+    CK_PROPERTY_GET(_EnsureBreakPolicy);
 };
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -88,6 +103,7 @@ class CKCORE_API UCk_Utils_Core_UserSettings_UE
 {
 public:
     static auto Get_DefaultDebugNameVerbosity() -> ECk_DebugNameVerbosity_Policy;
+    static auto Get_EnsureBreakPolicy() -> ECk_EnsureBreak_Policy;
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…vior

notes: default is to always break while the other setting follows Unreal's behavior of breaking on exception