### PR TITLE
fix: fixed issue where 'real' types (float, double) would appear as i…

### DIFF
--- a/Source/CkDataViewer/Public/DataViewer/CkDataViewerAsset.cpp
+++ b/Source/CkDataViewer/Public/DataViewer/CkDataViewerAsset.cpp
@@ -219,11 +219,13 @@ auto
     }
     else if (InProperty->IsA(FFloatProperty::StaticClass()))
     {
-        PinType.PinCategory = UEdGraphSchema_K2::PC_Float;
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
+        PinType.PinSubCategory = UEdGraphSchema_K2::PC_Float;
     }
     else if (InProperty->IsA(FDoubleProperty::StaticClass()))
     {
-        PinType.PinCategory = UEdGraphSchema_K2::PC_Double;
+        PinType.PinCategory = UEdGraphSchema_K2::PC_Real;
+        PinType.PinSubCategory = UEdGraphSchema_K2::PC_Double;
     }
     else if (InProperty->IsA(FStrProperty::StaticClass()))
     {


### PR DESCRIPTION
…ntegers

notes: this is because Unreal treats float/double as 'real' types for the pin categroy and requires the actual type (float or double) to be a subcategory type. This is different than all the other basic types for some reason.