### PR TITLE
Feature/revoke and transfer client request wait until fully replicated

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.cpp
@@ -332,7 +332,7 @@ auto
             return;
         }
 
-        UCk_Utils_AbilityOwner_UE::Request_TransferExistingAbility(AssociatedEntityAbilityOwner, TransferRequest, {});
+        UCk_Utils_AbilityOwner_UE::Request_TransferExistingAbility_DeferUntilReadyOnClient(AssociatedEntityAbilityOwner, TransferRequest);
     }
     _NextPendingTransferExistingAbilityRequests = _PendingTransferExistingAbilityRequests.Num();
 }
@@ -392,7 +392,19 @@ auto
             return;
         }
 
-        UCk_Utils_AbilityOwner_UE::Request_RevokeAbility(AssociatedEntityAbilityOwner, RevokeAbilityRequest, {});
+        switch (RevokeAbilityRequest.Get_SearchPolicy())
+        {
+            case ECk_AbilityOwner_AbilitySearch_Policy::SearchByClass:
+            {
+                UCk_Utils_AbilityOwner_UE::Request_RevokeAbility(AssociatedEntityAbilityOwner, RevokeAbilityRequest, {});
+                break;
+            }
+            case ECk_AbilityOwner_AbilitySearch_Policy::SearchByHandle:
+            {
+                UCk_Utils_AbilityOwner_UE::Request_RevokeAbility_DeferUntilReadyOnClient(AssociatedEntityAbilityOwner, RevokeAbilityRequest);
+                break;
+            }
+        }
     }
     _NextPendingRevokeAbilityRequests = _PendingRevokeAbilityRequests.Num();
 }

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Fragment.h
@@ -151,6 +151,31 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
+    struct CKABILITY_API FFragment_AbilityOwner_DeferredClientRequests
+    {
+    public:
+        CK_GENERATED_BODY(FFragment_AbilityOwner_Requests);
+
+    public:
+        friend class FProcessor_AbilityOwner_HandleRequests;
+        friend class UCk_Utils_AbilityOwner_UE;
+
+    public:
+        using TransferAbilityRequestType = FCk_Request_AbilityOwner_TransferExistingAbility;
+        using RevokeAbilityRequestType = FCk_Request_AbilityOwner_RevokeAbility;
+
+        using RequestType = std::variant<RevokeAbilityRequestType, TransferAbilityRequestType>;
+        using RequestList = TArray<RequestType>;
+
+    public:
+        RequestList _Requests;
+
+    public:
+        CK_PROPERTY_GET(_Requests);
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     struct CKABILITY_API FFragment_AbilityOwner_Events
     {
     public:

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.h
@@ -52,7 +52,7 @@ namespace ck
         auto ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            const FFragment_AbilityOwner_Params& InAbilityOwnerParams) const -> void;
+            const FFragment_AbilityOwner_Params& InParams) const -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -73,7 +73,7 @@ namespace ck
         static auto ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            FFragment_AbilityOwner_Events&  InAbilityOwnerEvents) -> void;
+            FFragment_AbilityOwner_Events& InAbilityOwnerEvents) -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -96,20 +96,20 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
-            FFragment_AbilityOwner_Requests& InAbilityRequestsComp) const -> void;
+            FFragment_AbilityOwner_Current& InCurrent,
+            FFragment_AbilityOwner_Requests& InRequests) const -> void;
 
     private:
         auto
         DoHandleRequest(
             HandleType& InAbilityOwnerEntity,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Current& InCurrent,
             const FCk_Request_AbilityOwner_AddAndGiveExistingAbility& InRequest) const -> void;
 
         auto
         DoHandleRequest(
             HandleType& InAbilityOwnerEntity,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Current& InCurrent,
             const FCk_Request_AbilityOwner_TransferExistingAbility& InRequest) const -> void;
 
         auto
@@ -121,31 +121,31 @@ namespace ck
         auto
         DoHandleRequest(
             HandleType& InAbilityOwnerEntity,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Current& InCurrent,
             const FCk_Request_AbilityOwner_GiveReplicatedAbility& InRequest) const -> void;
 
         auto
         DoHandleRequest(
             HandleType& InAbilityOwnerEntity,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Current& InCurrent,
             const FCk_Request_AbilityOwner_RevokeAbility& InRequest) const -> void;
 
         auto
         DoHandleRequest(
             HandleType InAbilityOwnerEntity,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Current& InCurrent,
             const FCk_Request_AbilityOwner_ActivateAbility& InRequest) const -> void;
 
         auto
         DoHandleRequest(
             HandleType InAbilityOwnerEntity,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Current& InCurrent,
             const FCk_Request_AbilityOwner_DeactivateAbility& InRequest) const -> void;
 
         auto
         DoHandleRequest(
             HandleType InAbilityOwnerEntity,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp,
+            FFragment_AbilityOwner_Current& InCurrent,
             const FCk_Request_AbilityOwner_CancelSubAbilities& InRequest) const -> void;
 
     private:
@@ -185,7 +185,7 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType& InHandle,
-            FFragment_AbilityOwner_Current& InAbilityOwnerComp) const -> void;
+            FFragment_AbilityOwner_Current& InCurrent) const -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -232,6 +232,44 @@ namespace ck
             TimeType InDeltaT,
             HandleType& InHandle,
             const FTag_AbilityOwner_PendingSubAbilityOperation& InCountedTag) const -> void;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    class CKABILITY_API FProcessor_AbilityOwner_DeferClientRequestUntilReady : public ck_exp::TProcessor<
+            FProcessor_AbilityOwner_DeferClientRequestUntilReady,
+            FCk_Handle_AbilityOwner,
+            FFragment_AbilityOwner_Current,
+            FFragment_AbilityOwner_DeferredClientRequests,
+            CK_IGNORE_PENDING_KILL>
+    {
+    public:
+        using Super = TProcessor;
+        using MarkedDirtyBy = FFragment_AbilityOwner_DeferredClientRequests;
+
+    public:
+        using TProcessor::TProcessor;
+
+    public:
+        auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType& InHandle,
+            FFragment_AbilityOwner_Current& InCurrent,
+            FFragment_AbilityOwner_DeferredClientRequests& InRequests) const -> void;
+
+    private:
+        auto
+        DoHandleRequest(
+            HandleType& InAbilityOwnerEntity,
+            FFragment_AbilityOwner_Current& InCurrent,
+            const FCk_Request_AbilityOwner_TransferExistingAbility& InRequest) const -> void;
+
+        auto
+        DoHandleRequest(
+            HandleType& InAbilityOwnerEntity,
+            FFragment_AbilityOwner_Current& InCurrent,
+            const FCk_Request_AbilityOwner_RevokeAbility& InRequest) const -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Utils.h
@@ -289,6 +289,11 @@ public:
         const FCk_Request_AbilityOwner_TransferExistingAbility& InRequest,
         const FCk_Delegate_AbilityOwner_OnAbilityTransferredOrNot& InDelegate);
 
+    static FCk_Handle_AbilityOwner
+    Request_TransferExistingAbility_DeferUntilReadyOnClient(
+        FCk_Handle_AbilityOwner& InAbilityOwnerHandle,
+        const FCk_Request_AbilityOwner_TransferExistingAbility& InRequest);
+
     UFUNCTION(BlueprintCallable,
               Category = "Ck|BLUEPRINT_INTERNAL_USE_ONLY",
               DisplayName="[Ck][AbilityOwner] Request Transfer Existing Ability (Replicated)",
@@ -329,6 +334,11 @@ public:
         UPARAM(ref) FCk_Handle_AbilityOwner& InAbilityOwnerHandle,
         const FCk_Request_AbilityOwner_RevokeAbility& InRequest,
         const FCk_Delegate_AbilityOwner_OnAbilityRevokedOrNot& InDelegate);
+
+    static FCk_Handle_AbilityOwner
+    Request_RevokeAbility_DeferUntilReadyOnClient(
+        FCk_Handle_AbilityOwner& InAbilityOwnerHandle,
+        const FCk_Request_AbilityOwner_RevokeAbility& InRequest);
 
     UFUNCTION(BlueprintCallable,
               BlueprintAuthorityOnly,

--- a/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbility_ProcessorInjector.cpp
+++ b/Source/CkAbility/Public/CkAbility/ProcessorInjector/CkAbility_ProcessorInjector.cpp
@@ -33,6 +33,7 @@ auto
     InWorld.Add<ck::FProcessor_AbilityOwner_EnsureAllAppended>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_Setup>(InWorld.Get_Registry());
 
+    InWorld.Add<ck::FProcessor_AbilityOwner_DeferClientRequestUntilReady>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_HandleRequests>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_Ability_HandleRequests>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_AbilityOwner_HandleEvents>(InWorld.Get_Registry());


### PR DESCRIPTION
$ git log 1f0da3ae915472d5f936cd390de1eb865c454551..HEAD
commit ec0d5435b7a2b8200a9774f2764ab338f3b4050c (HEAD -> feature/revoke-and-transfer-client-request-wait-until-fully-replicated, origin/feature/revoke-and-transfer-client-request-wait-until-fully-replicated, feature/ability-owner-request-delegate-update)
Author: Nitrogen-CK <nitrogen@chainkemists.com>
Date:   Thu Jan 16 17:29:27 2025 -0500

    fix: Workaround fix for TransferAbility/RevokeAbility replicated requests being handled on the Client before they have all their fragments replicated

    This is a bandaid solution until we implement a systemic fix to this problem. Once the Replicated fragment has a valid entity/entities for the content of these requests, it sends them to a new processor that will check every frame if the content of the request is FULLY replicated (meaning all the fragments of the various relevant entities are there). IFF it is the case will it then forward the request to the regular HandleRequest processor

commit a106842a7b4ac84b7107e944a992605921a68770
Author: Nitrogen-CK <nitrogen@chainkemists.com>
Date:   Thu Jan 16 16:06:44 2025 -0500

    feat: OnRep RevokeAbility/TransferAbility now wait for the relevant handles inside the request to be valid before proceeding with the request

    NOTE: This does NOT ensure that the entity fragments exist. A systemic fix for that will take some time, instead the bandaid solution will include a new set of processors (coming in a another commit)