### PR TITLE
feat: Improve multiply and divide operator overrides on CkTime

### DIFF
--- a/Source/CkCore/Public/CkCore/Time/CkTime.cpp
+++ b/Source/CkCore/Public/CkCore/Time/CkTime.cpp
@@ -46,19 +46,55 @@ auto
 auto
     FCk_Time::
     operator*(
-        const ThisType& InOther) const
+        float InOther) const
     -> ThisType
 {
-    return ThisType{_Seconds * InOther._Seconds};
+    return ThisType{_Seconds * InOther};
+}
+
+auto
+    FCk_Time::
+    operator*(
+        int32 InOther) const
+    -> ThisType
+{
+    return ThisType{_Seconds * InOther};
 }
 
 auto
     FCk_Time::
     operator/(
         const ThisType& InOther) const
+    -> float
+{
+    if (CK_ENSURE(InOther.Get_Seconds() == 0.f,
+        TEXT("Division of Time [{}] by zero!"), *this))
+    { return 0; }
+    return _Seconds / InOther._Seconds;
+}
+
+auto
+    FCk_Time::
+    operator/(
+        float InOther) const
     -> ThisType
 {
-    return ThisType{_Seconds / InOther._Seconds};
+    if (CK_ENSURE(InOther == 0.f,
+        TEXT("Division of Time [{}] by zero!"), *this))
+    { return ThisType{0.f}; }
+    return ThisType{_Seconds / InOther};
+}
+
+auto
+    FCk_Time::
+    operator/(
+        int32 InOther) const
+    -> ThisType
+{
+    if (CK_ENSURE(InOther == 0,
+        TEXT("Division of Time [{}] by zero!"), *this))
+    { return ThisType{0.f}; }
+    return ThisType{_Seconds / InOther};
 }
 
 auto
@@ -229,7 +265,8 @@ auto
 
 auto
     FCk_Time_Unreal::
-    operator-(const ThisType& InOther) const
+    operator-(
+        const ThisType& InOther) const
     -> ThisType
 {
     const auto& IsSameWorldTimeType = Get_TimeType() == InOther.Get_TimeType();
@@ -247,7 +284,8 @@ auto
 
 auto
     FCk_Time_Unreal::
-    operator+(const ThisType& InOther) const
+    operator+(
+        const ThisType& InOther) const
     -> ThisType
 {
     const auto& IsSameWorldTimeType = Get_TimeType() == InOther.Get_TimeType();
@@ -265,26 +303,27 @@ auto
 
 auto
     FCk_Time_Unreal::
-    operator*(const ThisType& InOther) const
+    operator*(
+        float InOther) const
     -> ThisType
 {
-    const auto& IsSameWorldTimeType = Get_TimeType() == InOther.Get_TimeType();
-
-    CK_ENSURE
-    (
-        IsSameWorldTimeType,
-        TEXT("WorldTimeTypes [{}] and [{}] do not match"),
-        Get_TimeType(),
-        InOther.Get_TimeType()
-    );
-
-    return ThisType{ Get_Time() * InOther.Get_Time(), Get_TimeType() };
+    return ThisType{ Get_Time() * InOther, Get_TimeType() };
 }
 
 auto
     FCk_Time_Unreal::
-    operator/(const ThisType& InOther) const
+    operator*(
+        int32 InOther) const
     -> ThisType
+{
+    return ThisType{ Get_Time() * InOther, Get_TimeType() };
+}
+
+auto
+    FCk_Time_Unreal::
+    operator/(
+        const ThisType& InOther) const
+    -> float
 {
     const auto& IsSameWorldTimeType = Get_TimeType() == InOther.Get_TimeType();
 
@@ -296,7 +335,25 @@ auto
         InOther.Get_TimeType()
     );
 
-    return ThisType{ Get_Time() / InOther.Get_Time(), Get_TimeType() };
+    return Get_Time() / InOther.Get_Time();
+}
+
+auto
+    FCk_Time_Unreal::
+    operator/(
+        float InOther) const
+    -> ThisType
+{
+    return ThisType{ Get_Time() / InOther, Get_TimeType() };
+}
+
+auto
+    FCk_Time_Unreal::
+    operator/(
+        int32 InOther) const
+    -> ThisType
+{
+    return ThisType{ Get_Time() / InOther, Get_TimeType() };
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCore/Public/CkCore/Time/CkTime.h
+++ b/Source/CkCore/Public/CkCore/Time/CkTime.h
@@ -36,8 +36,11 @@ public:
 
     auto operator+(const ThisType& InOther) const -> ThisType;
     auto operator-(const ThisType& InOther) const -> ThisType;
-    auto operator*(const ThisType& InOther) const -> ThisType;
-    auto operator/(const ThisType& InOther) const -> ThisType;
+    auto operator*(float InOther) const -> ThisType;
+    auto operator*(int32 InOther) const -> ThisType;
+    auto operator/(const ThisType& InOther) const -> float;
+    auto operator/(float InOther) const -> ThisType;
+    auto operator/(int32 InOther) const -> ThisType;
     CK_DECL_AND_DEF_ADD_SUBTRACT_ASSIGNMENT_OPERATORS(ThisType);
 
 public:
@@ -133,8 +136,11 @@ public:
 
     auto operator-(const ThisType& InOther) const  -> ThisType;
     auto operator+(const ThisType& InOther) const  -> ThisType;
-    auto operator*(const ThisType& InOther) const  -> ThisType;
-    auto operator/(const ThisType& InOther) const  -> ThisType;
+    auto operator*(float InOther) const -> ThisType;
+    auto operator*(int32 InOther) const -> ThisType;
+    auto operator/(const ThisType& InOther) const -> float;
+    auto operator/(float InOther) const -> ThisType;
+    auto operator/(int32 InOther) const -> ThisType;
     CK_DECL_AND_DEF_ADD_SUBTRACT_ASSIGNMENT_OPERATORS(ThisType);
 
     auto operator==(const TimeType& InOther) const -> bool;

--- a/Source/CkCore/Public/CkCore/Time/CkTime_Utils.cpp
+++ b/Source/CkCore/Public/CkCore/Time/CkTime_Utils.cpp
@@ -198,6 +198,16 @@ auto
     Divide(
         const FCk_Time& InA,
         const FCk_Time& InB)
+    -> float
+{
+    return InA / InB;
+}
+
+auto
+    UCk_Utils_Time_UE::
+    Divide_TimeFloat(
+        const FCk_Time& InA,
+        float InB)
     -> FCk_Time
 {
     return InA / InB;
@@ -205,9 +215,29 @@ auto
 
 auto
     UCk_Utils_Time_UE::
-    Multiply(
+    Divide_TimeInt(
         const FCk_Time& InA,
-        const FCk_Time& InB)
+        int32 InB)
+    -> FCk_Time
+{
+    return InA / InB;
+}
+
+auto
+    UCk_Utils_Time_UE::
+    Multiply_TimeFloat(
+        const FCk_Time& InA,
+        float InB)
+    -> FCk_Time
+{
+    return InA * InB;
+}
+
+auto
+    UCk_Utils_Time_UE::
+    Multiply_TimeInt(
+        const FCk_Time& InA,
+        int32 InB)
     -> FCk_Time
 {
     return InA * InB;

--- a/Source/CkCore/Public/CkCore/Time/CkTime_Utils.h
+++ b/Source/CkCore/Public/CkCore/Time/CkTime_Utils.h
@@ -165,18 +165,45 @@ public:
               DisplayName = "[Ck] Time / Time",
               Category = "Ck|Utils|Time",
               meta = (CompactNodeTitle = "/", KeyWords = "divide"))
-    static FCk_Time
+    static float
     Divide(const FCk_Time& InA,
         const FCk_Time& InB);
 
-    UFUNCTION(BlueprintPure,
-              DisplayName = "[Ck] Time * Time",
-              Category = "Ck|Utils|Time",
-              meta = (CompactNodeTitle = "*", KeyWords = "multiply"))
-    static FCk_Time
-    Multiply(
-        const FCk_Time& InA,
-        const FCk_Time& InB);
+	UFUNCTION(BlueprintPure,
+	          DisplayName = "[Ck] Time / float",
+	          Category = "Ck|Utils|Time",
+	          meta = (CompactNodeTitle = "/", KeyWords = "divide"))
+	static FCk_Time
+	Divide_TimeFloat(
+		const FCk_Time& InA,
+		float InB);
+
+	UFUNCTION(BlueprintPure,
+	          DisplayName = "[Ck] Time / int",
+	          Category = "Ck|Utils|Time",
+	          meta = (CompactNodeTitle = "/", KeyWords = "divide"))
+	static FCk_Time
+		Divide_TimeInt(
+		const FCk_Time& InA,
+		int32 InB);
+	
+	UFUNCTION(BlueprintPure,
+			  DisplayName = "[Ck] Time * float",
+			  Category = "Ck|Utils|Time",
+			  meta = (CompactNodeTitle = "*", KeyWords = "multiply"))
+	static FCk_Time
+	Multiply_TimeFloat(
+		const FCk_Time& InA,
+		float InB);
+
+	UFUNCTION(BlueprintPure,
+		  DisplayName = "[Ck] Time * int",
+		  Category = "Ck|Utils|Time",
+		  meta = (CompactNodeTitle = "*", KeyWords = "multiply"))
+	static FCk_Time
+	Multiply_TimeInt(
+		const FCk_Time& InA,
+		int32 InB);
 
     UFUNCTION(BlueprintPure,
               DisplayName = "[Ck] Time == Time",

--- a/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Processor.cpp
+++ b/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Processor.cpp
@@ -446,7 +446,7 @@ namespace ck
             return;
         }
 
-        const auto Fraction =  FMath::Clamp((InDeltaT / SmoothTime).Get_Seconds(), 0.0f, 1.0f);
+        const auto Fraction =  FMath::Clamp(InDeltaT / SmoothTime, 0.0f, 1.0f);
         const auto GoalFraction = InGoal.Get_InterpolationOffset() * Fraction;
 
         UCk_Utils_Transform_UE::Request_SetLocation
@@ -490,7 +490,7 @@ namespace ck
             return;
         }
 
-        const auto Fraction =  FMath::Clamp((InDeltaT / SmoothTime).Get_Seconds(), 0.0f, 1.0f);
+        const auto Fraction =  FMath::Clamp(InDeltaT / SmoothTime, 0.0f, 1.0f);
         const auto GoalFraction = InGoal.Get_InterpolationOffset() * Fraction;
 
         UCk_Utils_Transform_UE::Request_SetRotation


### PR DESCRIPTION
Changed the CkTime multiply and divide to make sense for time quantities.
*  Add multiply and divide for time and int/float
*  Removed Time*Time since we don't have a unit that would make sense for the output of that
*  Changed Time/Time to return a float instead of time since it makes more sense