### PR TITLE
fix: Transform SyncFromActor and SyncFromMeshSocket processors now ma…

### DIFF
--- a/Source/CkEcsExt/Public/CkEcsExt/SceneNode/CkSceneNode_Processor.cpp
+++ b/Source/CkEcsExt/Public/CkEcsExt/SceneNode/CkSceneNode_Processor.cpp
@@ -53,10 +53,10 @@ namespace ck
             FFragment_Transform_MeshSocket&)
         -> void
     {
-        const auto& Transform = UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentTransform(InParent.Get_Entity());
+        const auto& ParentTransform = UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentTransform(InParent.Get_Entity());
         const auto& MyTransform = UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentTransform(InHandle);
 
-        InCurrent._RelativeTransform = MyTransform.GetRelativeTransform(Transform);
+        InCurrent._RelativeTransform = MyTransform.GetRelativeTransform(ParentTransform);
     }
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -78,10 +78,11 @@ namespace ck
             const FFragment_SceneNode_Current& InCurrent)
         -> void
     {
-        const auto& Transform = UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentTransform(InParent.Get_Entity());
+        const auto& ParentTransform = UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentTransform(InParent.Get_Entity());
+        const auto NewTransform = InCurrent.Get_RelativeTransform() * ParentTransform;
 
         UCk_Utils_Transform_TypeUnsafe_UE::Request_SetTransform(InHandle,
-            FCk_Request_Transform_SetTransform{InCurrent.Get_RelativeTransform() * Transform});
+            FCk_Request_Transform_SetTransform{NewTransform});
     }
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Fragment.cpp
+++ b/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Fragment.cpp
@@ -61,65 +61,74 @@ auto
     UCk_Fragment_Transform_Rep::
     OnRep_Location() -> void
 {
-    CK_REP_OBJ_EXECUTE_IF_VALID([&]()
+    if (ck::Is_NOT_Valid(Get_AssociatedEntity()))
+    { return; }
+
+    CK_ENSURE_VALID_UNREAL_WORLD_IF_NOT(this)
+    { return; }
+
+    auto HandleTransform = UCk_Utils_Transform_UE::CastChecked(_AssociatedEntity);
+    const auto& CurrentLocation = UCk_Utils_Transform_UE::Get_EntityCurrentLocation(HandleTransform);
+
+    if (UCk_Utils_TransformInterpolation_UE::Has(HandleTransform))
     {
-        auto HandleTransform = UCk_Utils_Transform_UE::CastChecked(_AssociatedEntity);
-        const auto& CurrentLocation = UCk_Utils_Transform_UE::Get_EntityCurrentLocation(HandleTransform);
+        auto HandleTransformInterpolation = UCk_Utils_TransformInterpolation_UE::CastChecked(_AssociatedEntity);
+        UCk_Utils_TransformInterpolation_UE::Request_SetInterpolationGoal_LocationOffset
+        (
+            HandleTransformInterpolation,
+            _Location - CurrentLocation
+        );
+        return;
+    }
 
-        if (UCk_Utils_TransformInterpolation_UE::Has(HandleTransform))
-        {
-            auto HandleTransformInterpolation = UCk_Utils_TransformInterpolation_UE::CastChecked(_AssociatedEntity);
-            UCk_Utils_TransformInterpolation_UE::Request_SetInterpolationGoal_LocationOffset
-            (
-                HandleTransformInterpolation,
-                _Location - CurrentLocation
-            );
-            return;
-        }
-
-        UCk_Utils_Transform_UE::Request_SetLocation(
-            HandleTransform, FCk_Request_Transform_SetLocation{_Location});
-    });
+    UCk_Utils_Transform_UE::Request_SetLocation(
+        HandleTransform, FCk_Request_Transform_SetLocation{_Location});
 }
 
 auto
     UCk_Fragment_Transform_Rep::
     OnRep_Rotation() -> void
 {
-    CK_REP_OBJ_EXECUTE_IF_VALID([&]()
+    if (ck::Is_NOT_Valid(Get_AssociatedEntity()))
+    { return; }
+
+    CK_ENSURE_VALID_UNREAL_WORLD_IF_NOT(this)
+    { return; }
+
+    auto HandleTransform = UCk_Utils_Transform_UE::CastChecked(_AssociatedEntity);
+    const auto& CurrentRotation = UCk_Utils_Transform_UE::Get_EntityCurrentRotation(HandleTransform);
+
+    if (UCk_Utils_TransformInterpolation_UE::Has(HandleTransform))
     {
-        auto HandleTransform = UCk_Utils_Transform_UE::CastChecked(_AssociatedEntity);
-        const auto& CurrentRotation = UCk_Utils_Transform_UE::Get_EntityCurrentRotation(HandleTransform);
+        auto HandleTransformInterpolation = UCk_Utils_TransformInterpolation_UE::CastChecked(_AssociatedEntity);
+        UCk_Utils_TransformInterpolation_UE::Request_SetInterpolationGoal_RotationOffset
+        (
+            HandleTransformInterpolation,
+            _Rotation.Rotator() - CurrentRotation
+        );
 
-        if (UCk_Utils_TransformInterpolation_UE::Has(HandleTransform))
-        {
-            auto HandleTransformInterpolation = UCk_Utils_TransformInterpolation_UE::CastChecked(_AssociatedEntity);
-            UCk_Utils_TransformInterpolation_UE::Request_SetInterpolationGoal_RotationOffset
-            (
-                HandleTransformInterpolation,
-                _Rotation.Rotator() - CurrentRotation
-            );
+        return;
+    }
 
-            return;
-        }
-
-        UCk_Utils_Transform_UE::Request_SetRotation(HandleTransform, FCk_Request_Transform_SetRotation{_Rotation.Rotator()});
-    });
+    UCk_Utils_Transform_UE::Request_SetRotation(HandleTransform, FCk_Request_Transform_SetRotation{_Rotation.Rotator()});
 }
 
 auto
     UCk_Fragment_Transform_Rep::
     OnRep_Scale() -> void
 {
-    CK_REP_OBJ_EXECUTE_IF_VALID([&]()
-    {
-        auto HandleTransform = UCk_Utils_Transform_UE::CastChecked(_AssociatedEntity);
-        UCk_Utils_Transform_UE::Request_SetScale
-        (
-            HandleTransform,
-            FCk_Request_Transform_SetScale{_Scale}.Set_LocalWorld(ECk_LocalWorld::World)
-        );
-    });
+    if (ck::Is_NOT_Valid(Get_AssociatedEntity()))
+    { return; }
+
+    CK_ENSURE_VALID_UNREAL_WORLD_IF_NOT(this)
+    { return; }
+
+    auto HandleTransform = UCk_Utils_Transform_UE::CastChecked(_AssociatedEntity);
+    UCk_Utils_Transform_UE::Request_SetScale
+    (
+        HandleTransform,
+        FCk_Request_Transform_SetScale{_Scale}.Set_LocalWorld(ECk_LocalWorld::World)
+    );
 }
 
 auto

--- a/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Processor.h
+++ b/Source/CkEcsExt/Public/CkEcsExt/Transform/CkTransform_Processor.h
@@ -28,12 +28,12 @@ namespace ck
         using TProcessor::TProcessor;
 
     public:
-        auto
+        static auto
         ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             FFragment_Transform& InTransform,
-            const FFragment_Transform_RootComponent& InTransformRootComp) const -> void;
+            const FFragment_Transform_RootComponent& InTransformRootComp) -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -52,12 +52,12 @@ namespace ck
         using TProcessor::TProcessor;
 
     public:
-        auto
+        static auto
         ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             FFragment_Transform& InTransform,
-            const FFragment_Transform_MeshSocket& InSocket) const -> void;
+            const FFragment_Transform_MeshSocket& InSocket) -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -80,34 +80,40 @@ namespace ck
             TimeType InDeltaT) -> void;
 
     public:
-        auto ForEachEntity(
+        auto
+        ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             FFragment_Transform& InComp,
             FFragment_Transform_Requests& InRequestsComp) const -> void;
 
     private:
-        static auto DoHandleRequest(
+        static auto
+        DoHandleRequest(
             HandleType InHandle,
             FFragment_Transform& InComp,
             const FCk_Request_Transform_SetLocation& InRequest) -> void;
 
-        static auto DoHandleRequest(
+        static auto
+        DoHandleRequest(
             HandleType InHandle,
             FFragment_Transform& InComp,
             const FCk_Request_Transform_AddLocationOffset& InRequest) -> void;
 
-        static auto DoHandleRequest(
+        static auto
+        DoHandleRequest(
             HandleType InHandle,
             FFragment_Transform& InComp,
             const FCk_Request_Transform_SetRotation& InRequest) -> void;
 
-        static auto DoHandleRequest(
+        static auto
+        DoHandleRequest(
             HandleType InHandle,
             FFragment_Transform& InComp,
             const FCk_Request_Transform_AddRotationOffset& InRequest) -> void;
 
-        static auto DoHandleRequest(
+        static auto
+        DoHandleRequest(
             HandleType InHandle,
             FFragment_Transform& InComp,
             const FCk_Request_Transform_SetScale& InRequest) -> void;
@@ -130,11 +136,12 @@ namespace ck
         using TProcessor::TProcessor;
 
     public:
-        auto ForEachEntity(
+        static auto
+        ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             const FFragment_Transform_RootComponent& InTransformRootComp,
-            const FFragment_Transform& InComp) const -> void;
+            const FFragment_Transform& InComp) -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -192,11 +199,12 @@ namespace ck
         using TProcessor::TProcessor;
 
     public:
-        auto ForEachEntity(
+        static auto
+        ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             FFragment_Transform& InCurrent,
-            const TObjectPtr<UCk_Fragment_Transform_Rep>& InComp) const -> void;
+            const TObjectPtr<UCk_Fragment_Transform_Rep>& InComp) -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -216,12 +224,13 @@ namespace ck
         using TProcessor::TProcessor;
 
     public:
-        auto ForEachEntity(
+        static auto
+        ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             const FFragment_TransformInterpolation_Params& InParams,
             const FFragment_Transform& InCurrent,
-            FFragment_TransformInterpolation_NewGoal_Location& InGoal) const -> void;
+            FFragment_TransformInterpolation_NewGoal_Location& InGoal) -> void;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -241,12 +250,13 @@ namespace ck
         using TProcessor::TProcessor;
 
     public:
-        auto ForEachEntity(
+        static auto
+        ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
             const FFragment_TransformInterpolation_Params& InParams,
             const FFragment_Transform& InCurrent,
-            FFragment_TransformInterpolation_NewGoal_Rotation& InGoal) const -> void;
+            FFragment_TransformInterpolation_NewGoal_Rotation& InGoal) -> void;
     };
 }
 


### PR DESCRIPTION
…ke a proper Transform request instead of modifying the transform value inside the fragment

The replication processor only invokes the OnRep for Scale/Location/Rotation if the component of the transform was modified. By bypassing the request processor, the value of the transform is modified in the fragment correctly, but the ComponentsModified bitmask is not