### PR TITLE
feat: Add a getter for all actors of the same team as a team entity

### DIFF
--- a/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Utils.cpp
+++ b/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Utils.cpp
@@ -263,6 +263,24 @@ auto
 
 auto
     UCk_Utils_Team_UE::
+    Get_ActorsOfSameTeam(
+        FCk_Handle_Team& InHandle)
+    -> TArray<AActor*>
+{
+    TArray<AActor*> SameTeamActors;
+    for (const auto& Entity : ForEachEntity_OnSameTeam(InHandle, Get_ID(InHandle), {}, {}))
+    {
+        const auto& EntityActor = UCk_Utils_OwningActor_UE::Get_EntityOwningActor(Entity);
+        if (ck::IsValid(EntityActor))
+        {
+            SameTeamActors.Add(EntityActor);
+        }
+    }
+    return SameTeamActors;
+}
+
+auto
+    UCk_Utils_Team_UE::
     BindTo_OnTeamChanged(
         FCk_Handle& InHandle,
         ECk_Signal_BindingPolicy InBindingPolicy,

--- a/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Utils.h
+++ b/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Utils.h
@@ -119,6 +119,13 @@ public:
         const FInstancedStruct& InOptionalPayload,
         const FCk_Lambda_InHandle& InDelegate);
 
+    UFUNCTION(BlueprintCallable,
+              Category = "|Ck|Utils|Relationship|Team",
+              DisplayName="[Ck][Team] Get Actors Of Same Team")
+    static TArray<AActor*>
+    Get_ActorsOfSameTeam(
+        UPARAM(ref) FCk_Handle_Team& InHandle);
+
 public:
     template <typename T_Func>
     static auto


### PR DESCRIPTION
*  This is more performant than the BPFL to get all teammates since it doesn't need to convert the array of entities to actors in BP