### PR TITLE
fix: Fix bug where ability owner replicated requests were being proce…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
@@ -261,6 +261,16 @@ auto
 
 auto
     UCk_Fragment_AbilityOwner_Rep::
+    Request_TryUpdateReplicatedFragment()
+    -> void
+{
+    OnRep_PendingAddOrGiveExistingAbilityRequests();
+    OnRep_PendingGiveAbilityRequests();
+    OnRep_PendingRevokeAbilityRequests();
+}
+
+auto
+    UCk_Fragment_AbilityOwner_Rep::
     OnRep_PendingAddOrGiveExistingAbilityRequests()
     -> void
 {
@@ -270,7 +280,12 @@ auto
     if (GetWorld()->IsNetMode(NM_DedicatedServer))
     { return; }
 
-    auto AssociatedEntityAbilityOwner = ck::StaticCast<FCk_Handle_AbilityOwner>(_AssociatedEntity);
+    auto AssociatedEntityAbilityOwner = UCk_Utils_AbilityOwner_UE::Cast(_AssociatedEntity);
+
+    // If associated entity ability owner is not yet valid or setup, we should not process replicated requests until setup calls Request_TryUpdateReplicatedFragment
+    if (ck::Is_NOT_Valid(AssociatedEntityAbilityOwner) ||
+        AssociatedEntityAbilityOwner.Has<ck::FTag_AbilityOwner_NeedsSetup>())
+    { return; }
 
     for (auto Index = _NextPendingAddGiveExistingAbilityRequests; Index < _PendingAddAndGiveExistingAbilityRequests.Num(); ++Index)
     {
@@ -291,7 +306,12 @@ auto
     if (GetWorld()->IsNetMode(NM_DedicatedServer))
     { return; }
 
-    auto AssociatedEntityAbilityOwner = ck::StaticCast<FCk_Handle_AbilityOwner>(_AssociatedEntity);
+    auto AssociatedEntityAbilityOwner = UCk_Utils_AbilityOwner_UE::Cast(_AssociatedEntity);
+
+    // If associated entity ability owner is not yet valid or setup, we should not process replicated requests until setup calls Request_TryUpdateReplicatedFragment
+    if (ck::Is_NOT_Valid(AssociatedEntityAbilityOwner) ||
+        AssociatedEntityAbilityOwner.Has<ck::FTag_AbilityOwner_NeedsSetup>())
+    { return; }
 
     for (auto Index = _NextPendingGiveAbilityRequests; Index < _PendingGiveAbilityRequests.Num(); ++Index)
     {
@@ -312,7 +332,12 @@ auto
     if (GetWorld()->IsNetMode(NM_DedicatedServer))
     { return; }
 
-    auto AssociatedEntityAbilityOwner = ck::StaticCast<FCk_Handle_AbilityOwner>(_AssociatedEntity);
+    auto AssociatedEntityAbilityOwner = UCk_Utils_AbilityOwner_UE::Cast(_AssociatedEntity);
+
+    // If associated entity ability owner is not yet valid or setup, we should not process replicated requests until setup calls Request_TryUpdateReplicatedFragment
+    if (ck::Is_NOT_Valid(AssociatedEntityAbilityOwner) ||
+        AssociatedEntityAbilityOwner.Has<ck::FTag_AbilityOwner_NeedsSetup>())
+    { return; }
 
     for (auto Index = _NextPendingRevokeAbilityRequests; Index < _PendingRevokeAbilityRequests.Num(); ++Index)
     {

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
@@ -139,6 +139,30 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
+    struct CKABILITY_API FFragment_AbilityOwner_Requests_PendingReplication
+    {
+    public:
+        CK_GENERATED_BODY(FFragment_AbilityOwner_Requests);
+
+    public:
+        friend class FProcessor_AbilityOwner_HandleRequests;
+        friend class UCk_Utils_AbilityOwner_UE;
+
+    public:
+        using RevokeAbilityRequestType = FCk_Request_AbilityOwner_RevokeAbility;
+
+        using RequestType = std::variant<RevokeAbilityRequestType>;
+        using RequestList = TArray<RequestType>;
+
+    public:
+        RequestList _Requests;
+
+    public:
+        CK_PROPERTY_GET(_Requests);
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     struct CKABILITY_API FFragment_AbilityOwner_Events
     {
     public:

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
@@ -213,6 +213,9 @@ public:
     GetLifetimeReplicatedProps(
         TArray<FLifetimeProperty>&) const -> void override;
 
+    auto
+    Request_TryUpdateReplicatedFragment()-> void;
+
 private:
     UFUNCTION()
     void

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -81,6 +81,20 @@ namespace ck
                 {}
             );
         }
+
+        // it's possible that we have pending replication info
+        // This code is in Setup instead of Add since we need to have added the default abilities first
+        if (UCk_Utils_Net_UE::Get_IsEntityNetMode_Client(InHandle))
+        {
+            if (UCk_Utils_Ecs_Net_UE::Get_HasReplicatedFragment<UCk_Fragment_AbilityOwner_Rep>(InHandle))
+            {
+                InHandle.Try_Transform<TObjectPtr<UCk_Fragment_AbilityOwner_Rep>>(
+                [&](const TObjectPtr<UCk_Fragment_AbilityOwner_Rep>& InRepComp)
+                {
+                    InRepComp->Request_TryUpdateReplicatedFragment();
+                });
+            }
+        }
     }
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
@@ -156,6 +156,37 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
+    class CKABILITY_API FProcessor_AbilityOwner_HandleRequests_PendingReplication : public ck_exp::TProcessor<
+            FProcessor_AbilityOwner_HandleRequests_PendingReplication,
+            FCk_Handle_AbilityOwner,
+            FFragment_AbilityOwner_Current,
+            FFragment_AbilityOwner_Requests_PendingReplication,
+            CK_IGNORE_PENDING_KILL>
+    {
+    public:
+        using MarkedDirtyBy = FFragment_AbilityOwner_Requests_PendingReplication;
+
+    public:
+        using TProcessor::TProcessor;
+
+    public:
+        auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType& InHandle,
+            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Requests_PendingReplication& InAbilityRequestsComp) const -> void;
+
+    private:
+        auto
+        DoHandleRequest(
+            HandleType& InAbilityOwnerEntity,
+            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            const FCk_Request_AbilityOwner_RevokeAbility& InRequest) const -> void;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     class CKABILITY_API FProcessor_AbilityOwner_TagsUpdated : public ck_exp::TProcessor<
             FProcessor_AbilityOwner_TagsUpdated,
             FCk_Handle_AbilityOwner,

--- a/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbilityProcessorInjector.cpp
+++ b/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbilityProcessorInjector.cpp
@@ -28,6 +28,7 @@ auto
     InWorld.Add<ck::FProcessor_AbilityOwner_EnsureAllAppended>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_Setup>(InWorld.Get_Registry());
 
+    InWorld.Add<ck::FProcessor_AbilityOwner_HandleRequests_PendingReplication>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_HandleRequests>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_HandleEvents>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_TagsUpdated>(InWorld.Get_Registry());

--- a/Source/CkInteraction/Public/CkInteraction/InteractSource/CkInteractSource_Utils.h
+++ b/Source/CkInteraction/Public/CkInteraction/InteractSource/CkInteractSource_Utils.h
@@ -31,7 +31,7 @@ public:
               DisplayName="[Ck][InteractSource] Add Interaction Sources")
     static FCk_Handle_InteractSource
     Add(
-        UPARAM(ref) FCk_Handle InInteractSourceOwner,
+        UPARAM(ref) FCk_Handle& InInteractSourceOwner,
         const FCk_Fragment_InteractSource_ParamsData& InParams,
         ECk_Replication InReplicates = ECk_Replication::Replicates);
 


### PR DESCRIPTION
…ssed before client's ability owner is ready

*  In some cases, replicated requests may be received before ability owner is added or setup on client.
*  If ability owner is not both added and setup, then it may not have the default abilities added yet so it shouldn't process any replicated requests
   *  It is fine to skip requests here since we don't remove them so they will be processed later when ready
*  On setup on clients, call Request_TryUpdateReplicatedFragment to try to process replicated requests that were skipped earlier