### PR TITLE
fix: Ability owners send tags updated if their extension's tags changed

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
@@ -90,73 +90,81 @@ namespace ck
     auto
         FFragment_AbilityOwner_Current::
         AppendTags(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTagContainer& InTagsToAdd)
         -> void
     {
         if (InTagsToAdd.IsEmpty())
         { return; }
 
-        DoTry_TagsUpdatedOnExtensionOwner(InAbilityOwner);
         _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagsToAdd, 1);
 
-        _PreviousTags_IncludingAllEntityExtensions = _ActiveTags_IncludingAllEntityExtensions;
-        _ActiveTags_IncludingAllEntityExtensions = Get_ActiveTags(InAbilityOwner);
+        Do_TagsUpdated(InAbilityOwner);
     }
 
     auto
         FFragment_AbilityOwner_Current::
         AddTag(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTag& InTagToAdd)
         -> void
     {
-        DoTry_TagsUpdatedOnExtensionOwner(InAbilityOwner);
         _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagToAdd, 1);
 
-        _PreviousTags_IncludingAllEntityExtensions = _ActiveTags_IncludingAllEntityExtensions;
-        _ActiveTags_IncludingAllEntityExtensions = Get_ActiveTags(InAbilityOwner);
+        Do_TagsUpdated(InAbilityOwner);
     }
 
     auto
         FFragment_AbilityOwner_Current::
         RemoveTag(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTag& InTagToRemove)
         -> void
     {
-        DoTry_TagsUpdatedOnExtensionOwner(InAbilityOwner);
         _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagToRemove, -1);
 
-        _PreviousTags_IncludingAllEntityExtensions = _ActiveTags_IncludingAllEntityExtensions;
-        _ActiveTags_IncludingAllEntityExtensions = Get_ActiveTags(InAbilityOwner);
+        Do_TagsUpdated(InAbilityOwner);
     }
 
     auto
         FFragment_AbilityOwner_Current::
         RemoveTags(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTagContainer& InTagsToRemove)
         -> void
     {
         if (InTagsToRemove.IsEmpty())
         { return; }
 
-        DoTry_TagsUpdatedOnExtensionOwner(InAbilityOwner);
         _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagsToRemove, -1);
 
+        Do_TagsUpdated(InAbilityOwner);
+    }
+
+    auto
+        FFragment_AbilityOwner_Current::
+        Do_TagsUpdated(
+            FCk_Handle_AbilityOwner& InAbilityOwner)
+        -> void
+    {
         _PreviousTags_IncludingAllEntityExtensions = _ActiveTags_IncludingAllEntityExtensions;
         _ActiveTags_IncludingAllEntityExtensions = Get_ActiveTags(InAbilityOwner);
+
+        if (Get_AreActiveTagsDifferentThanPreviousTags())
+        {
+            UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(InAbilityOwner);
+        }
+        DoTry_TagsUpdatedOnExtensionOwner(InAbilityOwner);
     }
 
     auto
         FFragment_AbilityOwner_Current::
         DoTry_TagsUpdatedOnExtensionOwner(
-            const FCk_Handle_AbilityOwner& InAbilityOwner)
+            FCk_Handle_AbilityOwner& InAbilityOwner)
         -> void
     {
         if (const auto EntityExtension = UCk_Utils_EntityExtension_UE::Cast(InAbilityOwner);
@@ -167,7 +175,8 @@ namespace ck
 
             if (ck::IsValid(ExtensionOwner))
             {
-                UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(ExtensionOwnerAsAbilityOwner);
+                auto& ExtensionOwnerAbilityOwnerComp = ExtensionOwnerAsAbilityOwner.Get<FFragment_AbilityOwner_Current>();
+                ExtensionOwnerAbilityOwnerComp.Do_TagsUpdated(ExtensionOwnerAsAbilityOwner);
             }
         }
     }

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
@@ -79,22 +79,26 @@ namespace ck
             const FCk_Handle_AbilityOwner& InAbilityOwner) const -> bool;
 
         auto AppendTags(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTagContainer& InTagsToAdd) -> void;
         auto AddTag(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTag& InTagToAdd) -> void;
         auto RemoveTags(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTagContainer& InTagsToRemove) -> void;
         auto RemoveTag(
-            const FCk_Handle_AbilityOwner& InAbilityOwner,
+            FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTag& InTagToRemove) -> void;
 
     private:
-        static auto
+        auto
+        Do_TagsUpdated(
+            FCk_Handle_AbilityOwner& InAbilityOwner) -> void;
+
+        auto
         DoTry_TagsUpdatedOnExtensionOwner(
-            const FCk_Handle_AbilityOwner& InAbilityOwner) -> void;
+            FCk_Handle_AbilityOwner& InAbilityOwner) -> void;
 
         auto Get_ActiveTagsRecursive(
             const FCk_Handle_AbilityOwner& InAbilityOwner,

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -189,11 +189,6 @@ namespace ck
                 auto NonConstAbilityOwnerEntity = InAbilityOwnerEntity;
                 auto& AbilityOwnerComp = NonConstAbilityOwnerEntity.Get<FFragment_AbilityOwner_Current>();
                 AbilityOwnerComp.AppendTags(InAbilityOwnerEntity, GrantedTags);
-
-                if (AbilityOwnerComp.Get_AreActiveTagsDifferentThanPreviousTags())
-                {
-                    UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(NonConstAbilityOwnerEntity);
-                }
             }
 
             UCk_Utils_Ability_UE::DoGive(AbilityOwnerEntity, AbilityEntity, AbilitySource, OptionalPayload);
@@ -345,12 +340,7 @@ namespace ck
                     // HACK: need a non-const handle as we're unable to make the lambda mutable
                     auto NonConstAbilityOwnerEntity = InAbilityOwnerEntity;
                     auto& AbilityOwnerComp = NonConstAbilityOwnerEntity.Get<FFragment_AbilityOwner_Current>();
-                    AbilityOwnerComp.AppendTags(InAbilityOwnerEntity, GrantedTags);
-
-                    if (AbilityOwnerComp.Get_AreActiveTagsDifferentThanPreviousTags())
-                    {
-                        UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(NonConstAbilityOwnerEntity);
-                    }
+                    AbilityOwnerComp.AppendTags(NonConstAbilityOwnerEntity, GrantedTags);
                 }
 
                 UCk_Utils_Ability_UE::DoGive(AbilityOwnerEntity, AbilityEntity, AbilitySource, OptionalPayload);
@@ -537,12 +527,7 @@ namespace ck
                     // HACK: need a non-const handle as we're unable to make the lambda mutable
                     auto NonConstAbilityOwnerEntity = InAbilityOwnerEntity;
                     auto& AbilityOwnerComp = NonConstAbilityOwnerEntity.Get<FFragment_AbilityOwner_Current>();
-                    AbilityOwnerComp.AppendTags(InAbilityOwnerEntity, GrantedTags);
-
-                    if (AbilityOwnerComp.Get_AreActiveTagsDifferentThanPreviousTags())
-                    {
-                        UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(NonConstAbilityOwnerEntity);
-                    }
+                    AbilityOwnerComp.AppendTags(NonConstAbilityOwnerEntity, GrantedTags);
                 }
 
                 UCk_Utils_Ability_UE::DoGive(AbilityOwnerEntity, AbilityEntity, AbilitySource, {});
@@ -624,11 +609,6 @@ namespace ck
                 const auto& GrantedTags = AbilityOnGiveSettings.Get_OnGiveSettingsOnOwner().Get_GrantTagsOnAbilityOwner();
 
                 InAbilityOwnerComp.RemoveTags(InAbilityOwnerEntity, GrantedTags);
-
-                if (InAbilityOwnerComp.Get_AreActiveTagsDifferentThanPreviousTags())
-                {
-                    UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(InAbilityOwnerEntity);
-                }
             }
 
             UCk_Utils_Ability_UE::DoRevoke(InAbilityOwnerEntity, InAbilityEntity, InRequest.Get_DestructionPolicy());
@@ -848,11 +828,6 @@ namespace ck
 
                 InAbilityOwnerComp.AppendTags(InAbilityOwnerEntity, GrantedTags);
 
-                if (InAbilityOwnerComp.Get_AreActiveTagsDifferentThanPreviousTags())
-                {
-                    UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(InAbilityOwnerEntity);
-                }
-
                 // Try Deactivate our own Ability if we have one
                 if (UCk_Utils_Ability_UE::Has(InAbilityOwnerEntity))
                 {
@@ -1028,11 +1003,6 @@ namespace ck
             const auto& GrantedTags = AbilityActivationSettings.Get_ActivationSettingsOnOwner().Get_GrantTagsOnAbilityOwner();
 
             InAbilityOwnerComp.RemoveTags(InAbilityOwnerEntity, GrantedTags);
-
-            if (InAbilityOwnerComp.Get_AreActiveTagsDifferentThanPreviousTags())
-            {
-                UCk_Utils_AbilityOwner_UE::Request_TagsUpdated(InAbilityOwnerEntity);
-            }
 
             ability::VeryVerbose
             (
@@ -1238,7 +1208,7 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            const FFragment_AbilityOwner_Current& InCurrent) const
+            FFragment_AbilityOwner_Current& InCurrent) const
         -> void
     {
         // if we are an EntityExtension, then inform our ExtensionOwner of potentially updated tags

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
@@ -198,7 +198,7 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            const FFragment_AbilityOwner_Current& InCurrent) const -> void;
+            FFragment_AbilityOwner_Current& InCurrent) const -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
*  Tag modifier functions (add/remove) are responsible for setting the tags modified ecs tag to consolidate logic.
   *  Now there is one function Do_TagsUpdated thats responsible for updating ecs tag for modified and the cached tags from the last update
*  DoTry_TagsUpdatedOnExtensionOwner now also updates _PreviousTags_IncludingAllEntityExtensions and _ActiveTags_IncludingAllEntityExtensions
   *  This fixes a bug where extensions would get the ecs tag indicating tags changed, but since their cached tags weren't updated, the processor wouldn't process the change