### PR TITLE
fix: Undefine "max" macro to prevent compiler from getting confused

### DIFF
--- a/Source/CkThirdParty/Public/CkThirdParty/entt-3.12.2/src/entt/container/dense_set.hpp
+++ b/Source/CkThirdParty/Public/CkThirdParty/entt-3.12.2/src/entt/container/dense_set.hpp
@@ -17,6 +17,10 @@
 #include "../core/type_traits.hpp"
 #include "fwd.hpp"
 
+//++Ck
+#undef max
+//--Ck
+
 namespace entt {
 
 /**


### PR DESCRIPTION
*  An unrelated change caused this to be an issue, it's unclear why though
*  Source for fix: https://stackoverflow.com/a/6884102