### PR TITLE
fix: Allow spawning an actor from an outermost client actor with auth…

### DIFF
--- a/Source/CkActor/Public/CkActor/ActorModifier/CkActorModifier_Processor.cpp
+++ b/Source/CkActor/Public/CkActor/ActorModifier/CkActorModifier_Processor.cpp
@@ -60,7 +60,7 @@ namespace ck
                     ck::IsValid(OutermostActor))
                 {
                     if (OutermostActor->GetLocalRole() == ROLE_AutonomousProxy ||
-                        (OutermostActor->GetLocalRole() == ROLE_Authority && OutermostActor->GetRemoteRole() != ROLE_AutonomousProxy))
+                        (OutermostActor->GetLocalRole() == ROLE_Authority && OutermostActor->GetRemoteRole() == ROLE_AutonomousProxy))
                     { break; }
                 }
 


### PR DESCRIPTION
…ority

Based on log below, it seems like this was a mistake as clients oh auth have a remote role of autonomous proxy Log for reference: "Skipped Spawning [{}] because SpawnPolicy is [{}] and our role is neither ROLE_AutomousProxy NOR (if we are a client) do we have ROLE_Authority"