### PR TITLE
fix: NumDependents in ReplicationDriver were being overridden by the …

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.cpp
@@ -1135,6 +1135,9 @@ auto
         const ck::FFragment_AbilityOwner_Params& InParams)
     -> void
 {
+    if (NOT UCk_Utils_Net_UE::Get_IsEntityNetMode_Host(InHandle))
+    { return; }
+
     if (NOT InHandle.Has<TObjectPtr<UCk_Fragment_EntityReplicationDriver_Rep>>())
     { return; }
 

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
@@ -490,6 +490,10 @@ auto
         int32 InNumOfDependents)
     -> void
 {
+    CK_ENSURE_IF_NOT(GetWorld()->GetNetMode() != NM_Client,
+        TEXT("Setting the ExpectedNumberOfDependentReplicationDrivers is only allowed on the Server.{}"), ck::Context(this))
+    { return; }
+
     _ExpectedNumberOfDependentReplicationDrivers = InNumOfDependents;
     MARK_PROPERTY_DIRTY_FROM_NAME(ThisType, _ExpectedNumberOfDependentReplicationDrivers, this);
 }


### PR DESCRIPTION
…Client, resulting in a discrepency

notes: only the Server should change the NumDependents number. This is now protected by an Ensure.