### PR TITLE
Bugfix/ability status invalid

### DIFF
--- a/Source/CkResolver/Public/ResolverSource/CkResolverSource_Processor.cpp
+++ b/Source/CkResolver/Public/ResolverSource/CkResolverSource_Processor.cpp
@@ -84,7 +84,10 @@ namespace ck
         UUtils_Signal_ResolverSource_OnNewResolverDataBundle::Broadcast(InHandle,
             MakePayload(InHandle, InNewResolution.Get_Causer(), DataBundle));
 
-        UCk_Utils_ResolverTarget_UE::Request_InitiateNewResolution(Target, FCk_Request_ResolverTarget_InitiateNewResolution{DataBundle}, {});
+        if (ck::IsValid(Target))
+        {
+            UCk_Utils_ResolverTarget_UE::Request_InitiateNewResolution(Target, FCk_Request_ResolverTarget_InitiateNewResolution{DataBundle}, {});
+        }
     }
 
     // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
commit 2660d4d738ce5569db327e312a4711a459c4ad22 (HEAD -> bugfix/ability-status-invalid, origin/bugfix/ability-status-invalid)
Author: AlexObatake-CK <phosphorus@chainkemists.com>
Date:   Mon Feb 3 06:39:58 2025 -0800

    fix: Resolver no longer initiates a new resolution on Target if not valid

    *  This can happen if the target becomes pending kill before this is reached
    *  Without this fix, handling the request will ensure

commit e84f314d4061e0ef88f299a007d05f7fbb0fe5a9
Author: AlexObatake-CK <phosphorus@chainkemists.com>
Date:   Mon Feb 3 06:39:45 2025 -0800

    fix: Ability Status now has an Invalid option

    *  Returns Invalid status if the ability handle isn't valid instead of ensuring