### PR TITLE
fix: Ability Owner previous tags are updated in Tags Updated processo…

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
@@ -97,7 +97,6 @@ namespace ck
         if (InTagsToAdd.IsEmpty())
         { return; }
 
-        _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagsToAdd, 1);
 
         Do_TagsUpdated(InAbilityOwner);
@@ -110,7 +109,6 @@ namespace ck
             const FGameplayTag& InTagToAdd)
         -> void
     {
-        _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagToAdd, 1);
 
         Do_TagsUpdated(InAbilityOwner);
@@ -123,7 +121,6 @@ namespace ck
             const FGameplayTag& InTagToRemove)
         -> void
     {
-        _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagToRemove, -1);
 
         Do_TagsUpdated(InAbilityOwner);
@@ -139,10 +136,18 @@ namespace ck
         if (InTagsToRemove.IsEmpty())
         { return; }
 
-        _PreviousTags = _ActiveTags;
         _ActiveTags.UpdateTagCount(InTagsToRemove, -1);
 
         Do_TagsUpdated(InAbilityOwner);
+    }
+
+    auto
+        FFragment_AbilityOwner_Current::
+        UpdatePreviousTags()
+        -> void
+    {
+        _PreviousTags = _ActiveTags;
+        _PreviousTags_IncludingAllEntityExtensions = _ActiveTags_IncludingAllEntityExtensions;
     }
 
     auto
@@ -151,7 +156,6 @@ namespace ck
             FCk_Handle_AbilityOwner& InAbilityOwner)
         -> void
     {
-        _PreviousTags_IncludingAllEntityExtensions = _ActiveTags_IncludingAllEntityExtensions;
         _ActiveTags_IncludingAllEntityExtensions = Get_ActiveTags(InAbilityOwner);
 
         if (Get_AreActiveTagsDifferentThanPreviousTags())

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
@@ -90,6 +90,7 @@ namespace ck
         auto RemoveTag(
             FCk_Handle_AbilityOwner& InAbilityOwner,
             const FGameplayTag& InTagToRemove) -> void;
+        auto UpdatePreviousTags() -> void;
 
     private:
         auto

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -1181,7 +1181,7 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            const FFragment_AbilityOwner_Current& InAbilityOwnerComp) const
+            FFragment_AbilityOwner_Current& InAbilityOwnerComp) const
         -> void
     {
         const auto& ActiveTags = InAbilityOwnerComp.Get_ActiveTags(InHandle);
@@ -1228,6 +1228,7 @@ namespace ck
                 MakePayload(InHandle, PreviousTags, ActiveTags, TagsRemoved, TagsAdded));
         }
 
+        InAbilityOwnerComp.UpdatePreviousTags();
         InHandle.Remove<MarkedDirtyBy>();
     }
 

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
@@ -179,7 +179,7 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            const FFragment_AbilityOwner_Current& InAbilityOwnerComp) const -> void;
+            FFragment_AbilityOwner_Current& InAbilityOwnerComp) const -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
…r instead of immediately on tags changed

*  This prevents issues where tags are updated multiple times between processor calls, which could make it out of sync with whether the tags actually updated between processor calls
   *  This issue could happen if AddTag and RemoveTag are called back-to-back