### PR TITLE
Bugfix/ability transfer owner fixes

### DIFF
--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -269,10 +269,10 @@ namespace ck
             UCk_Utils_EntityLifetime_UE::Request_TransferLifetimeOwner(AbilityToTransfer, TransferTarget);
 
             const auto& AbilityToTransferCurrent = AbilityToTransfer.Get<FFragment_Ability_Current>();
-            const auto& OwnerAbilityCurrent = InRequest.Get_TransferTarget().Get<FFragment_Ability_Current>();
 
-            AbilityToTransferCurrent.Get_AbilityScript()->_ContextEntityWithActor = OwnerAbilityCurrent.
-                Get_AbilityScript()->DoGet_ContextEntityWithActor();
+            // Get Context Entity with Actor from ownership chain instead of transfer target's ability script since transfer target's ability script may not be initialized yet
+            AbilityToTransferCurrent.Get_AbilityScript()->_ContextEntityWithActor =
+                UCk_Utils_OwningActor_UE::TryGet_Entity_OwningActor_InOwnershipChain(InRequest.Get_TransferTarget());
         }
 
         if (auto MaybeAbilityOwner = UCk_Utils_AbilityOwner_UE::Cast(AbilityToTransfer);


### PR DESCRIPTION
commit 2b385ff4d7a5f694b4fe4e0cfbd5ad6105123810 (HEAD -> bugfix/ability-transfer-owner-fixes, origin/bugfix/ability-transfer-owner-fixes)
Author: AlexObatake-CK <phosphorus@chainkemists.com>
Date:   Wed Feb 26 19:33:12 2025 -0800

    fix: Correctly set context entity with actor and ability owner when transferring ability

    *  There are occasional times when we transfer an existing ability onto an ability that has not been initialized yet, so we can't rely on the transfer target's ability script to have a valid ContextEntityWithActor yet

commit f73d6f28ce7b2fb0b19adc2b83579d231c025bcb
Author: AlexObatake-CK <phosphorus@chainkemists.com>
Date:   Wed Feb 26 19:28:15 2025 -0800

    fix: Cancel and Transfer of abilities only loops through abilities that are lifetime dependents

    *  These functions are meant to cancel and transfer abilities that are direct children, not everything owned by extension
    *  In the case of cancel, this was causing an issue since it was deactivating but sending an ability owner that wasn't the lifetime owner, which causes problems when that ability is moved
    *  This fixes a majority of the incorrect ability owner ensures that happened when after transferring an ability
    *  Rename a function and add a comment about why the transfer processor loops through all subabilities to transfer them to their current owner