### PR TITLE
Feature/ability cue improvements

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Fragment_Data.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Fragment_Data.h
@@ -71,7 +71,7 @@ public:
 
 // --------------------------------------------------------------------------------------------------------------------
 
-USTRUCT(BlueprintType)
+USTRUCT(BlueprintType, meta = (HasNativeMake = "/Script/CkAbility.Ck_Utils_AbilityCue_UE:Make_AbilityCue_Params"))
 struct CKABILITY_API FCk_AbilityCue_Params
 {
     GENERATED_BODY()
@@ -110,6 +110,12 @@ public:
         FArchive& Ar,
         class UPackageMap* Map,
         bool& bOutSuccess) -> bool;
+
+public:
+    CK_PROPERTY(_Location);
+    CK_PROPERTY(_Normal);
+    CK_PROPERTY(_Instigator);
+    CK_PROPERTY(_EffectCauser);
 };
 
 template<>

--- a/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Utils.cpp
@@ -7,6 +7,8 @@
 
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 
+#include "CkNet/CkNet_Utils.h"
+
 // --------------------------------------------------------------------------------------------------------------------
 
 auto
@@ -28,6 +30,43 @@ auto
     -> FCk_AbilityCue_Params
 {
     return InAbilityCueEntity.Get<FCk_AbilityCue_Params>();
+}
+
+auto
+    UCk_Utils_AbilityCue_UE::
+    Make_AbilityCue_Params(
+        FVector InLocation,
+        FVector InNormal,
+        FCk_Handle InInstigator,
+        FCk_Handle InEffectCauser)
+    -> FCk_AbilityCue_Params
+{
+    FCk_AbilityCue_Params AbilityCueParams;
+
+    AbilityCueParams.Set_Location(InLocation);
+    AbilityCueParams.Set_Normal(InNormal);
+
+    if (ck::IsValid(InInstigator))
+    {
+        CK_ENSURE_IF_NOT(UCk_Utils_Net_UE::Get_EntityReplication(InInstigator) == ECk_Replication::Replicates,
+            TEXT("Constructing AbilityCue Params with Instigator Entity [{}] which is NOT replicated! AbilityCue using these params will NOT work as expected"),
+            InInstigator)
+        {}
+
+        AbilityCueParams.Set_Instigator(InInstigator);
+    }
+
+    if (ck::IsValid(InEffectCauser))
+    {
+        CK_ENSURE_IF_NOT(UCk_Utils_Net_UE::Get_EntityReplication(InEffectCauser) == ECk_Replication::Replicates,
+            TEXT("Constructing AbilityCue Params with EffectCauser Entity [{}] which is NOT replicated! AbilityCue using these params will NOT work as expected"),
+            InEffectCauser)
+        {}
+
+        AbilityCueParams.Set_EffectCauser(InEffectCauser);
+    }
+
+    return AbilityCueParams;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityCue/CkAbilityCue_Utils.h
@@ -33,6 +33,17 @@ public:
     static FCk_AbilityCue_Params
     Get_Params(
         const FCk_Handle& InAbilityCueEntity);
+
+    UFUNCTION(BlueprintPure,
+        DisplayName = "[Ck] Make AbilityCue Params",
+        Category = "Ck|Utils|AbilityCue",
+        meta = (NativeMakeFunc))
+    static FCk_AbilityCue_Params
+    Make_AbilityCue_Params(
+        FVector InLocation,
+        FVector InNormal,
+        FCk_Handle InInstigator,
+        FCk_Handle InEffectCauser);
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
commit c3643ee1712836f7e8728ed744e9170da95d8e3c (HEAD -> feature/ability-cue-improvements, origin/feature/ability-cue-improvements)
Author: Nitrogen-CK <nitrogen@chainkemists.com>
Date:   Mon Apr 1 15:51:42 2024 -0400

    feat: Added new custom make function for AbilityCueParams where we validate that the Instigator & EffectCauser handles are set to replicate if a valid one is provided as a parameter

    This helps detect potential issue where the wrong handle is sent over as a client RPC. If the handle is NOT set to replicate, when the AbilityCue Script on the client receives, the handle will resolve to none/invalid

commit 0f19b14b9557d3664d045eedfae9cc36e1e45c45
Author: Nitrogen-CK <nitrogen@chainkemists.com>
Date:   Mon Apr 1 15:49:12 2024 -0400

    feat: AbilityCue Params "_Normal" property default value is set to 0,0,0. This avoids serializing it everytime since we serialize this field if it is NOT nearly equal to a zero vector