### PR TITLE
feat: EntityBridge no longer requires EntityConfig and the now requir…

### DIFF
--- a/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_ConstructionScript.h
+++ b/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_ConstructionScript.h
@@ -44,6 +44,10 @@ public:
 protected:
     auto OnUnregister() -> void override;
 
+public:
+    auto
+    PostLoad() -> void override;
+
 protected:
     auto Do_Construct_Implementation(
         const FCk_ActorComponent_DoConstruct_Params& InParams) -> void override;
@@ -62,7 +66,10 @@ public:
     UPROPERTY(EditDefaultsOnly)
     ECk_Replication _Replication = ECk_Replication::Replicates;
 
-    UPROPERTY(EditDefaultsOnly, Instanced)
+    UPROPERTY(EditDefaultsOnly)
+    TSubclassOf<UCk_Entity_ConstructionScript_PDA> _ConstructionScript;
+
+    UPROPERTY(Instanced)
     TObjectPtr<class UCk_EntityBridge_Config_WithActor_PDA> EntityConfig;
 
 private:

--- a/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_Fragment_Data.h
+++ b/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_Fragment_Data.h
@@ -81,6 +81,9 @@ private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Instanced,
               meta = (AllowPrivateAccess = true, ExposeOnSpawn = true))
     TObjectPtr<class UCk_Entity_ConstructionScript_WithTransform_PDA> _EntityConstructionScript;
+
+public:
+    CK_PROPERTY_GET(_EntityConstructionScript);
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…ed ConstructionScript reference is no longer 'Instanced'

notes: The 'Instanced' EntityConfig was causing a bit of confusion where designers would adjust the properties of the Entity's Construction Script in the instanced DataAsset which is not recommended. The main reason for instancing was to give an overview of the construction script parameter without opening the asset.