### PR TITLE
fix: Entity destruction uses the iterator-based function

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
@@ -94,13 +94,23 @@ namespace ck
         InHandle.Remove<FTag_DestroyEntity_Await, ck::IsValid_Policy_IncludePendingKill>();
     }
 
+    auto
+        FProcessor_EntityLifetime_DestroyEntity::DoTick(
+            TimeType InDeltaT) -> void
+    {
+        EntitiesToDestroy.Empty();
+        Super::DoTick(InDeltaT);
+        QUICK_SCOPE_CYCLE_COUNTER(DestroyEntities)
+        _TransientEntity.Get_Registry().DestroyEntities(EntitiesToDestroy);
+    }
+
     // --------------------------------------------------------------------------------------------------------------------
 
     auto
         FProcessor_EntityLifetime_DestroyEntity::
         ForEachEntity(
             TimeType InDeltaT,
-            HandleType InHandle) const
+            HandleType InHandle)
         -> void
     {
         ecs::VeryVerbose(TEXT("[DESTRUCTION] Destroying Entity [{}]"), InHandle);
@@ -132,7 +142,7 @@ namespace ck
             ck::UUtils_Signal_EntityDestroyed::Broadcast(InHandle, ck::MakePayload(InHandle));
         }
 
-        InHandle->DestroyEntity(InHandle.Get_Entity());
+        EntitiesToDestroy.Emplace(InHandle.Get_Entity());
     }
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.h
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.h
@@ -79,10 +79,17 @@ namespace ck
         : public TProcessor<FProcessor_EntityLifetime_DestroyEntity, FTag_DestroyEntity_Finalize>
     {
     public:
+        using Super = TProcessor;
+    public:
         using TProcessor::TProcessor;
 
+        auto DoTick(TimeType InDeltaT) -> void;
+
     public:
-        auto ForEachEntity(TimeType InDeltaT, HandleType InHandle) const -> void;
+        auto ForEachEntity(TimeType InDeltaT, HandleType InHandle) -> void;
+
+    public:
+        TArray<EntityType> EntitiesToDestroy;
     };
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.cpp
+++ b/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.cpp
@@ -1,5 +1,7 @@
 #include "CkRegistry.h"
 
+#include "CkCore/Algorithms/CkAlgorithms.h"
+
 // --------------------------------------------------------------------------------------------------------------------
 
 FCk_Registry::
@@ -46,6 +48,18 @@ auto
     -> void
 {
     _InternalRegistry->destroy(InEntity.Get_ID());
+}
+
+auto
+    FCk_Registry::DestroyEntities(
+        const TArray<EntityType>& InEntities) -> void
+{
+    const auto& EntityIDs = ck::algo::Transform<TArray<EntityType::IdType>>(InEntities,
+        [](const EntityType& Entity)
+    {
+        return Entity.Get_ID();
+    });
+    _InternalRegistry->destroy(EntityIDs.begin(), EntityIDs.end());
 }
 
 auto

--- a/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
+++ b/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
@@ -189,10 +189,11 @@ private:
     template <typename T_Fragment>
     auto Get(EntityType InEntity) const -> const T_Fragment&;
 
-private:
+public:
     auto CreateEntity() -> EntityType;
     auto CreateEntity(EntityType InEntityHint) -> EntityType;
     auto DestroyEntity(EntityType InEntity) -> void;
+    auto DestroyEntities(const TArray<EntityType>& InEntities) -> void;
 
 public:
     auto IsValid(EntityType InEntity) const -> bool;


### PR DESCRIPTION
*  Entity lifetime destroy processor now stores entities to destroy and destroys all of them at the same time
   *  This uses the faster destroy call in entt to save some time (around 3.2 ms to 2.5 ms for player entity destoryed)