### PR TITLE
feat: Min/Max Clamp are now driven by the MayRequireClamping tag whic…

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
@@ -33,6 +33,7 @@ namespace ck
 namespace ck
 {
     CK_DEFINE_ECS_TAG(FTag_ReplicatedAttribute);
+    CK_DEFINE_ECS_TAG(FTag_MayRequireClamping);
 
     template <typename T_DerivedAttribute>
     class TUtils_Attribute;

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.h
@@ -87,6 +87,7 @@ namespace ck::detail
             TProcessor_Attribute_MinClamp<T_DerivedProcessor, T_DerivedAttributeCurrent, T_DerivedAttributeMin>,
             T_DerivedAttributeCurrent,
             T_DerivedAttributeMin,
+            FTag_MayRequireClamping,
             CK_IGNORE_PENDING_KILL>
     {
     public:
@@ -97,7 +98,7 @@ namespace ck::detail
         using AttributeFragmentType_Min     = T_DerivedAttributeMin;
         using AttributeDataType             = typename AttributeFragmentType_Current::AttributeDataType;
         using ThisType                      = TProcessor_Attribute_MinClamp<T_DerivedProcessor, AttributeFragmentType_Current, AttributeFragmentType_Min>;
-        using Super                         = TProcessor<ThisType, AttributeFragmentType_Current, MarkedDirtyBy, CK_IGNORE_PENDING_KILL>;
+        using Super                         = TProcessor<ThisType, AttributeFragmentType_Current, MarkedDirtyBy, FTag_MayRequireClamping, CK_IGNORE_PENDING_KILL>;
         using HandleType                    = typename Super::HandleType;
         using TimeType                      = typename Super::TimeType;
 
@@ -122,6 +123,7 @@ namespace ck::detail
             TProcessor_Attribute_MaxClamp<T_DerivedProcessor, T_DerivedAttributeCurrent, T_DerivedAttributeMax>,
             T_DerivedAttributeCurrent,
             T_DerivedAttributeMax,
+            FTag_MayRequireClamping,
             CK_IGNORE_PENDING_KILL>
     {
     public:
@@ -132,7 +134,7 @@ namespace ck::detail
         using AttributeFragmentType_Max     = T_DerivedAttributeMax;
         using AttributeDataType             = typename AttributeFragmentType_Current::AttributeDataType;
         using ThisType                      = TProcessor_Attribute_MaxClamp<T_DerivedProcessor, AttributeFragmentType_Current, AttributeFragmentType_Max>;
-        using Super                         = TProcessor<ThisType, AttributeFragmentType_Current, MarkedDirtyBy, CK_IGNORE_PENDING_KILL>;
+        using Super                         = TProcessor<ThisType, AttributeFragmentType_Current, MarkedDirtyBy, FTag_MayRequireClamping, CK_IGNORE_PENDING_KILL>;
         using HandleType                    = typename Super::HandleType;
         using TimeType                      = typename Super::TimeType;
 

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -221,6 +221,7 @@ namespace ck::detail
             }
         );
 
+        TUtils_Attribute<AttributeFragmentType>::Request_TryClamp(InHandle);
         TUtils_Attribute<AttributeFragmentType>::Request_FireSignals(InHandle);
         TUtils_Attribute<AttributeFragmentType>::Request_TryReplicateAttribute(InHandle);
     }
@@ -582,6 +583,8 @@ namespace ck
     {
         _MinClamp.Tick(InDeltaT);
         _MaxClamp.Tick(InDeltaT);
+
+        UCk_Utils_EntityLifetime_UE::Get_TransientEntity(_Registry).Clear<FTag_MayRequireClamping>();
     }
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
@@ -68,6 +68,10 @@ namespace ck
             HandleType& InHandle) -> void;
 
         static auto
+        Request_TryClamp(
+            HandleType& InHandle) -> void;
+
+        static auto
         Request_FireSignals(
             HandleType& InHandle) -> void;
 

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
@@ -83,6 +83,19 @@ namespace ck
     template <typename T_DerivedAttribute>
     auto
         TUtils_Attribute<T_DerivedAttribute>::
+        Request_TryClamp(
+            HandleType& InHandle)
+        -> void
+    {
+        if (NOT Ensure(InHandle))
+        { return; }
+
+        InHandle.AddOrGet<FTag_MayRequireClamping>();
+    }
+
+    template <typename T_DerivedAttribute>
+    auto
+        TUtils_Attribute<T_DerivedAttribute>::
         Request_FireSignals(
             HandleType& InHandle)
         -> void


### PR DESCRIPTION
…h is only added if a Tag requires recomputation

notes: this greatly reduces the cost of the processors since we have a lot of attributes at any given moment but only a few being updated