### PR TITLE
fix: Abilities now ignore Activate/Deactivate Requests after Revoke

### DIFF
--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Processor.cpp
@@ -437,6 +437,9 @@ namespace ck
             return OwnerToReturn;
         }();
 
+        if (UCk_Utils_Ability_UE::Get_IsAbilityGiven(InHandle) == false)
+        { return; }
+
         // --------------------------------------------------------------------------------------------------------------------
 
         auto& AbilityCurrent = InHandle.Get<ck::FFragment_Ability_Current>();
@@ -589,6 +592,9 @@ namespace ck
             OwnerToReturn.Add<ck::FTag_AbilityOwner_RemovePendingSubAbilityOperation>();
             return OwnerToReturn;
         }();
+
+        if (UCk_Utils_Ability_UE::Get_IsAbilityGiven(InHandle) == false)
+        { return; }
 
         // --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
notes: this fixes issues where there could be pending Activate events in the same frame as a Revoke resulting in ensures firing when trying to Activate an Ability that has already been Revoked. Ideally, we would not add the Request in the first place, but perhaps this is still a good approach especially if this needs to be debugged in the future.