### PR TITLE
fix: fixed issue where Handle debugging would result in partially com…

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
@@ -205,7 +205,9 @@ auto
 }
 
 auto
-    FCk_Handle::operator->() const -> TOptional<FCk_Registry>
+    FCk_Handle::
+    operator->() const
+    -> TOptional<FCk_Registry>
 {
     return _Registry;
 }

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -955,11 +955,11 @@ auto
     auto FragmentInfo = DebugWrapperPtrType{};
     if constexpr (std::is_empty_v<T_Fragment>)
     {
-        FragmentInfo = MakeShared<TCk_DebugWrapper<T_Fragment>, ESPMode::NotThreadSafe>(nullptr);
+        FragmentInfo = std::make_shared<TCk_DebugWrapper<T_Fragment>>(nullptr);
     }
     else
     {
-        FragmentInfo = TSharedPtr<TCk_DebugWrapper<T_Fragment>, ESPMode::NotThreadSafe>
+        FragmentInfo = std::shared_ptr<TCk_DebugWrapper<T_Fragment>>
         { new TCk_DebugWrapper<T_Fragment>(&InHandle.Get<T_Fragment, ck::IsValid_Policy_IncludePendingKill>()) };
     }
 

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Debugging.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Debugging.h
@@ -54,7 +54,7 @@ public:
     // ReSharper disable once CppInconsistentNaming
     static constexpr auto in_place_delete = true;
 
-    using DebugWrapperPtrType = TSharedPtr<FCk_DebugWrapper, ESPMode::NotThreadSafe>;
+    using DebugWrapperPtrType = std::shared_ptr<FCk_DebugWrapper>;
 
 public:
     template <typename T_Fragment>


### PR DESCRIPTION
…pleted fragments

notes: this is because of the following error:

```
Error: The number of times a <DisplayString> or <ExpandedItem> element
is needed to visualize a single object exceeds the maximum supported
limit of 100. Please simplify your visualizations. If circular
references are expected, but the evaluation is slow, the recursion
limits can be changed at Tools -> Options -> Debugging -> C++ Expression
Evaluator
```

Further investigation revealed that the fault lies with `TSharedPtr` and the way Epic is handling its natvis logic. Switching to `std::shared_ptr` addressed the issue and now we have full natvis completion for Entities with many fragments.