### PR TITLE
Bugfix/data viewer fixes

### DIFF
--- a/Source/CkDataViewer/Public/DataViewer/CkDataViewerAsset.cpp
+++ b/Source/CkDataViewer/Public/DataViewer/CkDataViewerAsset.cpp
@@ -48,6 +48,9 @@ auto
     const auto& TimerManager = GEditor->GetTimerManager();
     TimerManager->SetTimerForNextTick([this]()
     {
+        if (ck::Is_NOT_Valid(this))
+        { return; }
+
         Reload();
     });
 }
@@ -249,8 +252,8 @@ auto
 
         if (auto StructProp = CastField<FStructProperty>(InProperty))
         {
-        PinType.PinSubCategoryObject = StructProp->Struct;
-    }
+            PinType.PinSubCategoryObject = StructProp->Struct;
+        }
         else if (auto ObjectProp = CastField<FObjectProperty>(InProperty))
         {
             PinType.PinSubCategoryObject = ObjectProp->PropertyClass;


### PR DESCRIPTION
commit 264c960c505375ced10065753915855d154b4fe7 (HEAD -> bugfix/data-viewer-fixes, origin/bugfix/data-viewer-fixes)
Author: Sulfur-CK <sulfur@chainkemists.com>
Date:   Mon Jun 10 15:07:07 2024 -0700

    fix: blind-fix for a rare crash that happens when the DataViewer asset is not loaded and is deleted without loading it first

commit 6780983f109eac92b38c37b601c12db415333ab5
Author: Sulfur-CK <sulfur@chainkemists.com>
Date:   Mon Jun 10 15:06:29 2024 -0700

    feat: DataViewer properties now categorize the variables as they were in the original objects - DisplayThumbnail meta is now copied over to the DataViewer variable

commit 3d1f0452195b963d1bd263630f08962d4d1dc87e
Author: Sulfur-CK <sulfur@chainkemists.com>
Date:   Mon Jun 10 15:05:30 2024 -0700

    fix: fixed crash where we were assuming an incoming property of type FObjectPropertyBase is a struct when it could be a UObject too