### PR TITLE
fix: it is now expected behavior to encounter a Marker begin overlap …

### DIFF
--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
@@ -233,7 +233,7 @@ namespace ck
         const auto& SensorName           = InRequest.Get_SensorDetails().Get_SensorName();
         const auto& SensorFilteringInfo  = InParamsComp.Get_Params().Get_FilteringParams().Get_MarkerNames();
 
-        CK_ENSURE_IF_NOT(ck::IsValid(OverlappedMarkerEntity),
+        CK_ENSURE_IF_NOT(ck::IsValid(OverlappedMarkerEntity, ck::IsValid_Policy_IncludePendingKill{}),
             TEXT("Sensor [Name: {} | Entity: {}] received BeginOverlap with Marker [{}] that has an INVALID Entity"),
             SensorName,
             InSensorEntity,
@@ -249,13 +249,17 @@ namespace ck
         const auto& OverlappedMarkerEnableDisable = UCk_Utils_Marker_UE::
             Get_EnableDisable(OverlappedMarkerEntity);
 
-        CK_ENSURE_IF_NOT(OverlappedMarkerEnableDisable == ECk_EnableDisable::Enable,
-            TEXT("Sensor [Name: {} | Entity: {}] received BeginOverlap with Marker [Name: {} | Entity: {}] that is DISABLED"),
-            SensorName,
-            InSensorEntity,
-            OverlappedMarkerName,
-            OverlappedMarkerEntity)
-        { return; }
+        if (const auto IsMarkerEntity_Not_PendingKill = ck::IsValid(OverlappedMarkerEntity);
+            IsMarkerEntity_Not_PendingKill)
+        {
+            CK_ENSURE_IF_NOT(OverlappedMarkerEnableDisable == ECk_EnableDisable::Enable,
+                TEXT("Sensor [Name: {} | Entity: {}] received BeginOverlap with Marker [Name: {} | Entity: {}] that is DISABLED"),
+                SensorName,
+                InSensorEntity,
+                OverlappedMarkerName,
+                OverlappedMarkerEntity)
+            { return; }
+        }
 
         overlap_body::VeryVerbose
         (


### PR DESCRIPTION
commit 99518ed86113878bac3e4cee2b48b49de4c86c2a (HEAD -> bugfix/sensor-marker-begin-overlap-on-destroyed-entity, origin/bugfix/sensor-marker-begin-overlap-on-destroyed-entity)
Author: Sulfur-CK <sulfur@chainkemists.com>
Date:   Thu Apr 18 19:45:11 2024 -0700

    fix: it is now expected behavior to encounter a Marker begin overlap where the Marker Entity's destruction has been Initiated or Confirmed

    notes: it is possible that an Actor is destroyed and immediately after, in the same frame, begin and end overlaps are fired by Unreal. These overlaps are now processed correctly by the receiving Sensor (with a valid Entity) so that the loop is fully completed and no overlaps go undetected. This also fixes the ensure that fires when a BeginOverlap is fired with a Marker that is disabled, since we now only fire that Ensure if the Marker Entity is NOT pending destruction. Because if the Marker Entity _is_ pending destruction, then the teardown of the Marker was already invoked, and the Marker was disabled during that Teardown processor. However, begin/end overlaps may still have been called.