### PR TITLE
fix: fixed issue where the Toolbar widgets would not load on Editor s…

### DIFF
--- a/Source/CkEditorToolbar/CkEditorToolbar.Build.cs
+++ b/Source/CkEditorToolbar/CkEditorToolbar.Build.cs
@@ -36,9 +36,11 @@ public class CkEditorToolbar : CkModuleRules
             "UMG",
 
             "CkCore",
+            "CkEcs",
             "CkLog",
+			"CkResourceLoader",
             "CkSettings",
-            "CkUI",
+            "CkUI"
         });
     }
 }

--- a/Source/CkEditorToolbar/Public/CkEditorToolbar/Settings/CkEditorToolbar_Settings.h
+++ b/Source/CkEditorToolbar/Public/CkEditorToolbar/Settings/CkEditorToolbar_Settings.h
@@ -36,8 +36,8 @@ public:
     CK_GENERATED_BODY(FCk_EditorToolbar_ExtensionWidgets);
 
 private:
-    UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = true))
-    TArray<TSoftClassPtr<UEditorUtilityWidget>> _UtilityWidgets;
+    UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = true, MetaClass="EditorUtilityWidget"))
+    TArray<FSoftClassPath> _UtilityWidgets;
 
 public:
     CK_PROPERTY_GET(_UtilityWidgets);

--- a/Source/CkEditorToolbar/Public/CkEditorToolbar/Subsystem/CkEditorToolbar_Subsystem.h
+++ b/Source/CkEditorToolbar/Public/CkEditorToolbar/Subsystem/CkEditorToolbar_Subsystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkEcsWorld.h"
+
 #include "CkEditorToolbar/Settings/CkEditorToolbar_Settings.h"
 
 #include "CkCore/Macros/CkMacros.h"
@@ -64,6 +66,10 @@ private:
 
 private:
     static FName _ToolbarExtensionSectionName;
+
+private:
+    ck::FEcsWorld _World;
+    FCk_Handle _AssetLoaderEntity;
 
 private:
     UPROPERTY(Transient)


### PR DESCRIPTION
…tart

notes: this is because there is no guarantee that the Objects are loaded. Unfortunately, the SoftObjectPtr fails to load the object and we instead go through our ResourceLoader to resolve the object synchronously before attemping to create the toolbar widget.

notes: loading the object synchronously also means longer Editor load time. The logic here should be improved to instead load the widgets asynchronously and then create the objects only when async loading is completed.