### PR TITLE
fix: CkUserWidget unbinds actor when deactivated

### DIFF
--- a/Source/CkUI/Public/CkUI/UserWidget/CkUserWidget.cpp
+++ b/Source/CkUI/Public/CkUI/UserWidget/CkUserWidget.cpp
@@ -201,5 +201,15 @@ auto
     }
 }
 
-// --------------------------------------------------------------------------------------------------------------------
+auto
+    UCk_UserWidget_UE::
+    NativeOnDeactivated() -> void
+{
+    if (const auto& BindActor = Get_BindActor().Get();
+        ck::IsValid(BindActor))
+    { UnbindFromActor(Get_BindActor().Get()); }
 
+    Super::NativeOnDeactivated();
+}
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkUI/Public/CkUI/UserWidget/CkUserWidget.h
+++ b/Source/CkUI/Public/CkUI/UserWidget/CkUserWidget.h
@@ -21,7 +21,6 @@ UCLASS(Abstract, BlueprintType, Blueprintable, meta = (DisableNativeTick))
 class CKUI_API UCk_UserWidget_UE : public UCommonActivatableWidget
 {
     GENERATED_BODY()
-
 public:
     CK_GENERATED_BODY(UCk_UserWidget_UE);
 
@@ -56,6 +55,7 @@ protected:
 
 protected:
     virtual void NativeDestruct() override;
+    virtual void NativeOnDeactivated() override;
 
 protected:
     UPROPERTY(Transient, BlueprintReadOnly,


### PR DESCRIPTION
*  Prevents ensure when widget is recycled while actor is still valid