### PR TITLE
fix: Revoke AddAndGiveExistingAbility now has replication type to avo…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.cpp
@@ -25,6 +25,18 @@ auto
 
 // --------------------------------------------------------------------------------------------------------------------
 
+FCk_Request_AbilityOwner_AddAndGiveExistingAbility::
+    FCk_Request_AbilityOwner_AddAndGiveExistingAbility(
+        FCk_Handle_Ability InAbility,
+        FCk_Handle InAbilitySource)
+    : _Ability(InAbility)
+    , _AbilitySource(InAbilitySource)
+    , _ReplicationType(UCk_Utils_Ability_UE::Get_NetworkSettings(InAbility).Get_ReplicationType())
+{
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
 FCk_Request_AbilityOwner_RevokeAbility::
     FCk_Request_AbilityOwner_RevokeAbility(
         TSubclassOf<UCk_Ability_Script_PDA> InAbilityClass)

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment_Data.h
@@ -153,13 +153,21 @@ public:
 
 // --------------------------------------------------------------------------------------------------------------------
 
-USTRUCT(BlueprintType)
+USTRUCT(BlueprintType, meta= (HasNativeMake))
 struct CKABILITY_API FCk_Request_AbilityOwner_AddAndGiveExistingAbility : public FCk_Request_Base
 {
     GENERATED_BODY()
 
 public:
     CK_GENERATED_BODY(FCk_Request_AbilityOwner_AddAndGiveExistingAbility);
+
+public:
+    FCk_Request_AbilityOwner_AddAndGiveExistingAbility() = default;
+
+    explicit
+    FCk_Request_AbilityOwner_AddAndGiveExistingAbility(
+        FCk_Handle_Ability InAbility,
+        FCk_Handle InAbilitySource);
 
 private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
@@ -174,13 +182,15 @@ private:
               meta = (AllowPrivateAccess = true))
     FCk_Ability_Payload_OnGranted _OptionalPayload;
 
+    UPROPERTY(EditAnywhere, BlueprintReadWrite,
+              meta = (AllowPrivateAccess = true))
+    ECk_Net_ReplicationType _ReplicationType = ECk_Net_ReplicationType::All;
+
 public:
     CK_PROPERTY_GET(_Ability)
     CK_PROPERTY_GET(_AbilitySource)
     CK_PROPERTY(_OptionalPayload)
-
-public:
-    CK_DEFINE_CONSTRUCTORS(FCk_Request_AbilityOwner_AddAndGiveExistingAbility, _Ability, _AbilitySource);
+    CK_PROPERTY(_ReplicationType)
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
@@ -485,6 +485,24 @@ auto
         const FCk_Delegate_AbilityOwner_OnAbilityGivenOrNot& InDelegate)
     -> FCk_Handle_AbilityOwner
 {
+    if (NOT UCk_Utils_Net_UE::Get_IsEntityRoleMatching(InAbilityOwnerHandle, InRequest.Get_ReplicationType()))
+    {
+        ck::ability::Verbose
+        (
+            TEXT("Skipping Revoking Ability [{}] because ReplicationType [{}] does not match for Entity [{}], meaning this ability shouldn't have have been added on this instance anyways"),
+            InRequest.Get_Ability(),
+            InRequest.Get_ReplicationType(),
+            InAbilityOwnerHandle
+        );
+        return InAbilityOwnerHandle;
+    }
+
+    // Need to re-cast to make sure it all relevant fragments were replicated properly
+    const auto AbilityHandle = UCk_Utils_Ability_UE::Cast(InRequest.Get_Ability());
+    CK_ENSURE_IF_NOT(ck::IsValid(AbilityHandle), TEXT("AbilityHandle [{}] to Revoke on AbilityOwner [{}] is INVALID"),
+        AbilityHandle, InAbilityOwnerHandle)
+    { return InAbilityOwnerHandle; }
+
     CK_ENSURE_IF_NOT(ck::IsValid(InRequest.Get_Ability()),
         TEXT("Unable to process AddAndGiveExistingAbility on Handle [{}] as the AbilityHandle [{}] is INVALID.{}"),
         InAbilityOwnerHandle, InRequest.Get_Ability(), ck::Context(InDelegate.GetFunctionName()))
@@ -897,6 +915,17 @@ auto
     -> FCk_Request_AbilityOwner_RevokeAbility
 {
     return FCk_Request_AbilityOwner_RevokeAbility{InAbilityEntity}.Set_DestructionPolicy(InDestructionPolicy);
+}
+
+auto
+    UCk_Utils_AbilityOwner_UE::
+    Make_Request_AddAndGiveExistingAbility(
+        FCk_Handle_Ability InAbility,
+        FCk_Handle InAbilitySource,
+        FCk_Ability_Payload_OnGranted InOptionalPayload)
+    -> FCk_Request_AbilityOwner_AddAndGiveExistingAbility
+{
+    return FCk_Request_AbilityOwner_AddAndGiveExistingAbility{InAbility, InAbilitySource}.Set_OptionalPayload(InOptionalPayload);
 }
 
 auto

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
@@ -490,6 +490,14 @@ private:
         const FCk_Handle_Ability& InAbilityEntity,
         ECk_AbilityOwner_DestructionOnRevoke_Policy InDestructionPolicy = ECk_AbilityOwner_DestructionOnRevoke_Policy::DestroyOnRevoke);
 
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Ability|Owner")
+    static FCk_Request_AbilityOwner_AddAndGiveExistingAbility
+    Make_Request_AddAndGiveExistingAbility(
+        FCk_Handle_Ability InAbility,
+        FCk_Handle InAbilitySource,
+        FCk_Ability_Payload_OnGranted InOptionalPayload);
+
 public:
     static auto
     Get_DefaultAbilities(


### PR DESCRIPTION
…id running on non-matching instances

*  Abilities can be given on some instances but not others, but replicated AddAndGiveExistingAbility request was always processed on all instances
*  Now AddAndGiveExistingAbility request gets replication type on creation and this is checked when processing the replicated AddAndGiveExistingAbility request
   *  We cannot rely on getting the replication type from the ability when processing the request since the ability entity in the request will not be valid if the ability was never added on that instance *  ex. ability is added as local+host and is being processed on a client where the ability owner isn't local