### PR TITLE
fix: AbilityEvents can now be fired while existing events are being p…

### DIFF
--- a/Content/CkNet/CkNet_Utils_BPFL.uasset
+++ b/Content/CkNet/CkNet_Utils_BPFL.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cd7db045ecf93ba97b910fa7b9614cb438ec62d8cb5a8a21ce5cb19719471c8
+size 25085

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -90,16 +90,18 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            const FFragment_AbilityOwner_Events&  InAbilityOwnerEvents)
+            FFragment_AbilityOwner_Events&  InAbilityOwnerEvents)
         -> void
     {
-        for (const auto& Event : InAbilityOwnerEvents.Get_Events())
+        const auto CopiedEvents = InAbilityOwnerEvents.Get_Events();
+        InHandle.Remove<MarkedDirtyBy>();
+
+        for (const auto& Event : CopiedEvents)
         {
             UUtils_Signal_AbilityOwner_SingleEvent::Broadcast(InHandle, MakePayload(InHandle, Event));
         }
 
-        UUtils_Signal_AbilityOwner_Events::Broadcast(InHandle, MakePayload(InHandle, InAbilityOwnerEvents.Get_Events()));
-        InHandle.Remove<MarkedDirtyBy>();
+        UUtils_Signal_AbilityOwner_Events::Broadcast(InHandle, MakePayload(InHandle, CopiedEvents));
     }
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
@@ -73,7 +73,7 @@ namespace ck
         static auto ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            const FFragment_AbilityOwner_Events&  InAbilityOwnerEvents) -> void;
+            FFragment_AbilityOwner_Events&  InAbilityOwnerEvents) -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…rocessed

notes: this fix uses the same pattern as Requests where we copy the events, clear them (and the Fragment) and then proceed to process the events. This ensures that any new events while processing the events (in callbacks) are correctly queued.