### PR TITLE
chore: Removed Record_ForEach_Policy param in the Record functions as…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
@@ -245,12 +245,7 @@ auto
         const TFunction<void(FCk_Handle_Ability)>& InFunc)
     -> void
 {
-    RecordOfAbilities_Utils::ForEach_ValidEntry
-    (
-        InAbilityOwnerEntity,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfAbilities_Utils::ForEach_ValidEntry(InAbilityOwnerEntity, InFunc);
 }
 
 auto
@@ -298,13 +293,7 @@ auto
         const TFunction<bool(FCk_Handle_Ability)>& InPredicate)
     -> void
 {
-    RecordOfAbilities_Utils::ForEach_ValidEntry_If
-    (
-        InAbilityOwnerEntity,
-        InFunc,
-        InPredicate,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfAbilities_Utils::ForEach_ValidEntry_If(InAbilityOwnerEntity, InFunc, InPredicate);
 }
 
 auto
@@ -503,7 +492,7 @@ auto
         const FCk_Delegate_AbilityOwner_OnAbilityRevokedOrNot& InDelegate)
     -> FCk_Handle_AbilityOwner
 {
-    CK_SIGNAL_BIND_REQUEST_FULFILLED(ck::UUtils_Signal_AbilityOwner_OnAbilityRevokedOrNot, 
+    CK_SIGNAL_BIND_REQUEST_FULFILLED(ck::UUtils_Signal_AbilityOwner_OnAbilityRevokedOrNot,
         InRequest.PopulateRequestHandle(InAbilityOwnerHandle), InDelegate);
 
     Request_RevokeAbility(InAbilityOwnerHandle, InRequest, InDelegate);
@@ -535,7 +524,7 @@ auto
         const FCk_Delegate_AbilityOwner_OnAbilityActivatedOrNot& InDelegate)
     -> FCk_Handle_AbilityOwner
 {
-    CK_SIGNAL_BIND_REQUEST_FULFILLED(ck::UUtils_Signal_AbilityOwner_OnAbilityActivatedOrNot, 
+    CK_SIGNAL_BIND_REQUEST_FULFILLED(ck::UUtils_Signal_AbilityOwner_OnAbilityActivatedOrNot,
         InRequest.PopulateRequestHandle(InAbilityOwnerHandle), InDelegate);
 
     InAbilityOwnerHandle.AddOrGet<ck::FFragment_AbilityOwner_Requests>()._Requests.Emplace(InRequest);
@@ -550,7 +539,7 @@ auto
         const FCk_Delegate_AbilityOwner_OnAbilityDeactivatedOrNot& InDelegate)
     -> FCk_Handle_AbilityOwner
 {
-    CK_SIGNAL_BIND_REQUEST_FULFILLED(ck::UUtils_Signal_AbilityOwner_OnAbilityDeactivatedOrNot, 
+    CK_SIGNAL_BIND_REQUEST_FULFILLED(ck::UUtils_Signal_AbilityOwner_OnAbilityDeactivatedOrNot,
         InRequest.PopulateRequestHandle(InAbilityOwnerHandle), InDelegate);
 
     InAbilityOwnerHandle.AddOrGet<ck::FFragment_AbilityOwner_Requests>()._Requests.Emplace(InRequest);

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
@@ -145,12 +145,7 @@ auto
         const TFunction<void(FCk_Handle_ByteAttribute)>& InFunc)
     -> void
 {
-    RecordOfByteAttributes_Utils::ForEach_ValidEntry
-    (
-        InAttributeOwner,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfByteAttributes_Utils::ForEach_ValidEntry(InAttributeOwner, InFunc);
 }
 
 auto
@@ -198,13 +193,7 @@ auto
         const TFunction<bool(FCk_Handle_ByteAttribute)>& InPredicate)
     -> void
 {
-    RecordOfByteAttributes_Utils::ForEach_ValidEntry_If
-    (
-        InAttributeOwner,
-        InFunc,
-        InPredicate,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfByteAttributes_Utils::ForEach_ValidEntry_If(InAttributeOwner, InFunc, InPredicate);
 }
 
 auto
@@ -771,32 +760,17 @@ auto
     {
         case ECk_MinMaxCurrent::Current:
         {
-            RecordOfByteAttributeModifiers_Utils_Current::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfByteAttributeModifiers_Utils_Current::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
         case ECk_MinMaxCurrent::Min:
         {
-            RecordOfByteAttributeModifiers_Utils_Min::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfByteAttributeModifiers_Utils_Min::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
         case ECk_MinMaxCurrent::Max:
         {
-            RecordOfByteAttributeModifiers_Utils_Max::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfByteAttributeModifiers_Utils_Max::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
     }
@@ -854,35 +828,17 @@ auto
     {
         case ECk_MinMaxCurrent::Current:
         {
-            RecordOfByteAttributeModifiers_Utils_Current::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfByteAttributeModifiers_Utils_Current::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
         case ECk_MinMaxCurrent::Min:
         {
-            RecordOfByteAttributeModifiers_Utils_Min::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfByteAttributeModifiers_Utils_Min::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
         case ECk_MinMaxCurrent::Max:
         {
-            RecordOfByteAttributeModifiers_Utils_Max::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfByteAttributeModifiers_Utils_Max::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
     }

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -163,8 +163,7 @@ namespace ck::detail
                 { return; }
 
                 TUtils_AttributeModifier<AttributeModifierFragmentType>::Request_ComputeResult(InAttributeModifier);
-            },
-            ECk_Record_ForEach_Policy::IgnoreRecordMissing
+            }
         );
 
         TUtils_Attribute<AttributeFragmentType>::Request_FireSignals(InHandle);

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.cpp
@@ -146,12 +146,7 @@ auto
         const TFunction<void(FCk_Handle_FloatAttribute)>& InFunc)
     -> void
 {
-    RecordOfFloatAttributes_Utils::ForEach_ValidEntry
-    (
-        InAttributeOwner,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfFloatAttributes_Utils::ForEach_ValidEntry(InAttributeOwner, InFunc);
 }
 
 auto
@@ -199,13 +194,7 @@ auto
         const TFunction<bool(FCk_Handle_FloatAttribute)>& InPredicate)
     -> void
 {
-    RecordOfFloatAttributes_Utils::ForEach_ValidEntry_If
-    (
-        InAttributeOwner,
-        InFunc,
-        InPredicate,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfFloatAttributes_Utils::ForEach_ValidEntry_If(InAttributeOwner, InFunc, InPredicate);
 }
 
 auto
@@ -772,32 +761,17 @@ auto
     {
         case ECk_MinMaxCurrent::Current:
         {
-            RecordOfFloatAttributeModifiers_Utils_Current::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfFloatAttributeModifiers_Utils_Current::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
         case ECk_MinMaxCurrent::Min:
         {
-            RecordOfFloatAttributeModifiers_Utils_Min::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfFloatAttributeModifiers_Utils_Min::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
         case ECk_MinMaxCurrent::Max:
         {
-            RecordOfFloatAttributeModifiers_Utils_Max::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfFloatAttributeModifiers_Utils_Max::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
     }
@@ -855,35 +829,17 @@ auto
     {
         case ECk_MinMaxCurrent::Current:
         {
-            RecordOfFloatAttributeModifiers_Utils_Current::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfFloatAttributeModifiers_Utils_Current::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
         case ECk_MinMaxCurrent::Min:
         {
-            RecordOfFloatAttributeModifiers_Utils_Min::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfFloatAttributeModifiers_Utils_Min::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
         case ECk_MinMaxCurrent::Max:
         {
-            RecordOfFloatAttributeModifiers_Utils_Max::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfFloatAttributeModifiers_Utils_Max::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
     }

--- a/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Utils.cpp
@@ -145,12 +145,7 @@ auto
         const TFunction<void(FCk_Handle_VectorAttribute)>& InFunc)
     -> void
 {
-    RecordOfVectorAttributes_Utils::ForEach_ValidEntry
-    (
-        InAttributeOwner,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfVectorAttributes_Utils::ForEach_ValidEntry(InAttributeOwner, InFunc);
 }
 
 auto
@@ -198,13 +193,7 @@ auto
         const TFunction<bool(FCk_Handle_VectorAttribute)>& InPredicate)
     -> void
 {
-    RecordOfVectorAttributes_Utils::ForEach_ValidEntry_If
-    (
-        InAttributeOwner,
-        InFunc,
-        InPredicate,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfVectorAttributes_Utils::ForEach_ValidEntry_If(InAttributeOwner, InFunc, InPredicate);
 }
 
 auto
@@ -771,32 +760,17 @@ auto
     {
         case ECk_MinMaxCurrent::Current:
         {
-            RecordOfVectorAttributeModifiers_Utils_Current::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfVectorAttributeModifiers_Utils_Current::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
         case ECk_MinMaxCurrent::Min:
         {
-            RecordOfVectorAttributeModifiers_Utils_Min::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfVectorAttributeModifiers_Utils_Min::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
         case ECk_MinMaxCurrent::Max:
         {
-            RecordOfVectorAttributeModifiers_Utils_Max::ForEach_ValidEntry
-            (
-                InAttribute,
-                InFunc,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfVectorAttributeModifiers_Utils_Max::ForEach_ValidEntry(InAttribute, InFunc);
             break;
         }
     }
@@ -854,35 +828,17 @@ auto
     {
         case ECk_MinMaxCurrent::Current:
         {
-            RecordOfVectorAttributeModifiers_Utils_Current::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfVectorAttributeModifiers_Utils_Current::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
         case ECk_MinMaxCurrent::Min:
         {
-            RecordOfVectorAttributeModifiers_Utils_Min::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfVectorAttributeModifiers_Utils_Min::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
         case ECk_MinMaxCurrent::Max:
         {
-            RecordOfVectorAttributeModifiers_Utils_Max::ForEach_ValidEntry_If
-            (
-                InAttribute,
-                InFunc,
-                InPredicate,
-                ECk_Record_ForEach_Policy::IgnoreRecordMissing
-            );
+            RecordOfVectorAttributeModifiers_Utils_Max::ForEach_ValidEntry_If(InAttribute, InFunc, InPredicate);
             break;
         }
     }

--- a/Source/CkCamera/Public/CkCamera/CameraShake/CkCameraShake_Utils.cpp
+++ b/Source/CkCamera/Public/CkCamera/CameraShake/CkCameraShake_Utils.cpp
@@ -92,12 +92,7 @@ auto
         const TFunction<void(FCk_Handle_CameraShake)>& InFunc)
     -> void
 {
-    RecordOfCameraShakes_Utils::ForEach_ValidEntry
-    (
-        InCameraShakeOwnerEntity,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfCameraShakes_Utils::ForEach_ValidEntry(InCameraShakeOwnerEntity, InFunc);
 }
 
 auto

--- a/Source/CkEntityExtension/Public/CkEntityExtension/CkEntityExtension_Utils.cpp
+++ b/Source/CkEntityExtension/Public/CkEntityExtension/CkEntityExtension_Utils.cpp
@@ -8,8 +8,8 @@
 auto
     UCk_Utils_EntityExtension_UE::
     Add(
-        FCk_Handle      InExtensionOwner,
-        FCk_Handle      InEntityToAddAsExtension,
+        FCk_Handle& InExtensionOwner,
+        FCk_Handle& InEntityToAddAsExtension,
         ECk_Replication InReplicates)
     -> FCk_Handle_EntityExtension
 {
@@ -41,8 +41,8 @@ auto
 auto
     UCk_Utils_EntityExtension_UE::
     ForEach_EntityExtension(
-        FCk_Handle                 InEntityExtensionOwner,
-        const FInstancedStruct&    InOptionalPayload,
+        FCk_Handle& InEntityExtensionOwner,
+        const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate)
     -> TArray<FCk_Handle_EntityExtension>
 {
@@ -63,16 +63,11 @@ auto
 auto
     UCk_Utils_EntityExtension_UE::
     ForEach_EntityExtension(
-        FCk_Handle InEntityExtensionOwner,
+        FCk_Handle& InEntityExtensionOwner,
         const TFunction<void(FCk_Handle_EntityExtension)>& InFunc)
     -> void
 {
-    RecordOfEntityExtensions_Utils::ForEach_ValidEntry
-    (
-        InEntityExtensionOwner,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfEntityExtensions_Utils::ForEach_ValidEntry(InEntityExtensionOwner, InFunc);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEntityExtension/Public/CkEntityExtension/CkEntityExtension_Utils.h
+++ b/Source/CkEntityExtension/Public/CkEntityExtension/CkEntityExtension_Utils.h
@@ -33,8 +33,9 @@ public:
               DisplayName="[Ck][EntityExtension] Add Entity As Extension")
     static FCk_Handle_EntityExtension
     Add(
-        UPARAM(ref) FCk_Handle InExtensionOwner,
-        UPARAM(ref) FCk_Handle InEntityToAddAsExtension, ECk_Replication InReplicates = ECk_Replication::Replicates);
+        UPARAM(ref) FCk_Handle& InExtensionOwner,
+        UPARAM(ref) FCk_Handle& InEntityToAddAsExtension,
+        ECk_Replication InReplicates = ECk_Replication::Replicates);
 
 public:
     // Has Feature
@@ -75,12 +76,12 @@ public:
               meta=(AutoCreateRefTerm="InDelegate, InOptionalPayload"))
     static TArray<FCk_Handle_EntityExtension>
     ForEach_EntityExtension(
-        FCk_Handle InEntityExtensionOwner,
+        UPARAM(ref) FCk_Handle& InEntityExtensionOwner,
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate);
     static auto
     ForEach_EntityExtension(
-        FCk_Handle InEntityExtensionOwner,
+        FCk_Handle& InEntityExtensionOwner,
         const TFunction<void(FCk_Handle_EntityExtension)>& InFunc) -> void;
 
 };

--- a/Source/CkFx/Public/Sfx/CkSfx_Utils.cpp
+++ b/Source/CkFx/Public/Sfx/CkSfx_Utils.cpp
@@ -104,12 +104,7 @@ auto
         const TFunction<void(FCk_Handle_Sfx)>& InFunc)
     -> void
 {
-    RecordOfSfx_Utils::ForEach_ValidEntry
-    (
-        InSfxOwnerEntity,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfSfx_Utils::ForEach_ValidEntry(InSfxOwnerEntity, InFunc);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkFx/Public/Vfx/CkVfx_Utils.cpp
+++ b/Source/CkFx/Public/Vfx/CkVfx_Utils.cpp
@@ -116,12 +116,7 @@ auto
         const TFunction<void(FCk_Handle_Vfx)>& InFunc)
     -> void
 {
-    RecordOfVfx_Utils::ForEach_ValidEntry
-    (
-        InVfxOwnerEntity,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfVfx_Utils::ForEach_ValidEntry(InVfxOwnerEntity, InFunc);
 }
 
 auto

--- a/Source/CkRecord/Public/CkRecord/Record/CkRecord_Fragment_Data.h
+++ b/Source/CkRecord/Public/CkRecord/Record/CkRecord_Fragment_Data.h
@@ -28,17 +28,6 @@ CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_FragmentQuery_Policy);
 // --------------------------------------------------------------------------------------------------------------------
 
 UENUM(BlueprintType)
-enum class ECk_Record_ForEach_Policy : uint8
-{
-    EnsureRecordExists,
-    IgnoreRecordMissing
-};
-
-CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_Record_ForEach_Policy);
-
-// --------------------------------------------------------------------------------------------------------------------
-
-UENUM(BlueprintType)
 enum class ECk_Record_ForEachIterationResult : uint8
 {
     Continue,

--- a/Source/CkRecord/Public/CkRecord/Record/CkRecord_Utils.h
+++ b/Source/CkRecord/Public/CkRecord/Record/CkRecord_Utils.h
@@ -117,31 +117,27 @@ namespace ck
         static auto
         ForEach_ValidEntry(
             FCk_Handle& InHandle,
-            T_Func InFunc,
-            ECk_Record_ForEach_Policy InPolicy = ECk_Record_ForEach_Policy::EnsureRecordExists) -> void;
+            T_Func InFunc) -> void;
 
         template <typename T_Func>
         static auto
         ForEach_ValidEntry(
             const FCk_Handle& InHandle,
-            T_Func InFunc,
-            ECk_Record_ForEach_Policy InPolicy = ECk_Record_ForEach_Policy::EnsureRecordExists) -> void;
+            T_Func InFunc) -> void;
 
         template <typename T_Unary, typename T_Predicate>
         static auto
         ForEach_ValidEntry_If(
             FCk_Handle& InRecordHandle,
             T_Unary InFunc,
-            T_Predicate InPredicate,
-            ECk_Record_ForEach_Policy InPolicy = ECk_Record_ForEach_Policy::EnsureRecordExists) -> void;
+            T_Predicate InPredicate) -> void;
 
         template <typename T_Unary, typename T_Predicate>
         static auto
         ForEach_ValidEntry_If(
             const FCk_Handle& InRecordHandle,
             T_Unary InFunc,
-            T_Predicate InPredicate,
-            ECk_Record_ForEach_Policy InPolicy = ECk_Record_ForEach_Policy::EnsureRecordExists) -> void;
+            T_Predicate InPredicate) -> void;
 
     protected:
         template <typename T_ValidationPolicy, typename T_Func>
@@ -438,8 +434,7 @@ namespace ck
         TUtils_RecordOfEntities<T_DerivedRecord>::
         ForEach_ValidEntry(
             FCk_Handle& InHandle,
-            T_Func InFunc,
-            ECk_Record_ForEach_Policy InPolicy)
+            T_Func InFunc)
         -> void
     {
         DoForEach_Entry<IsValid_Policy_Default>(InHandle, InFunc);
@@ -457,8 +452,7 @@ namespace ck
         TUtils_RecordOfEntities<T_DerivedRecord>::
         ForEach_ValidEntry(
             const FCk_Handle& InHandle,
-            T_Func InFunc,
-            ECk_Record_ForEach_Policy InPolicy)
+            T_Func InFunc)
         -> void
     {
         DoForEach_Entry<IsValid_Policy_Default>(InHandle, InFunc);
@@ -477,8 +471,7 @@ namespace ck
         ForEach_ValidEntry_If(
             FCk_Handle& InRecordHandle,
             T_Unary InFunc,
-            T_Predicate InPredicate,
-            ECk_Record_ForEach_Policy InPolicy)
+            T_Predicate InPredicate)
         -> void
     {
         DoForEach_Entry_If<IsValid_Policy_Default>(InRecordHandle, InFunc, InPredicate);
@@ -497,8 +490,7 @@ namespace ck
         ForEach_ValidEntry_If(
             const FCk_Handle& InRecordHandle,
             T_Unary InFunc,
-            T_Predicate InPredicate,
-            ECk_Record_ForEach_Policy InPolicy)
+            T_Predicate InPredicate)
         -> void
     {
         DoForEach_Entry_If<IsValid_Policy_Default>(InRecordHandle, InFunc, InPredicate);

--- a/Source/CkTargeting/Public/Targetable/CkTargetable_Utils.cpp
+++ b/Source/CkTargeting/Public/Targetable/CkTargetable_Utils.cpp
@@ -157,12 +157,7 @@ auto
         const TFunction<void(FCk_Handle_Targetable)>& InFunc)
     -> void
 {
-    RecordOfTargetables_Utils::ForEach_ValidEntry
-    (
-        InTargetableOwnerEntity,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfTargetables_Utils::ForEach_ValidEntry(InTargetableOwnerEntity, InFunc);
 }
 
 auto

--- a/Source/CkTargeting/Public/Targeter/CkTargeter_Utils.cpp
+++ b/Source/CkTargeting/Public/Targeter/CkTargeter_Utils.cpp
@@ -176,12 +176,7 @@ auto
         const TFunction<void(FCk_Handle_Targeter)>& InFunc)
     -> void
 {
-    RecordOfTargeters_Utils::ForEach_ValidEntry
-    (
-        InTargeterOwnerEntity,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfTargeters_Utils::ForEach_ValidEntry(InTargeterOwnerEntity, InFunc);
 }
 
 auto

--- a/Source/CkTimer/Public/CkTimer/CkTimer_Utils.cpp
+++ b/Source/CkTimer/Public/CkTimer/CkTimer_Utils.cpp
@@ -179,12 +179,7 @@ auto
         const TFunction<void(FCk_Handle_Timer)>& InFunc)
     -> void
 {
-    RecordOfTimers_Utils::ForEach_ValidEntry
-    (
-        InTimerOwnerEntity,
-        InFunc,
-        ECk_Record_ForEach_Policy::IgnoreRecordMissing
-    );
+    RecordOfTimers_Utils::ForEach_ValidEntry(InTimerOwnerEntity, InFunc);
 }
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
… it was deprecated a while ago and was not used.

The various record functions were updated to NOT ensure if the record is missing from the entity being passed it (by design).

Because of this, the Policy parameter was redundant and needed to be removed since then