### PR TITLE
fix: Console command replicators will now wait until their owner is v…

### DIFF
--- a/Source/CkConsoleCommands/Public/CkConsoleCommands/Subsystem/CkConsoleCommands_Subsystem.cpp
+++ b/Source/CkConsoleCommands/Public/CkConsoleCommands/Subsystem/CkConsoleCommands_Subsystem.cpp
@@ -17,6 +17,7 @@ ACk_ConsoleCommandsHelper_UE::
 {
     bReplicates = true;
     bAlwaysRelevant = true;
+    PrimaryActorTick.bCanEverTick = true;
 }
 
 auto
@@ -29,11 +30,28 @@ auto
     if (IsTemplate())
     { return; }
 
-    if (GetWorld()->GetFirstPlayerController() != GetOwner())
-    { return; }
+    if (ck::Is_NOT_Valid(GetOwner()))
+    {
+        SetActorTickEnabled(true);
+        return;
+    }
+    SetActorTickEnabled(false);
+    CheckOwnerIsFirstController();
+}
 
-    const auto Subsystem = GetWorld()->GetSubsystem<UCk_ConsoleCommands_Subsystem_UE>();
-    Subsystem->_ConsoleCommandsHelper.Emplace(this);
+auto
+    ACk_ConsoleCommandsHelper_UE::
+    Tick(
+        float DeltaTime)
+    -> void
+{
+    Super::Tick(DeltaTime);
+
+    if (ck::IsValid(GetOwner()))
+    {
+        SetActorTickEnabled(false);
+        CheckOwnerIsFirstController();
+    }
 }
 
 auto
@@ -83,6 +101,18 @@ auto
     -> void
 {
     MC_Request_OutputOnAll(InCommandOutput, InNetModeName, InContext);
+}
+
+auto
+    ACk_ConsoleCommandsHelper_UE::
+    CheckOwnerIsFirstController()
+    -> void
+{
+    if (GetWorld()->GetFirstPlayerController() != GetOwner())
+    { return; }
+
+    const auto Subsystem = GetWorld()->GetSubsystem<UCk_ConsoleCommands_Subsystem_UE>();
+    Subsystem->_ConsoleCommandsHelper.Emplace(this);
 }
 
 auto

--- a/Source/CkConsoleCommands/Public/CkConsoleCommands/Subsystem/CkConsoleCommands_Subsystem.h
+++ b/Source/CkConsoleCommands/Public/CkConsoleCommands/Subsystem/CkConsoleCommands_Subsystem.h
@@ -25,6 +25,7 @@ public:
 
 protected:
     auto BeginPlay() -> void override;
+    auto Tick(float DeltaTime) -> void override;
 
 public:
     UFUNCTION(Server, Reliable)
@@ -40,6 +41,8 @@ public:
         const FString&  InCommand);
 
 private:
+    auto CheckOwnerIsFirstController() -> void;
+
     auto RunConsoleCommand(
         const FString& InCommand)
         -> void;


### PR DESCRIPTION
…alid to compare to local player

*  Checks if owner is local player so we only assign one per client, but would check before GetOwner is valid
*  Now checks on tick if GetOwner isn't valid until it becomes valid