### PR TITLE
fix: crash-fix for Ecs Stats Subsystem related to an async function

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsWorldStats_Subsystem.cpp
+++ b/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsWorldStats_Subsystem.cpp
@@ -115,8 +115,10 @@ auto
     Deinitialize()
     -> void
 {
+#if STATS
     const auto& Stats = FStatsThreadState::GetLocalState();
     Stats.NewFrameDelegate.Remove(_OnNewFrameDelegateHandle);
+#endif
 
     Super::Deinitialize();
 }


### PR DESCRIPTION
notes: it is possible that the `this` pointer is invalid by the time the Async function is invoked. Because the pointer is `raw`, there is no way to check it for validity. Passing a weak object pointer will allow us to correctly check for validity.