### PR TITLE
fix: Get Object Net Mode no longer hides input pin in BP

### DIFF
--- a/Source/CkNet/Public/CkNet/CkNet_Utils.h
+++ b/Source/CkNet/Public/CkNet/CkNet_Utils.h
@@ -201,14 +201,14 @@ public:
 
     UFUNCTION(BlueprintPure,
               DisplayName="[Ck] Get Net Role",
-              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext", HidePin = "InContext"))
+              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext"))
     static ECk_Net_NetModeType
     Get_NetRole(
         const UObject* InContext = nullptr);
 
     UFUNCTION(BlueprintPure,
               DisplayName="[Ck] Get Object Net Mode",
-              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext", HidePin = "InContext"))
+              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext"))
     static ECk_Net_NetModeType
     Get_NetMode(
         const UObject* InContext = nullptr);
@@ -237,28 +237,28 @@ public:
 public:
     UFUNCTION(BlueprintPure,
               DisplayName="[Ck] Get Min Ping",
-              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext", HidePin = "InContext"))
+              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext"))
     static FCk_Time
     Get_MinPing(
         const UObject* InContext = nullptr);
 
     UFUNCTION(BlueprintPure,
               DisplayName="[Ck] Get Max Ping",
-              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext", HidePin = "InContext"))
+              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext"))
     static FCk_Time
     Get_MaxPing(
         const UObject* InContext = nullptr);
 
     UFUNCTION(BlueprintPure,
               DisplayName="[Ck] Get Average Ping",
-              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext", HidePin = "InContext"))
+              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext"))
     static FCk_Time
     Get_AveragePing(
         const UObject* InContext = nullptr);
 
     UFUNCTION(BlueprintPure,
               DisplayName="[Ck] Get Average Latency",
-              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext", HidePin = "InContext"))
+              Category = "Ck|Utils|Net", meta = (DefaultToSelf = "InContext"))
     static FCk_Time
     Get_AverageLatency(
         const UObject* InContext = nullptr);


### PR DESCRIPTION
commit 77695a6e413754eab649d341b3b32905495a95cb (HEAD -> bugfix/get-object-net-mode-input-pin, origin/bugfix/get-object-net-mode-input-pin)
Author: AlexObatake-CK <phosphorus@chainkemists.com>
Date:   Tue Nov 12 13:53:49 2024 -0800

    fix: Net Utils getters no longer hide input pin for context in BP

    *  Allows setting input pin to something other than self