### PR TITLE
feat: Box/Sphere/Capsule shape overlaps no longer tick

### DIFF
--- a/Source/CkOverlapBody/Public/CkOverlapBody/CkOverlapBody_Common.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/CkOverlapBody_Common.cpp
@@ -20,7 +20,8 @@ UCk_OverlapBody_ActorComponent_Box_UE::
     this->bAlwaysCreatePhysicsState = false;
     this->bWantsInitializeComponent = true;
 
-    DoSet_CanEverTick_ForCCD();
+    // Our Sensors do NOT yet have CCD support
+    // DoSet_CanEverTick_ForCCD();
 
     UCk_Utils_Physics_UE::Request_SetGenerateOverlapEvents(this, ECk_EnableDisable::Disable, this);
 }
@@ -42,7 +43,8 @@ UCk_OverlapBody_ActorComponent_Sphere_UE::
     this->bAlwaysCreatePhysicsState = false;
     this->bWantsInitializeComponent = true;
 
-    DoSet_CanEverTick_ForCCD();
+    // Our Sensors do NOT yet have CCD support
+    // DoSet_CanEverTick_ForCCD();
 
     UCk_Utils_Physics_UE::Request_SetGenerateOverlapEvents(this, ECk_EnableDisable::Disable, this);
 }
@@ -64,7 +66,8 @@ UCk_OverlapBody_ActorComponent_Capsule_UE::
     this->bAlwaysCreatePhysicsState = false;
     this->bWantsInitializeComponent = true;
 
-    DoSet_CanEverTick_ForCCD();
+    // Our Sensors do NOT yet have CCD support
+    // DoSet_CanEverTick_ForCCD();
 
     UCk_Utils_Physics_UE::Request_SetGenerateOverlapEvents(this, ECk_EnableDisable::Disable, this);
 }


### PR DESCRIPTION
notes: the ticking is mainly for CCD overlaps. However, CCD in Unreal requires the shape to be the root component of an Actor which we currently do not have support for.