### PR TITLE
feat: added LocalClientOnly and RemoteClientsOnly replication types

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Net/CkNet_Common.h
+++ b/Source/CkEcs/Public/CkEcs/Net/CkNet_Common.h
@@ -8,10 +8,18 @@
 UENUM(BlueprintType)
 enum class ECk_Net_ReplicationType : uint8
 {
-    LocalOnly,
-    LocalAndHost,
+    // Replicates on machine(s) that locally owns the object (NOTE: the Player is Local to BOTH Client and Server)
+    LocalOnly UMETA(DisplayName="Local Only (Has Authority)"),
+    // Replicates on machine(s) that locally owns the object AND the Host
+    LocalAndHost UMETA(DisplayName="Local (Has Authority) AND Host"),
+    // Replicates on the Host only
     HostOnly,
+    // Replicates on Clients only
     ClientsOnly,
+    // Replicates on Client ONLY IF the Client has authority
+    LocalClientOnly,
+    // Replicates on REMOTE Clients only
+    RemoteClientsOnly,
     All
 };
 

--- a/Source/CkNet/Public/CkNet/CkNet_Utils.cpp
+++ b/Source/CkNet/Public/CkNet/CkNet_Utils.cpp
@@ -270,6 +270,14 @@ auto
         {
             return Get_EntityNetMode(InEntity) == ECk_Net_NetModeType::Client;
         }
+        case ECk_Net_ReplicationType::LocalClientOnly:
+        {
+            return Get_HasAuthority(InEntity) && Get_IsEntityNetMode_Client(InEntity);
+        }
+        case ECk_Net_ReplicationType::RemoteClientsOnly:
+        {
+            return NOT Get_HasAuthority(InEntity) && Get_IsEntityNetMode_Client(InEntity);
+        }
         case ECk_Net_ReplicationType::All:
         {
             return true;
@@ -383,7 +391,21 @@ auto
         }
         case ECk_Net_ReplicationType::ClientsOnly:
         {
-            if (NetRole != ECk_Net_NetModeType::Host)
+            if (NetRole == ECk_Net_NetModeType::Client)
+            { return true; }
+
+            break;
+        }
+        case ECk_Net_ReplicationType::LocalClientOnly:
+        {
+            if (IsLocallyOwned && NetRole == ECk_Net_NetModeType::Client)
+            { return true; }
+
+            break;
+        }
+        case ECk_Net_ReplicationType::RemoteClientsOnly:
+        {
+            if (NOT IsLocallyOwned && NetRole == ECk_Net_NetModeType::Client)
             { return true; }
 
             break;


### PR DESCRIPTION
notes: because an Actor is always locally owned by the Server, LocalOnly and LocalAndHost are the same replication type. LocalOnly will be deprecated soon.