### PR TITLE
feat: ReplicationDriver now defers the Broadcast of ReplicationComplete

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -309,9 +309,9 @@ auto
     QUICK_SCOPE_CYCLE_COUNTER(Request_Create_Entity)
 
     const auto& NewEntity = InRegistry.CreateEntity();
-    InRegistry.Add<ck::FTag_EntityJustCreated>(NewEntity);
 
     auto NewEntityHandle = HandleType{ NewEntity, InRegistry };
+    NewEntityHandle.Add<ck::FTag_EntityJustCreated>();
 
     if (InFunc)
     {
@@ -332,9 +332,9 @@ auto
     QUICK_SCOPE_CYCLE_COUNTER(Request_Create_Entity)
 
     const auto& NewEntity = InRegistry.CreateEntity(InEntityHint.Get_Entity());
-    InRegistry.Add<ck::FTag_EntityJustCreated>(NewEntity);
 
     auto NewEntityHandle = HandleType{ NewEntity, InRegistry };
+    NewEntityHandle.Add<ck::FTag_EntityJustCreated>();
 
     if (InFunc)
     {

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
@@ -457,8 +457,8 @@ auto
 {
     if (_NumSyncedDependentReplicationDrivers == Get_ExpectedNumberOfDependentReplicationDrivers())
     {
-        const auto AssociatedEntity = Get_AssociatedEntity();
-        ck::UUtils_Signal_OnDependentsReplicationComplete::Broadcast(AssociatedEntity, ck::MakePayload(AssociatedEntity));
+        auto AssociatedEntity = Get_AssociatedEntity();
+        AssociatedEntity.Add<ck::FTag_EntityReplicationDriver_FireOnDependentReplicationComplete>();
     }
 }
 
@@ -478,8 +478,8 @@ auto
 
     if (_ExpectedNumberOfDependentReplicationDrivers == _NumSyncedDependentReplicationDrivers)
     {
-        const auto AssociatedEntity = Get_AssociatedEntity();
-        ck::UUtils_Signal_OnDependentsReplicationComplete::Broadcast(AssociatedEntity, ck::MakePayload(AssociatedEntity));
+        auto AssociatedEntity = Get_AssociatedEntity();
+        AssociatedEntity.Add<ck::FTag_EntityReplicationDriver_FireOnDependentReplicationComplete>();
     }
 }
 

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.h
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.h
@@ -32,6 +32,8 @@ class UCk_Utils_EntityReplicationDriver_UE;
 
 namespace ck
 {
+    CK_DEFINE_ECS_TAG(FTag_EntityReplicationDriver_FireOnDependentReplicationComplete);
+
     // --------------------------------------------------------------------------------------------------------------------
 
     struct FFragment_ReplicationDriver_Requests

--- a/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Processor.h
+++ b/Source/CkNet/Public/CkNet/EntityReplicationDriver/CkEntityReplicationDriver_Processor.h
@@ -21,10 +21,33 @@ namespace ck
         using TProcessor::TProcessor;
 
     public:
-        auto ForEachEntity(
+        auto
+        ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             const FCk_Request_EntityScript_Replicate& InRequest) const -> void;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    class CKNET_API FProcessor_ReplicationDriver_FireOnDependentReplicationComplete : public
+        ck_exp::TProcessor<FProcessor_ReplicationDriver_FireOnDependentReplicationComplete,
+            FCk_Handle,
+            FFragment_Signal_OnDependentsReplicationComplete,
+            FTag_EntityReplicationDriver_FireOnDependentReplicationComplete>
+    {
+    public:
+        using MarkedDirtyBy = FTag_EntityReplicationDriver_FireOnDependentReplicationComplete;
+
+    public:
+        using TProcessor::TProcessor;
+
+    public:
+        auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            FFragment_Signal_OnDependentsReplicationComplete&) const -> void;
     };
 }
 

--- a/Source/CkNet/Public/CkNet/ProcessorInjector/CkNetProcessorInjector.cpp
+++ b/Source/CkNet/Public/CkNet/ProcessorInjector/CkNetProcessorInjector.cpp
@@ -25,6 +25,7 @@ auto
     -> void
 {
     InWorld.Add<ck::FProcessor_ReplicationDriver_ReplicateEntityScript>(InWorld.Get_Registry());
+    InWorld.Add<ck::FProcessor_ReplicationDriver_FireOnDependentReplicationComplete>(InWorld.Get_Registry());
 }
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
notes: this has the following advantages/fixes
- EntityScript creation is deferred and now the Broadcast message for ReplicationComplete is fired when the EntityScript has finished construction
- Any Entity that is successfully replicated now has a chance to complete it's setup before the ReplicationComplete is fired