### PR TITLE
fix: Aim doesn't consider targetables that don't have an attachment n…

### DIFF
--- a/Source/CkTargeting/Public/Targetable/CkTargetable_Fragment.h
+++ b/Source/CkTargeting/Public/Targetable/CkTargetable_Fragment.h
@@ -16,6 +16,7 @@ class UCk_Utils_Targetable_UE;
 namespace ck
 {
     CK_DEFINE_ECS_TAG(FTag_Targetable_NeedsSetup);
+    CK_DEFINE_ECS_TAG(FTag_Targetable_IsReady);
 
     // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkTargeting/Public/Targetable/CkTargetable_Fragment_Data.h
+++ b/Source/CkTargeting/Public/Targetable/CkTargetable_Fragment_Data.h
@@ -17,6 +17,18 @@ CK_DEFINE_CUSTOM_ISVALID_AND_FORMATTER_HANDLE_TYPESAFE(FCk_Handle_Targetable);
 
 // --------------------------------------------------------------------------------------------------------------------
 
+UENUM(BlueprintType)
+enum class ECk_Targetable_Status : uint8
+{
+    CanTarget,
+    CannotTarget,
+    NotYetReady
+};
+
+CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_Targetable_Status);
+
+// --------------------------------------------------------------------------------------------------------------------
+
 USTRUCT(BlueprintType)
 struct CKTARGETING_API FCk_Targetable_BasicInfo
 {

--- a/Source/CkTargeting/Public/Targetable/CkTargetable_Processor.cpp
+++ b/Source/CkTargeting/Public/Targetable/CkTargetable_Processor.cpp
@@ -98,6 +98,7 @@ namespace ck
                     SceneComp->AddLocalOffset(LocalOffset);
 
                     InHandle.Get<FFragment_Targetable_Current>()._AttachmentNode = SceneComp;
+                    InHandle.Add<FTag_Targetable_IsReady>();
                 }),
             {},
             {}

--- a/Source/CkTargeting/Public/Targeter/CkTargeter_Processor.cpp
+++ b/Source/CkTargeting/Public/Targeter/CkTargeter_Processor.cpp
@@ -96,7 +96,7 @@ namespace ck
             const auto Handle = ck::MakeHandle(InEntity, InHandle);
             const auto Targetable = UCk_Utils_Targetable_UE::Cast(Handle);
 
-            if (NOT UCk_Utils_Targeter_UE::Get_CanTarget(InHandle, Targetable))
+            if (UCk_Utils_Targeter_UE::Get_CanTarget(InHandle, Targetable) != ECk_Targetable_Status::CanTarget)
             { return; }
 
             ValidTargets.Add(FCk_Targetable_BasicInfo{Targetable, UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(Targetable)});

--- a/Source/CkTargeting/Public/Targeter/CkTargeter_Utils.cpp
+++ b/Source/CkTargeting/Public/Targeter/CkTargeter_Utils.cpp
@@ -102,16 +102,22 @@ auto
     Get_CanTarget(
         const FCk_Handle_Targeter& InTargeter,
         const FCk_Handle_Targetable& InTarget)
-    -> bool
+    -> ECk_Targetable_Status
 {
     if (UCk_Utils_Targetable_UE::Get_EnableDisable(InTarget) == ECk_EnableDisable::Disable)
-    { return false; }
+    { return ECk_Targetable_Status::CannotTarget; }
+
+    // Adding attachment node is deferred and may happen after setup is run, but we should not try to target this until attachment node has been added
+    if (NOT InTarget.Has<ck::FTag_Targetable_IsReady>())
+    { return ECk_Targetable_Status::NotYetReady; }
 
     const auto& TargetingQuery    =  InTargeter.Get<ck::FFragment_Targeter_Params>().Get_Params().Get_TargetingQuery();
     const auto& TargetabilityTags = UCk_Utils_Targetable_UE::Get_TargetabilityTags(InTarget);
     const auto& QueryResult       = TargetingQuery.Matches(TargetabilityTags);
 
-    return QueryResult;
+    return QueryResult ?
+        ECk_Targetable_Status::CanTarget :
+        ECk_Targetable_Status::CannotTarget;
 }
 
 auto

--- a/Source/CkTargeting/Public/Targeter/CkTargeter_Utils.h
+++ b/Source/CkTargeting/Public/Targeter/CkTargeter_Utils.h
@@ -125,7 +125,7 @@ public:
     UFUNCTION(BlueprintPure,
               Category = "Ck|Utils|Targeter",
               DisplayName="[Ck][Targeter] Get Can Target")
-    static bool
+    static ECk_Targetable_Status
     Get_CanTarget(
         const FCk_Handle_Targeter& InTargeter,
         const FCk_Handle_Targetable& InTarget);


### PR DESCRIPTION
…ode yet

*  Adding attachment node is asynchronous and may happen after setup is run, but we should not try to target this until attachment node has been added