### PR TITLE
fix: Fix bug causing replicated entity transform being wrong on clients

### DIFF
--- a/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Fragment.cpp
+++ b/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Fragment.cpp
@@ -24,6 +24,27 @@ auto
 
 auto
     UCk_Fragment_Transform_Rep::
+    PostLink()
+    -> void
+{
+    Super::PostLink();
+
+    const auto& TransformHandle = UCk_Utils_Transform_UE::Cast(Get_AssociatedEntity());
+
+    CK_ENSURE_IF_NOT(ck::IsValid(TransformHandle),
+        TEXT("Entity [{}] with a Transform_Rep fragment does NOT have a transform fragment"),
+        Get_AssociatedEntity())
+    { return; }
+
+    // Make sure the initial values match the transforms values since a rep-notify is sent on client spawned which needs to have the correct info
+    const auto& EntityCurrentTransform = UCk_Utils_Transform_UE::Get_EntityCurrentTransform(TransformHandle);
+    _Location = EntityCurrentTransform.GetLocation();
+    _Rotation = EntityCurrentTransform.GetRotation();
+    _Scale = EntityCurrentTransform.GetScale3D();
+}
+
+auto
+    UCk_Fragment_Transform_Rep::
     OnRep_Location() -> void
 {
     CK_REP_OBJ_EXECUTE_IF_VALID([&]()

--- a/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Fragment.h
+++ b/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Fragment.h
@@ -208,22 +208,30 @@ UCLASS(Blueprintable)
 class CKECSEXT_API UCk_Fragment_Transform_Rep : public UCk_Ecs_ReplicatedObject_UE
 {
     GENERATED_BODY()
-
 public:
     CK_GENERATED_BODY_FRAGMENT_REP(UCk_Fragment_Transform_Rep);
 
 public:
-    virtual auto GetLifetimeReplicatedProps(TArray<FLifetimeProperty>&) const -> void override;
+    auto
+    GetLifetimeReplicatedProps(
+        TArray<FLifetimeProperty>&) const -> void override;
+
+protected:
+    auto
+    PostLink() -> void override;
 
 public:
     UFUNCTION()
-    void OnRep_Location();
+    void
+    OnRep_Location();
 
     UFUNCTION()
-    void OnRep_Rotation();
+    void
+    OnRep_Rotation();
 
     UFUNCTION()
-    void OnRep_Scale();
+    void
+    OnRep_Scale();
 
 private:
     UPROPERTY(ReplicatedUsing = OnRep_Location)


### PR DESCRIPTION
*  Issue was caused by the rep_notify for transform components being sent on client spawned even though the values were never marked dirty
*  To fix this, we initialize the replicate fragment's values on PostLink so the repnotify sends the correct info
   *  TODO: It would be better if the rep_notify was not sent at all until the value is marked dirty, but we don't currently know of a way to do that