### PR TITLE
fix: Rename build config params to have more uniform names

### DIFF
--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.cpp
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.cpp
@@ -601,7 +601,7 @@ auto
     DoDebugSet_Activated()
     -> void
 {
-#if CK_ENABLE_ABILITY_SCRIPT_DEBUGGING
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
     _ActivateDeactivate = EActivatedDeactivated::Activated;
 #endif
 }
@@ -611,7 +611,7 @@ auto
     DoDebugSet_Deactivated()
     -> void
 {
-#if CK_ENABLE_ABILITY_SCRIPT_DEBUGGING
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
     _ActivateDeactivate = EActivatedDeactivated::Deactivated;
 #endif
 }
@@ -621,7 +621,7 @@ auto
     DoDebugSet_Given()
     -> void
 {
-#if CK_ENABLE_ABILITY_SCRIPT_DEBUGGING
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
     _GiveRevoke = EGivenRevoked::Given;
 #endif
 }
@@ -631,7 +631,7 @@ auto
     DoDebugSet_Revoked()
     -> void
 {
-#if CK_ENABLE_ABILITY_SCRIPT_DEBUGGING
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
     _GiveRevoke = EGivenRevoked::Revoked;
 #endif
 }

--- a/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.h
+++ b/Source/CkAbility/Public/CkAbility/Ability/CkAbility_Script.h
@@ -319,7 +319,7 @@ private:
     mutable TOptional<FCk_Handle> _ContextEntityWithActor;
 
 private:
-#if CK_ENABLE_ABILITY_SCRIPT_DEBUGGING
+#if NOT CK_DISABLE_ABILITY_SCRIPT_DEBUGGING
     enum class EActivatedDeactivated
     {
         None,

--- a/Source/CkBuildConfig/CkBuildConfig.Build.cs
+++ b/Source/CkBuildConfig/CkBuildConfig.Build.cs
@@ -25,92 +25,92 @@ public class CkModuleRules : ModuleRules
                 switch(Target.Configuration)
                 {
                     case UnrealTargetConfiguration.Unknown:
-                        PublicDefinitions.Add("CK_BYPASS_ENSURES=0");
-                        PublicDefinitions.Add("CK_BYPASS_ENSURE_DEBUGGING=0");
-                        PublicDefinitions.Add("CK_LOG_NO_CONTEXT=1");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=0");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=1");
                         PublicDefinitions.Add("CK_DISABLE_STACK_TRACE=0");
-                        PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=1");
-                        PublicDefinitions.Add("CK_MEMORY_TRACKING=0");
-                        PublicDefinitions.Add("CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY=0");
+                        PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=1");
+                        PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=0");
+                        PublicDefinitions.Add("CK_DISABLE_NET_PARAM_COPY_PER_ENTITY=0");
                         PublicDefinitions.Add("CK_DISABLE_STAT_DESCRIPTION=1");
-                        PublicDefinitions.Add("CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS=1");
-                        PublicDefinitions.Add("CK_ENABLE_ABILITY_SCRIPT_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION=1");
+                        PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=0");
                         break;
                     case UnrealTargetConfiguration.Debug:
-                        PublicDefinitions.Add("CK_BYPASS_ENSURES=0");
-                        PublicDefinitions.Add("CK_BYPASS_ENSURE_DEBUGGING=0");
-                        PublicDefinitions.Add("CK_LOG_NO_CONTEXT=0");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=0");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=0");
                         PublicDefinitions.Add("CK_DISABLE_STACK_TRACE=0");
-                        PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=0");
-                        PublicDefinitions.Add("CK_MEMORY_TRACKING=0");
-                        PublicDefinitions.Add("CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY=0");
+                        PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=0");
+                        PublicDefinitions.Add("CK_DISABLE_NET_PARAM_COPY_PER_ENTITY=0");
                         PublicDefinitions.Add("CK_DISABLE_STAT_DESCRIPTION=0");
-                        PublicDefinitions.Add("CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS=0");
-                        PublicDefinitions.Add("CK_ENABLE_ABILITY_SCRIPT_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION=0");
+                        PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=0");
                         break;
                     case UnrealTargetConfiguration.DebugGame:
-                        PublicDefinitions.Add("CK_BYPASS_ENSURES=0");
-                        PublicDefinitions.Add("CK_BYPASS_ENSURE_DEBUGGING=0");
-                        PublicDefinitions.Add("CK_LOG_NO_CONTEXT=0");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=0");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=0");
                         PublicDefinitions.Add("CK_DISABLE_STACK_TRACE=0");
-                        PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=0");
-                        PublicDefinitions.Add("CK_MEMORY_TRACKING=0");
-                        PublicDefinitions.Add("CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY=0");
+                        PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=0");
+                        PublicDefinitions.Add("CK_DISABLE_NET_PARAM_COPY_PER_ENTITY=0");
                         PublicDefinitions.Add("CK_DISABLE_STAT_DESCRIPTION=0");
-                        PublicDefinitions.Add("CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS=0");
-                        PublicDefinitions.Add("CK_ENABLE_ABILITY_SCRIPT_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION=0");
+                        PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=0");
                         break;
                     case UnrealTargetConfiguration.Development:
                         if (Target.bBuildEditor)
                         {
-                            PublicDefinitions.Add("CK_BYPASS_ENSURES=0");
-							PublicDefinitions.Add("CK_BYPASS_ENSURE_DEBUGGING=0");
-                            PublicDefinitions.Add("CK_LOG_NO_CONTEXT=0");
+                            PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=0");
+                            PublicDefinitions.Add("CK_DISABLE_ENSURE_DEBUGGING=0");
+                            PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=0");
                             PublicDefinitions.Add("CK_DISABLE_STACK_TRACE=0");
-                            PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=0");
-                            PublicDefinitions.Add("CK_MEMORY_TRACKING=0");
-                            PublicDefinitions.Add("CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY=0");
+                            PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=0");
+                            PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=0");
+                            PublicDefinitions.Add("CK_DISABLE_NET_PARAM_COPY_PER_ENTITY=0");
                             PublicDefinitions.Add("CK_DISABLE_STAT_DESCRIPTION=0");
-                            PublicDefinitions.Add("CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS=0");
-                            PublicDefinitions.Add("CK_ENABLE_ABILITY_SCRIPT_DEBUGGING=0");
+                            PublicDefinitions.Add("CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION=0");
+                            PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=0");
                         }
                         else
                         {
-                            PublicDefinitions.Add("CK_BYPASS_ENSURES=0");
-							PublicDefinitions.Add("CK_BYPASS_ENSURE_DEBUGGING=0");
-                            PublicDefinitions.Add("CK_LOG_NO_CONTEXT=1");
+                            PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=0");
+                            PublicDefinitions.Add("CK_DISABLE_ENSURE_DEBUGGING=0");
+                            PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=1");
                             PublicDefinitions.Add("CK_DISABLE_STACK_TRACE=0");
-                            PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=1");
-                            PublicDefinitions.Add("CK_MEMORY_TRACKING=0");
-                            PublicDefinitions.Add("CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY=0");
+                            PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=1");
+                            PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=0");
+                            PublicDefinitions.Add("CK_DISABLE_NET_PARAM_COPY_PER_ENTITY=0");
                             PublicDefinitions.Add("CK_DISABLE_STAT_DESCRIPTION=0");
-                            PublicDefinitions.Add("CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS=1");
-                            PublicDefinitions.Add("CK_ENABLE_ABILITY_SCRIPT_DEBUGGING=1");
+                            PublicDefinitions.Add("CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION=1");
+                            PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=1");
                         }
                         break;
                     case UnrealTargetConfiguration.Test:
-                        PublicDefinitions.Add("CK_BYPASS_ENSURES=0");
-                        PublicDefinitions.Add("CK_BYPASS_ENSURE_DEBUGGING=1");
-                        PublicDefinitions.Add("CK_LOG_NO_CONTEXT=1");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=0");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_DEBUGGING=1");
+                        PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=1");
                         PublicDefinitions.Add("CK_DISABLE_STACK_TRACE=1");
-                        PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=1");
-                        PublicDefinitions.Add("CK_MEMORY_TRACKING=0");
-                        PublicDefinitions.Add("CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY=0");
+                        PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=1");
+                        PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=0");
+                        PublicDefinitions.Add("CK_DISABLE_NET_PARAM_COPY_PER_ENTITY=0");
                         PublicDefinitions.Add("CK_DISABLE_STAT_DESCRIPTION=1");
-                        PublicDefinitions.Add("CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS=1");
-                        PublicDefinitions.Add("CK_ENABLE_ABILITY_SCRIPT_DEBUGGING=1");
+                        PublicDefinitions.Add("CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION=1");
+                        PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=1");
                         break;
                     case UnrealTargetConfiguration.Shipping:
-                        PublicDefinitions.Add("CK_BYPASS_ENSURES=1");
-                        PublicDefinitions.Add("CK_BYPASS_ENSURE_DEBUGGING=0");
-                        PublicDefinitions.Add("CK_LOG_NO_CONTEXT=1");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=1");
+                        PublicDefinitions.Add("CK_DISABLE_ENSURE_DEBUGGING=0");
+                        PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=1");
                         PublicDefinitions.Add("CK_DISABLE_STACK_TRACE=1");
-                        PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=1");
-                        PublicDefinitions.Add("CK_MEMORY_TRACKING=0");
-                        PublicDefinitions.Add("CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY=0");
+                        PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=1");
+                        PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=0");
+                        PublicDefinitions.Add("CK_DISABLE_NET_PARAM_COPY_PER_ENTITY=0");
                         PublicDefinitions.Add("CK_DISABLE_STAT_DESCRIPTION=1");
-                        PublicDefinitions.Add("CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS=1");
-                        PublicDefinitions.Add("CK_ENABLE_ABILITY_SCRIPT_DEBUGGING=1");
+                        PublicDefinitions.Add("CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION=1");
+                        PublicDefinitions.Add("CK_DISABLE_ABILITY_SCRIPT_DEBUGGING=1");
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
@@ -119,10 +119,10 @@ public class CkModuleRules : ModuleRules
             }
             // ReSharper disable once UnreachableSwitchCaseDueToIntegerAnalysis
             case BuildConfiguration.Profile:
-                PublicDefinitions.Add("CK_LOG_NO_CONTEXT=1");
-                PublicDefinitions.Add("CK_BYPASS_ENSURES=1");
-                PublicDefinitions.Add("CK_MEMORY_TRACKING=1");
-                PublicDefinitions.Add("CK_ECS_DISABLE_HANDLE_DEBUGGING=1");
+                PublicDefinitions.Add("CK_DISABLE_LOG_CONTEXT=1");
+                PublicDefinitions.Add("CK_DISABLE_ENSURE_CHECKS=1");
+                PublicDefinitions.Add("CK_ENABLE_MEMORY_TRACKING=1");
+                PublicDefinitions.Add("CK_DISABLE_ECS_HANDLE_DEBUGGING=1");
                 break;
             default:
                 throw new ArgumentOutOfRangeException();

--- a/Source/CkCore/Public/CkCore/Ensure/CkEnsure.h
+++ b/Source/CkCore/Public/CkCore/Ensure/CkEnsure.h
@@ -396,10 +396,10 @@ public:
     return ReturnResult;                                                                                                                   \
 }()
 
-#if CK_BYPASS_ENSURES
+#if CK_DISABLE_ENSURE_CHECKS
 #define CK_ENSURE_IF_NOT(InExpression, InFormat, ...)\
 if constexpr(false)
-#elif CK_BYPASS_ENSURE_DEBUGGING
+#elif CK_DISABLE_ENSURE_DEBUGGING
 #define CK_ENSURE_IF_NOT(InExpression, InFormat, ...)\
 if (NOT InExpression)
 #else

--- a/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.h
+++ b/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.h
@@ -174,7 +174,7 @@ CK_DEFINE_CUSTOM_FORMATTER(FNativeGameplayTag, [&]()
     return ck::Format(TEXT("{}"), InObj.GetTag());
 });
 
-#if CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS
+#if CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION
 CK_DEFINE_CUSTOM_FORMATTER(FGameplayTag, [&]()
 {
     if (ck::IsValid(InObj))

--- a/Source/CkCore/Public/CkCore/Validation/CkIsValid_Defaults.h
+++ b/Source/CkCore/Public/CkCore/Validation/CkIsValid_Defaults.h
@@ -134,7 +134,7 @@ CK_DEFINE_CUSTOM_IS_VALID(FNativeGameplayTag, ck::IsValid_Policy_Default, [=](co
     return ck::IsValid(InGameplayTag.GetTag());
 });
 
-#if CK_SKIP_VALIDATE_GAMEPLAYTAG_STALENESS
+#if CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION
 CK_DEFINE_CUSTOM_IS_VALID(FGameplayTag, ck::IsValid_Policy_Default, [=](const FGameplayTag& InGameplayTag)
 {
     return InGameplayTag.IsValid();

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -398,7 +398,7 @@ auto
 
     InNewEntity.Add<ck::FFragment_LifetimeOwner>(InLifetimeOwner);
 
-#if NOT CK_NO_COPY_NET_PARAMS_ON_EVERY_ENTITY
+#if NOT CK_DISABLE_NET_PARAM_COPY_PER_ENTITY
     if (NOT Get_IsTransientEntity(InLifetimeOwner) && InLifetimeOwner.Has<ck::FFragment_Net_Params>())
     {
         const auto& ConnectionSettings = InLifetimeOwner.Get<ck::FFragment_Net_Params>().Get_ConnectionSettings();

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
@@ -17,7 +17,7 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
 
 auto
     DEBUG_NAME::DoSet_DebugName(
@@ -112,7 +112,7 @@ FCk_Handle::
     : _Entity(std::move(InOther._Entity))
     , _Registry(std::move(InOther._Registry))
     , _ReplicationDriver(std::move(InOther._ReplicationDriver))
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     , _Mapper(std::move(InOther._Mapper))
 #endif
 #if WITH_EDITORONLY_DATA
@@ -128,7 +128,7 @@ FCk_Handle::
     : _Entity(InOther._Entity)
     , _Registry(InOther._Registry)
     , _ReplicationDriver(InOther._ReplicationDriver)
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     , _Mapper(InOther._Mapper)
 #endif
 #if WITH_EDITORONLY_DATA
@@ -150,7 +150,7 @@ auto
 FCk_Handle::
     ~FCk_Handle()
 {
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     _Mapper = nullptr;
     _ReplicationDriver = nullptr;
 #endif
@@ -164,7 +164,7 @@ auto
     ::Swap(_Entity, InOther._Entity);
     ::Swap(_Registry, InOther._Registry);
     ::Swap(_ReplicationDriver, InOther._ReplicationDriver);
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     ::Swap(_Mapper, InOther._Mapper);
 #endif
 #if WITH_EDITORONLY_DATA
@@ -294,7 +294,7 @@ auto
     if (NOT IsValid(ck::IsValid_Policy_IncludePendingKill{}))
     { return; }
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     if (ck::Is_NOT_Valid(_Mapper, ck::IsValid_Policy_NullptrOnly{}))
     { _Mapper = &_Registry->AddOrGet<FEntity_FragmentMapper>(_Entity); }
 
@@ -322,7 +322,7 @@ auto
     Get_DebugName() const
     -> FName
 {
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     if (NOT IsValid(ck::IsValid_Policy_IncludePendingKill{}))
     {
         if (NOT ck::IsValid(_Registry))

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -52,7 +52,7 @@ namespace ck
 
 // --------------------------------------------------------------------------------------------------------------------
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -293,7 +293,7 @@ private:
     UPROPERTY()
     TWeakObjectPtr<class UCk_Ecs_ReplicatedObject_UE> _ReplicationDriver;
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     const struct FEntity_FragmentMapper* _Mapper = nullptr;
 #endif
 
@@ -499,7 +499,7 @@ FCk_Handle::
     : _Entity(InOther._Entity)
     , _Registry(InOther._Registry)
     , _ReplicationDriver(InOther._ReplicationDriver)
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     , _Mapper(InOther._Mapper)
 #endif
 #if WITH_EDITORONLY_DATA
@@ -901,7 +901,7 @@ auto
     { return; }
 
     // we need to do this to allow Entity debugging to properly clear the debug mapping
-#if CK_ECS_DISABLE_HANDLE_DEBUGGING == 0
+#if CK_DISABLE_ECS_HANDLE_DEBUGGING == 0
     (DoClear<T_Fragments>(), ...);
 #endif
     _Registry->Clear<T_Fragments...>();
@@ -1097,7 +1097,7 @@ auto
     if (UCk_Utils_Ecs_Settings_UE::Get_HandleDebuggerBehavior() == ECk_Ecs_HandleDebuggerBehavior::Disable)
     { return; }
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     _Mapper = &_Registry->AddOrGet<FEntity_FragmentMapper>(_Entity);
     _Mapper->Add_FragmentInfo<T_Fragment>(*this);
 #endif
@@ -1112,7 +1112,7 @@ auto
     if (UCk_Utils_Ecs_Settings_UE::Get_HandleDebuggerBehavior() == ECk_Ecs_HandleDebuggerBehavior::Disable)
     { return; }
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     _Mapper = &_Registry->AddOrGet<FEntity_FragmentMapper>(_Entity);
     _Mapper->Remove_FragmentInfo<T_Fragment>();
 #endif
@@ -1127,7 +1127,7 @@ auto
     Add_FragmentInfo(const FCk_Handle& InHandle) const
     -> void
 {
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     const auto FragmentInfo = [&]() -> DebugWrapperPtrType
     {
         if constexpr (std::is_empty_v<T_Fragment>)

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_Utils.cpp
@@ -87,7 +87,7 @@ auto
 {
     QUICK_SCOPE_CYCLE_COUNTER(Set_DebugName)
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
     if (NOT InHandle.Has<DEBUG_NAME>())
     {
         InHandle.Add<DEBUG_NAME>(InDebugName);
@@ -108,7 +108,7 @@ auto
         const FCk_Handle& InHandle)
     -> FName
 {
-#if CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if CK_DISABLE_ECS_HANDLE_DEBUGGING
     return {};
 #else
     if (NOT InHandle.Has<DEBUG_NAME>())

--- a/Source/CkEcs/Public/CkEcs/ProcessorInjector/CkEcsProcessorInjector.cpp
+++ b/Source/CkEcs/Public/CkEcs/ProcessorInjector/CkEcsProcessorInjector.cpp
@@ -30,7 +30,7 @@ auto
     InWorld.Add<ck::FProcessor_EntityLifetime_DestroyEntity>(InWorld.Get_Registry());
     InWorld.Add<ck::FProcessor_EntityLifetime_DestructionPhase_InitiateConfirm>(InWorld.Get_Registry());
 
-#if CK_MEMORY_TRACKING
+#if CK_ENABLE_MEMORY_TRACKING
     InWorld.Add<ck::FProcessor_Memory_Stats>();
 #endif
 }

--- a/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
+++ b/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
@@ -69,7 +69,7 @@ public:
 public:
     using EntityType = FCk_Entity;
 
-#if CK_MEMORY_TRACKING
+#if CK_ENABLE_MEMORY_TRACKING
     // TODO: Replace 'std::allocator' with custom one when it is created
     using InternalRegistryType = entt::basic_registry<EntityType::IdType, std::allocator<EntityType::IdType>>;
 #else

--- a/Source/CkEcs/Public/CkEcs/Ticker/CkTicker.h
+++ b/Source/CkEcs/Public/CkEcs/Ticker/CkTicker.h
@@ -79,7 +79,7 @@ namespace ck
     private:
         RegistryType _ProcessorsRegistry;
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
         TArray<FCk_Handle> _EntitiesToTick;
 #endif
     };
@@ -110,7 +110,7 @@ namespace ck
         });
 
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
         _EntitiesToTick.Emplace(NewEntity);
 #endif
         return NewEntity;
@@ -130,7 +130,7 @@ namespace ck
 
         DoSortTickable<TickableType>();
 
-#if NOT CK_ECS_DISABLE_HANDLE_DEBUGGING
+#if NOT CK_DISABLE_ECS_HANDLE_DEBUGGING
         _EntitiesToTick.Emplace(NewEntity);
 #endif
 

--- a/Source/CkLog/Public/CkLog/CkLog_Utils.cpp
+++ b/Source/CkLog/Public/CkLog/CkLog_Utils.cpp
@@ -483,7 +483,7 @@ auto
     }
 
     // logging the context can be expensive and can optionally be turned off
-#if CK_LOG_NO_CONTEXT
+#if CK_DISABLE_LOG_CONTEXT
     const auto& Formatted = InMsg.ToString();
 #else
     const auto& BpContext = ck::log::Get_BlueprintContext();

--- a/Source/CkMemory/Public/CkMemory/Allocator/CkMemoryAllocator.h
+++ b/Source/CkMemory/Public/CkMemory/Allocator/CkMemoryAllocator.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#ifndef CK_MEMORY_TRACKING
+#ifndef CK_ENABLE_MEMORY_TRACKING
 // Track allocations when stats are available to display it.
-#define CK_MEMORY_TRACKING STATS
+#define CK_ENABLE_MEMORY_TRACKING STATS
 #endif
 
-#if CK_MEMORY_TRACKING
+#if CK_ENABLE_MEMORY_TRACKING
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkMemory/Public/CkMemory/CkMemory_Processor.cpp
+++ b/Source/CkMemory/Public/CkMemory/CkMemory_Processor.cpp
@@ -1,6 +1,6 @@
 #include "CkMemory_Processor.h"
 
-#if CK_MEMORY_TRACKING
+#if CK_ENABLE_MEMORY_TRACKING
 
 #include <CoreMinimal.h>
 

--- a/Source/CkMemory/Public/CkMemory/CkMemory_Processor.h
+++ b/Source/CkMemory/Public/CkMemory/CkMemory_Processor.h
@@ -2,7 +2,7 @@
 
 #include "Allocator/CkMemoryAllocator.h"
 
-#if CK_MEMORY_TRACKING
+#if CK_ENABLE_MEMORY_TRACKING
 
 #include "CkCore/Time/CkTime.h"
 


### PR DESCRIPTION
*  Names now use enable or disable as a prefix
*  CK_ENABLE_ABILITY_SCRIPT_DEBUGGING inverted so it's enabled in debug and disabled in shipping