### PR TITLE
fix: fixed issue where Substep could fire multiple other steps even i…

### DIFF
--- a/Source/CkSubstep/Public/CkSubstep/CkSubstep_Processor.cpp
+++ b/Source/CkSubstep/Public/CkSubstep/CkSubstep_Processor.cpp
@@ -38,6 +38,9 @@ namespace ck
             ++StepNumber;
             AdjustedTickRate -= TickRate;
             UUtils_Signal_OnSubstepUpdate::Broadcast(InHandle, MakePayload(InHandle, TickRate, StepNumber, InDeltaT));
+
+            if (NOT InHandle.Has<FTag_Substep_Update>())
+            { break; }
         }
 
         InCurrent._DeltaOverflowFromLastFrame = AdjustedTickRate;


### PR DESCRIPTION
…f a Request to pause was sent

notes: it's possible that when a Substep broadcasts a step, the user logic in that Step attempts to pause/reset the Substep. We now watch for that while we are processing the steps.