### PR TITLE
feat: added IsNearlyEqual for all types to facilitate generic code

### DIFF
--- a/Source/CkCore/Public/CkCore/Math/Arithmetic/CkArithmetic_Utils.cpp
+++ b/Source/CkCore/Public/CkCore/Math/Arithmetic/CkArithmetic_Utils.cpp
@@ -139,6 +139,58 @@ auto
     return Offset_WithWrap(InToDecrement, InOffset, InRange);
 }
 
+auto
+    UCk_Utils_Arithmetic_UE::
+    Get_IsNearlyEqual(
+        uint8 A,
+        uint8 B)
+    -> bool
+{
+    return A == B;
+}
+
+auto
+    UCk_Utils_Arithmetic_UE::
+    Get_IsNearlyEqual(
+        int32 A,
+        int32 B)
+    -> bool
+{
+    return A == B;
+}
+
+auto
+    UCk_Utils_Arithmetic_UE::
+    Get_IsNearlyEqual(
+        float A,
+        float B)
+    -> bool
+{
+    return FMath::IsNearlyEqual(A, B);
+}
+
+auto
+    UCk_Utils_Arithmetic_UE::
+    Get_IsNearlyEqual(
+        double A,
+        double B)
+    -> bool
+{
+    return FMath::IsNearlyEqual(A, B);
+}
+
+auto
+    UCk_Utils_Arithmetic_UE::
+    Get_IsNearlyEqual(
+        const FVector& A,
+        const FVector& B)
+    -> bool
+{
+    return Get_IsNearlyEqual(A.X, B.X) &&
+        Get_IsNearlyEqual(A.Y, B.Y) &&
+        Get_IsNearlyEqual(A.Z, B.Z);
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace ck

--- a/Source/CkCore/Public/CkCore/Math/Arithmetic/CkArithmetic_Utils.h
+++ b/Source/CkCore/Public/CkCore/Math/Arithmetic/CkArithmetic_Utils.h
@@ -99,6 +99,22 @@ public:
         int32 InToDecrement,
         int32 InOffset,
         const FCk_IntRange& InRange);
+
+public:
+    static auto
+    Get_IsNearlyEqual(uint8 A, uint8 B) -> bool;
+
+    static auto
+    Get_IsNearlyEqual(int32 A, int32 B) -> bool;
+
+    static auto
+    Get_IsNearlyEqual(float A, float B) -> bool;
+
+    static auto
+    Get_IsNearlyEqual(double A, double B) -> bool;
+
+    static auto
+    Get_IsNearlyEqual(const FVector& A, const FVector& B) -> bool;
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
notes: in generic code, we want to check equality but we may not know whether we are working with int32 or float or byte. These functions facilitate writing IsNearlyEqual for all such types