### PR TITLE
fix: removed PostLoad override from EntityBridge which can sometimes …

### DIFF
--- a/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_ConstructionScript.cpp
+++ b/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_ConstructionScript.cpp
@@ -74,25 +74,6 @@ auto
 
 auto
     UCk_EntityBridge_ActorComponent_UE::
-    PostLoad()
-    -> void
-{
-    Super::PostLoad();
-
-    if (IsTemplate())
-    { return; }
-
-    if (ck::Is_NOT_Valid(EntityConfig))
-    { return; }
-
-    _ConstructionScript = EntityConfig->Get_EntityConstructionScript()->GetClass();
-    EntityConfig = nullptr;
-
-    ck::entity_bridge::Log(TEXT("[MIGRATE] EntityConfig with ConstructionScript [{}] migrated for [{}]"), _ConstructionScript, GetOwner());
-}
-
-auto
-    UCk_EntityBridge_ActorComponent_UE::
     Do_Construct_Implementation(
         const FCk_ActorComponent_DoConstruct_Params& InParams)
     -> void
@@ -111,6 +92,7 @@ auto
     if (ck::Is_NOT_Valid(_ConstructionScript) && ck::IsValid(EntityConfig))
     {
         _ConstructionScript = EntityConfig->Get_EntityConstructionScript()->GetClass();
+        ck::entity_bridge::Log(TEXT("[MIGRATE] EntityConfig with ConstructionScript [{}] migrated for [{}]"), _ConstructionScript, GetOwner());
         EntityConfig = nullptr;
     }
 

--- a/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_ConstructionScript.h
+++ b/Source/CkEntityBridge/Public/CkEntityBridge/CkEntityBridge_ConstructionScript.h
@@ -44,10 +44,6 @@ public:
 protected:
     auto OnUnregister() -> void override;
 
-public:
-    auto
-    PostLoad() -> void override;
-
 protected:
     auto Do_Construct_Implementation(
         const FCk_ActorComponent_DoConstruct_Params& InParams) -> void override;


### PR DESCRIPTION
…cause the ConstructionScript parameter to be incorrect

notes: the new ConstructionScript parameter supercedes the old EntityConfig parameter. The idea behind the PostLoad override was to automatically adjust the Blueprint Asset and upon re-save, remove the now obsolete property. Normally this works well for most Blueprints but because this is an ActorComponent instantiated inside an Actor Blueprint, overriding the values does not propagate to the instance found in the Actor Blueprint. Until we find another way to correct modify the values of the instanced ActorComponent in an Actor, we'll continue to do the migrate at runtime.