### PR TITLE
fix: fixed issues where the ReplicationDriver pointer may be null or …

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
@@ -203,6 +203,11 @@ auto
 {
     if (Ar.IsSaving())
     {
+        if (ck::Is_NOT_Valid(_ReplicationDriver) && Has<TWeakObjectPtr<class UCk_Ecs_ReplicatedObject_UE>>())
+        {
+            _ReplicationDriver = Get<TWeakObjectPtr<class UCk_Ecs_ReplicatedObject_UE>>();
+        }
+
         Ar << _ReplicationDriver;
     }
 

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -45,6 +45,7 @@ struct CKECS_API FCk_Handle
     GENERATED_BODY()
 
     friend class UCk_Utils_EntityReplicationDriver_UE;
+    friend class UCk_Fragment_EntityReplicationDriver_Rep;
 
 public:
     CK_GENERATED_BODY(FCk_Handle);
@@ -322,6 +323,7 @@ FCk_Handle::
         const T_WrappedHandle& InOther)
     : _Entity(InOther._Entity)
     , _Registry(InOther._Registry)
+    , _ReplicationDriver(InOther._ReplicationDriver)
 #if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
     , _Mapper(InOther._Mapper)
 #endif

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
@@ -108,6 +108,9 @@ auto
                 ECk_Net_EntityNetRole::Proxy
             });
 
+        NewEntity._ReplicationDriver = this;
+        NewEntity.Add<TWeakObjectPtr<UCk_Ecs_ReplicatedObject_UE>>(this);
+
         ConstructionScript->GetDefaultObject<UCk_Entity_ConstructionScript_PDA>()->Construct(
             NewEntity, ConstructionInfo.Get_OptionalParams());
 
@@ -152,6 +155,9 @@ auto
                 ECk_Net_NetModeType::Client,
                 ReplicatedActor->GetLocalRole() == ROLE_AutonomousProxy ? ECk_Net_EntityNetRole::Authority : ECk_Net_EntityNetRole::Proxy
             });
+
+        InEntity._ReplicationDriver = this;
+        InEntity.Add<TWeakObjectPtr<UCk_Ecs_ReplicatedObject_UE>>(this);
     });
 
     // TODO: we need the transform

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
@@ -18,6 +18,7 @@ auto
     if (AddedOrNot != ECk_AddedOrNot::NotAdded)
     {
         InHandle._ReplicationDriver = InHandle.Get<TObjectPtr<UCk_Fragment_EntityReplicationDriver_Rep>>();
+        InHandle.Add<TWeakObjectPtr<UCk_Ecs_ReplicatedObject_UE>>(InHandle.Get<TObjectPtr<UCk_Fragment_EntityReplicationDriver_Rep>>());
     }
     return AddedOrNot;
 }


### PR DESCRIPTION
…nullified

- on the Client, the ReplicationDriver is now setting the pointer directly
- the pointer may be nullified when reconstructing the Handle from an Entity and Registry
- to circumvent the above, we now store the pointer in a Fragment and the NetSerialize gets the ReplicationDriver pointer from the Fragment