### PR TITLE
fix: Separate declaration and definition of CkFormat macros

### DIFF
--- a/Source/CkAnimation/Public/CkAnimation/AnimPlan/CkAnimPlan_Fragment_Data.h
+++ b/Source/CkAnimation/Public/CkAnimation/AnimPlan/CkAnimPlan_Fragment_Data.h
@@ -106,7 +106,7 @@ public:
 
 auto CKANIMATION_API GetTypeHash(const FCk_AnimPlan_Goal& InObj) -> uint32;
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_AnimPlan_Goal, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_AnimPlan_Goal, [](const FCk_AnimPlan_Goal& InObj)
 {
     return ck::Format(TEXT("Goal: {}"), InObj.Get_AnimGoal());
 });
@@ -144,7 +144,7 @@ public:
 
 auto CKANIMATION_API GetTypeHash(const FCk_AnimPlan_Cluster& InObj) -> uint32;
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_AnimPlan_Cluster, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_AnimPlan_Cluster, [](const FCk_AnimPlan_Cluster& InObj)
 {
     return ck::Format(TEXT("Goal: {} | Cluster: {}"), InObj.Get_AnimGoal(), InObj.Get_AnimCluster());
 });
@@ -187,7 +187,7 @@ public:
 
 auto CKANIMATION_API GetTypeHash(const FCk_AnimPlan_State& InObj) -> uint32;
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_AnimPlan_State, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_AnimPlan_State, [](const FCk_AnimPlan_State& InObj)
 {
     return ck::Format(TEXT("Goal: {} | Cluster: {} | State: {}"), InObj.Get_AnimGoal(), InObj.Get_AnimCluster(), InObj.Get_AnimState());
 });

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment.h
@@ -228,7 +228,7 @@ public:
     CK_DEFINE_CONSTRUCTORS(FCk_Fragment_ByteAttribute_BaseFinal, _AttributeName, _Base, _Final, _Component);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Fragment_ByteAttribute_BaseFinal, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Fragment_ByteAttribute_BaseFinal, [](const FCk_Fragment_ByteAttribute_BaseFinal& InObj)
 {
     return ck::Format
     (

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment.h
@@ -229,7 +229,7 @@ public:
     CK_DEFINE_CONSTRUCTORS(FCk_Fragment_FloatAttribute_BaseFinal, _AttributeName, _Base, _Final, _Component);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Fragment_FloatAttribute_BaseFinal, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Fragment_FloatAttribute_BaseFinal, [](const FCk_Fragment_FloatAttribute_BaseFinal& InObj)
 {
     return ck::Format
     (

--- a/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment.h
@@ -254,7 +254,7 @@ public:
     CK_DEFINE_CONSTRUCTORS(FCk_Fragment_VectorAttribute_BaseFinal, _AttributeName, _Base, _Final, _Component);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Fragment_VectorAttribute_BaseFinal, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Fragment_VectorAttribute_BaseFinal, [](const FCk_Fragment_VectorAttribute_BaseFinal& InObj)
 {
     return ck::Format
     (

--- a/Source/CkCore/Public/CkCore/Chrono/CkChrono.h
+++ b/Source/CkCore/Public/CkCore/Chrono/CkChrono.h
@@ -80,7 +80,7 @@ public:
     CK_PROPERTY_GET(_GoalValue);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Chrono, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Chrono, [](const FCk_Chrono& InObj)
 {
     return ck::Format
     (

--- a/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.cpp
+++ b/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.cpp
@@ -1,0 +1,313 @@
+﻿#include "CkFormat_Defaults.h"
+
+#include "ctti/type_id.hpp"
+
+#include <NativeGameplayTags.h>
+
+// --------------------------------------------------------------------------------------------------------------------
+
+CK_DEFINE_CUSTOM_FORMATTER(FName, [](const FName& InObj) { return InObj.ToString(); });
+CK_DEFINE_CUSTOM_FORMATTER(FText, [](const FText& InObj) { return InObj.ToString(); });
+CK_DEFINE_CUSTOM_FORMATTER(FGuid, [](const FGuid& InObj) { return InObj.ToString(); });
+CK_DEFINE_CUSTOM_FORMATTER(FNetworkGUID, [](const FNetworkGUID& InObj) { return InObj.ToString(); });
+CK_DEFINE_CUSTOM_FORMATTER(FKey, [](const FKey& InObj) { return InObj.ToString(); });
+CK_DEFINE_CUSTOM_FORMATTER(FInputChord, [](const FInputChord& InObj) { return InObj.GetInputText().ToString(); });
+CK_DEFINE_CUSTOM_FORMATTER(FSoftObjectPath, [](const FSoftObjectPath& InObj) { return InObj.GetAssetName(); });
+CK_DEFINE_CUSTOM_FORMATTER(FSoftClassPath, [](const FSoftClassPath& InObj) { return InObj.GetAssetName(); });
+
+CK_DEFINE_CUSTOM_FORMATTER(FRandomStream, [](const FRandomStream& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("Initial Seed: [{}], Current Seed: [{}]"),
+        InObj.GetInitialSeed(),
+        InObj.GetCurrentSeed()
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FRotator, [](const FRotator& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("P{:.2f}, Y:{:.2f}, R:{:.2f}"),
+        InObj.Pitch,
+        InObj.Yaw,
+        InObj.Roll
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FVector, [](const FVector& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("X:{:.2f}, Y:{:.2f}, Z:{:.2f}"),
+        InObj.X,
+        InObj.Y,
+        InObj.Z
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FVector2D, [](const FVector2D& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("X:{:.2f}, Y:{:.2f}"),
+        InObj.X,
+        InObj.Y
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FIntVector, [](const FIntVector& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("X:{}, Y:{}, Z:{}"),
+        InObj.X,
+        InObj.Y,
+        InObj.Z
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FIntVector2, [](const FIntVector2& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("X:{}, Y:{}"),
+        InObj.X,
+        InObj.Y
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FIntVector4, [](const FIntVector4& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("X:{}, Y:{}, Z:{}, W:{}"),
+        InObj.X,
+        InObj.Y,
+        InObj.Z,
+        InObj.W
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FQuat, [](const FQuat& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("X:{:.2f}, Y:{:.2f}, Z:{:.2f}, W:{:.2f}"),
+        InObj.X,
+        InObj.Y,
+        InObj.Z,
+        InObj.W
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FBox, [](const FBox& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("Min:{}, Max:{}, IsValid:{}"),
+        InObj.Min,
+        InObj.Max,
+        InObj.IsValid
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FBox2D, [](const FBox2D& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("Min:{}, Max:{}, IsValid:{}"),
+        InObj.Min,
+        InObj.Max,
+        InObj.bIsValid
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FTransform, [](const FTransform& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("T:[{}] R:[{}] S:[{}]"),
+        InObj.GetTranslation(),
+        InObj.GetRotation(),
+        InObj.GetScale3D()
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FTimespan, [](const FTimespan& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("Days:[{}] Hours:[{}] Minutes:[{}] Seconds:[{}]"),
+        InObj.GetDays(),
+        InObj.GetHours(),
+        InObj.GetMinutes(),
+        InObj.GetSeconds()
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FNativeGameplayTag, [](const FNativeGameplayTag& InObj)
+{
+    return ck::Format_UE(TEXT("{}"), InObj.GetTag());
+});
+
+#if CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION
+CK_DEFINE_CUSTOM_FORMATTER(FGameplayTag, [](const FGameplayTag& InObj)
+{
+    if (ck::IsValid(InObj))
+    {
+        return ck::Format_UE(TEXT("{}"), InObj.ToString());
+    }
+
+    return ck::Format_UE(TEXT("TAG_NOT_SET"));
+});
+#else
+CK_DEFINE_CUSTOM_FORMATTER(FGameplayTag, [](const FGameplayTag& InObj)
+{
+    if (ck::IsValid(InObj))
+    {
+        return ck::Format_UE(TEXT("{}"), InObj.ToString());
+    }
+
+    if (InObj.GetTagName() != NAME_None)
+    {
+        return ck::Format_UE(TEXT("{}[STALE]"), InObj.ToString());
+    }
+
+    return ck::Format_UE(TEXT("TAG_NOT_SET"));
+});
+#endif
+
+CK_DEFINE_CUSTOM_FORMATTER(FGameplayTagContainer, [](const FGameplayTagContainer& InObj)
+{
+    if (ck::IsValid(InObj))
+    {
+        return ck::Format_UE(TEXT("{}"), InObj.ToString());
+    }
+
+    return ck::Format_UE(TEXT("TAG_CONTAINER_NOT_SET"));
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FAssetData, [](const FAssetData& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("AssetPath: [{}]"),
+        InObj.AssetClassPath.ToString()
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FCollisionProfileName, [](const FCollisionProfileName& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("CollisionProfileName: [{}]"),
+        InObj.Name
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FDataTableRowHandle, [](const FDataTableRowHandle& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("DataTable: [{}], RowName: [{}]"),
+        InObj.DataTable,
+        InObj.RowName
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FCurveTableRowHandle, [](const FCurveTableRowHandle& InObj)
+{
+    return ck::Format_UE
+    (
+        TEXT("CurveTable: [{}], RowName: [{}]"),
+        InObj.CurveTable,
+        InObj.RowName
+    );
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FPlayInEditorID, [](const int32& InObj)
+{
+    return ck::Format_UE(TEXT("{}"), static_cast<int32>(InObj));
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FInstancedStruct, [](const FInstancedStruct& InObj)
+{
+    return ck::Format_UE(TEXT("{}"), InObj.GetScriptStruct());
+});
+
+// --------------------------------------------------------------------------------------------------------------------
+
+CK_DEFINE_CUSTOM_FORMATTER(SWindow, [](const SWindow& InObj)
+{
+    return ck::Format_UE(TEXT("{}"), InObj.ToString());
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(UObject, [](const UObject& InObj)
+{
+    return UCk_Utils_Debug_UE::Get_DebugName(&InObj).ToString();
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(UActorComponent, [](const UActorComponent& InObj)
+{
+    return UCk_Utils_Debug_UE::Get_DebugName(&InObj).ToString();
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(AActor, [](const AActor& InObj)
+{
+    return UCk_Utils_Debug_UE::Get_DebugName(&InObj).ToString();
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(UClass, [](const UClass& InObj)
+{
+    return UCk_Utils_Debug_UE::Get_DebugName(&InObj).ToString();
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(UFunction, [](const UFunction& InObj)
+{
+    return ck::Format_UE(TEXT("{}.{}[{}]"), InObj.GetOuter()->GetName(), InObj.GetName(), InObj.GetUniqueID());
+});
+
+CK_DEFINE_CUSTOM_FORMATTER(FProperty, [](const FProperty& InObj)
+{
+    return ck::Format_UE(TEXT("{}[{}]"), InObj.GetName(), InObj.GetOffset_ForDebug());
+});
+
+// --------------------------------------------------------------------------------------------------------------------
+
+CK_DEFINE_CUSTOM_FORMATTER(ENetMode, [](const ENetMode& InObj)
+{
+    switch(InObj)
+    {
+        case NM_Standalone: return TEXT("Standalone");
+        case NM_DedicatedServer: return TEXT("Dedicated Server");
+        case NM_ListenServer: return TEXT("ListenServer");
+        case NM_Client: return TEXT("Client");
+        case NM_MAX: return TEXT("Max (INVALID)");
+        default: return TEXT("Default (INVALID)");
+    }
+});
+
+#if WITH_EDITOR
+CK_DEFINE_CUSTOM_FORMATTER(EMapChangeType, [](const EMapChangeType& InObj)
+{
+    switch (InObj)
+    {
+        case EMapChangeType::NewMap: { return TEXT("NewMap"); }
+        case EMapChangeType::LoadMap: { return TEXT("LoadMap"); }
+        case EMapChangeType::TearDownWorld: { return TEXT("TearDownWorld"); }
+        case EMapChangeType::SaveMap: { return TEXT("SaveMap"); }
+        default:  { return TEXT("Unknown"); }
+    }
+});
+#endif
+
+// --------------------------------------------------------------------------------------------------------------------
+
+CK_DEFINE_CUSTOM_FORMATTER_NAMESPACE(ctti::detail::cstring, cstring, [](const ctti::detail::cstring& InObj)
+{
+    return FString(InObj.size(), InObj.begin());
+});
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.h
+++ b/Source/CkCore/Public/CkCore/Format/CkFormat_Defaults.h
@@ -4,21 +4,16 @@
 
 #include <Templates/SubclassOf.h>
 
-#include <CoreMinimal.h>
-#include <GameplayTagContainer.h>
-#include <InputCoreTypes.h>
-#include <NativeGameplayTags.h>
-#include <AssetRegistry/AssetData.h>
-#include <Engine/CollisionProfile.h>
-#include <Engine/CurveTable.h>
-#include <Engine/DataTable.h>
-#include <Framework/Commands/InputChord.h>
-#include <GameFramework/Actor.h>
-#include <StructUtils.h>
-
 #if WITH_EDITOR
 #include <UnrealEdMisc.h>
 #endif
+
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ctti::detail
+{
+    class cstring;
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -27,331 +22,142 @@ namespace ck_format_default::details
     inline const auto Invalid_FProperty = FProperty {{}, NAME_None, {}};
 }
 
-CK_DEFINE_CUSTOM_FORMATTER(FString, [InObj]() { return *InObj; });
-CK_DEFINE_CUSTOM_FORMATTER(FName,   [&]() { return InObj.ToString(); });
-CK_DEFINE_CUSTOM_FORMATTER(FText,   [&]() { return InObj.ToString(); });
-CK_DEFINE_CUSTOM_FORMATTER(FGuid,   [&]() { return InObj.ToString(); });
-CK_DEFINE_CUSTOM_FORMATTER(FNetworkGUID,   [&]() { return InObj.ToString(); });
-CK_DEFINE_CUSTOM_FORMATTER(FKey,   [&]() { return InObj.ToString(); });
-CK_DEFINE_CUSTOM_FORMATTER(FInputChord,   [&]() { return InObj.GetInputText(); });
-CK_DEFINE_CUSTOM_FORMATTER(FSoftObjectPath,   [&]() { return InObj.GetAssetName(); });
-CK_DEFINE_CUSTOM_FORMATTER(FSoftClassPath,   [&]() { return InObj.GetAssetName(); });
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FString, [](const FString& InObj) { return *InObj; });
 
-CK_DEFINE_CUSTOM_FORMATTER(FRandomStream, [&]()
-{
-    return ck::Format
-    (
-        TEXT("Initial Seed: [{}], Current Seed: [{}]"),
-        InObj.GetInitialSeed(),
-        InObj.GetCurrentSeed()
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FName);
 
-CK_DEFINE_CUSTOM_FORMATTER(FRotator, [&]()
-{
-    return ck::Format
-    (
-        TEXT("P{:.2f}, Y:{:.2f}, R:{:.2f}"),
-        InObj.Pitch,
-        InObj.Yaw,
-        InObj.Roll
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FText);
 
-CK_DEFINE_CUSTOM_FORMATTER(FVector, [&]()
-{
-    return ck::Format
-    (
-        TEXT("X:{:.2f}, Y:{:.2f}, Z:{:.2f}"),
-        InObj.X,
-        InObj.Y,
-        InObj.Z
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FGuid);
 
-CK_DEFINE_CUSTOM_FORMATTER(FVector2D, [&]()
-{
-    return ck::Format
-    (
-        TEXT("X:{:.2f}, Y:{:.2f}"),
-        InObj.X,
-        InObj.Y
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FNetworkGUID);
 
-CK_DEFINE_CUSTOM_FORMATTER(FIntVector, [&]()
-{
-    return ck::Format
-    (
-        TEXT("X:{}, Y:{}, Z:{}"),
-        InObj.X,
-        InObj.Y,
-        InObj.Z
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FKey);
 
-CK_DEFINE_CUSTOM_FORMATTER(FIntVector2, [&]()
-{
-    return ck::Format
-    (
-        TEXT("X:{}, Y:{}"),
-        InObj.X,
-        InObj.Y
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FInputChord);
 
-CK_DEFINE_CUSTOM_FORMATTER(FIntVector4, [&]()
-{
-    return ck::Format
-    (
-        TEXT("X:{}, Y:{}, Z:{}, W:{}"),
-        InObj.X,
-        InObj.Y,
-        InObj.Z,
-        InObj.W
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FSoftObjectPath);
 
-CK_DEFINE_CUSTOM_FORMATTER(FQuat, [&]()
-{
-    return ck::Format
-    (
-        TEXT("X:{:.2f}, Y:{:.2f}, Z:{:.2f}, W:{:.2f}"),
-        InObj.X,
-        InObj.Y,
-        InObj.Z,
-        InObj.W
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FSoftClassPath);
 
-CK_DEFINE_CUSTOM_FORMATTER(FBox, [&]()
-{
-    return ck::Format
-    (
-        TEXT("Min:{}, Max:{}, IsValid:{}"),
-        InObj.Min,
-        InObj.Max,
-        InObj.IsValid
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FRandomStream);
 
-CK_DEFINE_CUSTOM_FORMATTER(FBox2D, [&]()
-{
-    return ck::Format
-    (
-        TEXT("Min:{}, Max:{}, IsValid:{}"),
-        InObj.Min,
-        InObj.Max,
-        InObj.bIsValid
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FRotator);
 
-CK_DEFINE_CUSTOM_FORMATTER(FTransform, [&]()
-{
-    return ck::Format
-    (
-        TEXT("T:[{}] R:[{}] S:[{}]"),
-        InObj.GetTranslation(),
-        InObj.GetRotation(),
-        InObj.GetScale3D()
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FVector);
 
-CK_DEFINE_CUSTOM_FORMATTER(FTimespan, [&]()
-{
-    return ck::Format
-    (
-        TEXT("Days:[{}] Hours:[{}] Minutes:[{}] Seconds:[{}]"),
-        InObj.GetDays(),
-        InObj.GetHours(),
-        InObj.GetMinutes(),
-        InObj.GetSeconds()
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FVector2D);
 
-CK_DEFINE_CUSTOM_FORMATTER(FNativeGameplayTag, [&]()
-{
-    return ck::Format(TEXT("{}"), InObj.GetTag());
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FIntVector);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FIntVector2);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FIntVector4);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FQuat);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FBox);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FBox2D);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FTransform);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FTimespan);
+
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FNativeGameplayTag);
 
 #if CK_DISABLE_GAMEPLAYTAG_STALENESS_VALIDATION
-CK_DEFINE_CUSTOM_FORMATTER(FGameplayTag, [&]()
-{
-    if (ck::IsValid(InObj))
-    {
-        return ck::Format(TEXT("{}"), InObj.ToString());
-    }
-
-    return ck::Format(TEXT("TAG_NOT_SET"));
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FGameplayTag);
 #else
-CK_DEFINE_CUSTOM_FORMATTER(FGameplayTag, [&]()
-{
-    if (ck::IsValid(InObj))
-    {
-        return ck::Format(TEXT("{}"), InObj.ToString());
-    }
-
-    if (InObj.GetTagName() != NAME_None)
-    {
-        return ck::Format(TEXT("{}[STALE]"), InObj.ToString());
-    }
-
-    return ck::Format(TEXT("TAG_NOT_SET"));
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FGameplayTag);
 #endif
 
-CK_DEFINE_CUSTOM_FORMATTER(FGameplayTagContainer, [&]()
-{
-    if (ck::IsValid(InObj))
-    {
-        return ck::Format(TEXT("{}"), InObj.ToString());
-    }
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FGameplayTagContainer);
 
-    return ck::Format(TEXT("TAG_CONTAINER_NOT_SET"));
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FAssetData);
 
-CK_DEFINE_CUSTOM_FORMATTER(FAssetData, [&]()
-{
-    return ck::Format
-    (
-        TEXT("AssetPath: [{}]"),
-        InObj.AssetClassPath.ToString()
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FCollisionProfileName);
 
-CK_DEFINE_CUSTOM_FORMATTER(FCollisionProfileName, [&]()
-{
-    return ck::Format
-    (
-        TEXT("CollisionProfileName: [{}]"),
-        InObj.Name
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FDataTableRowHandle);
 
-CK_DEFINE_CUSTOM_FORMATTER(FDataTableRowHandle, [&]()
-{
-    return ck::Format
-    (
-        TEXT("DataTable: [{}], RowName: [{}]"),
-        InObj.DataTable,
-        InObj.RowName
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FCurveTableRowHandle);
 
-CK_DEFINE_CUSTOM_FORMATTER(FCurveTableRowHandle, [&]()
-{
-    return ck::Format
-    (
-        TEXT("CurveTable: [{}], RowName: [{}]"),
-        InObj.CurveTable,
-        InObj.RowName
-    );
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FPlayInEditorID);
 
-CK_DEFINE_CUSTOM_FORMATTER(FPlayInEditorID, [&]()
-{
-    return ck::Format(TEXT("{}"), static_cast<int32>(InObj));
-});
-
-CK_DEFINE_CUSTOM_FORMATTER(FInstancedStruct, [&]()
-{
-    return ck::Format(TEXT("{}"), InObj.GetScriptStruct());
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FInstancedStruct);
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER(SWindow, [&]()
-{
-    return ck::Format(TEXT("{}"), InObj.ToString());
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, SWindow);
 
 CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER_NULLPTR_VALIDITY(SWindow, [&]() -> const SWindow&
 {
     return *InObj;
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(UObject, [&]()
-{
-    return UCk_Utils_Debug_UE::Get_DebugName(&InObj);
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, UObject);
 
 CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER(UObject, [&]() -> const UObject&
 {
     return *InObj;
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(UActorComponent, [&]()
-{
-    return UCk_Utils_Debug_UE::Get_DebugName(&InObj);
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, UActorComponent);
 
 CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER(UActorComponent, [&]() -> const UActorComponent&
 {
     return *InObj;
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(AActor, [&]()
-{
-    return UCk_Utils_Debug_UE::Get_DebugName(&InObj);
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, AActor);
 
 CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER(AActor, [&]() -> const AActor&
 {
     return *InObj;
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(UClass, [&]()
-{
-    return UCk_Utils_Debug_UE::Get_DebugName(&InObj);
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, UClass);
 
 CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER(UClass, [&]() -> const UClass&
 {
     return *InObj;
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(UFunction, [&]()
-{
-    return ck::Format(TEXT("{}.{}[{}]"), InObj.GetOuter()->GetName(), InObj.GetName(), InObj.GetUniqueID());
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, UFunction);
 
 CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER(UFunction, [&]() -> const UFunction&
 {
     return *InObj;
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(FProperty, [&]()
-{
-    return ck::Format(TEXT("{}[{}]"), InObj.GetName(), InObj.GetOffset_ForDebug());
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, FProperty);
 
 CK_DEFINE_CUSTOM_FORMATTER_PTR_FORWARDER(FProperty, []() -> const FProperty&
 {
     return ck_format_default::details::Invalid_FProperty;
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TScriptInterface<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TScriptInterface<T>, [](const auto& InObj)
 {
     return ck::Format(TEXT("{}"), InObj.GetObject());
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TWeakObjectPtr<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TWeakObjectPtr<T>, [](const auto& InObj)
 {
     return ck::Format(TEXT("{}"), InObj.Get());
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TSubclassOf<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TSubclassOf<T>, [](const auto& InObj)
 {
     return ck::Format(TEXT("{}"), InObj.Get());
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TObjectPtr<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TObjectPtr<T>, [](const auto& InObj)
 {
     return ck::Format(TEXT("{}"), InObj.Get());
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TOptional<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TOptional<T>, [](const auto& InObj)
 {
     if (NOT ck::IsValid(InObj))
     { return ck::Format(TEXT("nullopt")); }
@@ -359,7 +165,7 @@ CK_DEFINE_CUSTOM_FORMATTER_T(TOptional<T>, [&]()
     return ck::Format(TEXT("{}"), *InObj);
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TSoftObjectPtr<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TSoftObjectPtr<T>, [](const auto& InObj)
 {
     if (NOT ck::IsValid(InObj))
     { return ck::Format(TEXT("nullopt")); }
@@ -367,7 +173,7 @@ CK_DEFINE_CUSTOM_FORMATTER_T(TSoftObjectPtr<T>, [&]()
     return ck::Format(TEXT("{}"), *InObj);
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TSoftClassPtr<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TSoftClassPtr<T>, [](const auto& InObj)
 {
     if (NOT ck::IsValid(InObj))
     { return ck::Format(TEXT("nullopt")); }
@@ -375,7 +181,7 @@ CK_DEFINE_CUSTOM_FORMATTER_T(TSoftClassPtr<T>, [&]()
     return ck::Format(TEXT("{}"), *InObj);
 });
 
-CK_DEFINE_CUSTOM_FORMATTER_T(TEnumAsByte<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(TEnumAsByte<T>, [](const auto& InObj)
 {
     return ck::Format(TEXT("{}"), T(InObj.GetValue()));
 });
@@ -386,40 +192,14 @@ CK_DEFINE_CUSTOM_FORMATTER_ENUM(EAppReturnType::Type);
 CK_DEFINE_CUSTOM_FORMATTER_ENUM(ETickingGroup);
 CK_DEFINE_CUSTOM_FORMATTER_ENUM(EComponentMobility::Type);
 
-CK_DEFINE_CUSTOM_FORMATTER(ENetMode, [&]()
-{
-    switch(InObj)
-    {
-        case NM_Standalone: return TEXT("Standalone");
-        case NM_DedicatedServer: return TEXT("Dedicated Server");
-        case NM_ListenServer: return TEXT("ListenServer");
-        case NM_Client: return TEXT("Client");
-        case NM_MAX: return TEXT("Max (INVALID)");
-        default: return TEXT("Default (INVALID)");
-    }
-});
-
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, ENetMode);
 #if WITH_EDITOR
-CK_DEFINE_CUSTOM_FORMATTER(EMapChangeType, [&]()
-{
-    switch (InObj)
-    {
-        case EMapChangeType::NewMap: { return TEXT("NewMap"); }
-        case EMapChangeType::LoadMap: { return TEXT("LoadMap"); }
-        case EMapChangeType::TearDownWorld: { return TEXT("TearDownWorld"); }
-        case EMapChangeType::SaveMap: { return TEXT("SaveMap"); }
-        default:  { return TEXT("Unknown"); }
-    }
-});
+CK_DECLARE_CUSTOM_FORMATTER(CKCORE_API, EMapChangeType);
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
 
-#include "ctti/type_id.hpp"
-CK_DEFINE_CUSTOM_FORMATTER(ctti::detail::cstring, [&]()
-{
-    return FString(InObj.size(), InObj.begin());
-});
+CK_DECLARE_CUSTOM_FORMATTER_NAMESPACE(CKCORE_API, ctti::detail::cstring, cstring);
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -451,7 +231,33 @@ namespace ck
     }
 }
 
-CK_DEFINE_CUSTOM_FORMATTER_T(ck::FContext<T>, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_T(ck::FContext<T>, [](const auto& InObj)
 {
     return ck::Format(TEXT("\nContext: [{}]"), InObj._Context);
 });
+
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ck
+{
+    namespace ck_format_detail
+    {
+        template <typename T>
+        constexpr auto&& ArgsForward(T&& InType)
+        {
+            using decayed_t = std::decay_t<T>;
+            using original_t = std::remove_const_t<decayed_t>;
+
+            if constexpr (std::is_pointer_v<decayed_t> && NOT std::is_void_v<std::remove_pointer_t<std::remove_cv_t<original_t>>> && NOT std::is_same_v<decayed_t, const wchar_t*>)
+            {
+                return ForwarderForPointers(InType);
+            }
+            else
+            {
+                return InType;
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCore/Public/CkCore/GameplayTag/CkGameplayTagStack.h
+++ b/Source/CkCore/Public/CkCore/GameplayTag/CkGameplayTagStack.h
@@ -43,7 +43,7 @@ public:
     CK_DEFINE_CONSTRUCTORS(FCk_GameplayTagStack, _Tag, _StackCount);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_GameplayTagStack, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_GameplayTagStack, [](const FCk_GameplayTagStack& InObj)
 {
     return ck::Format
     (

--- a/Source/CkCore/Public/CkCore/Math/NumericLimits/CkNumericLimits.h
+++ b/Source/CkCore/Public/CkCore/Math/NumericLimits/CkNumericLimits.h
@@ -29,7 +29,7 @@ public:
     CK_PROPERTY_GET(_Max);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_FloatNumericLimits, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_FloatNumericLimits, *[](const FCk_FloatNumericLimits& InObj)
 {
     return ck::Format(TEXT("Min: [{}], Max: [{}]"), InObj.Get_Min(), InObj.Get_Max());
 });
@@ -58,7 +58,7 @@ public:
     CK_PROPERTY_GET(_Max);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_DoubleNumericLimits, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_DoubleNumericLimits, [](const FCk_DoubleNumericLimits& InObj)
 {
     return ck::Format(TEXT("Min: [{}], Max: [{}]"), InObj.Get_Min(), InObj.Get_Max());
 });
@@ -87,7 +87,7 @@ public:
     CK_PROPERTY_GET(_Max);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Int32NumericLimits, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Int32NumericLimits, [](const FCk_Int32NumericLimits& InObj)
 {
     return ck::Format(TEXT("Min: [{}], Max: [{}]"), InObj.Get_Min(), InObj.Get_Max());
 });
@@ -116,7 +116,7 @@ public:
     CK_PROPERTY_GET(_Max);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Int64NumericLimits, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Int64NumericLimits, [](const FCk_Int64NumericLimits& InObj)
 {
     return ck::Format(TEXT("Min: [{}], Max: [{}]"), InObj.Get_Min(), InObj.Get_Max());
 });

--- a/Source/CkCore/Public/CkCore/Math/ValueRange/CkValueRange.h
+++ b/Source/CkCore/Public/CkCore/Math/ValueRange/CkValueRange.h
@@ -46,7 +46,7 @@ public:
     CK_DEFINE_CONSTRUCTORS(FCk_FloatRange, _Min, _Max);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_FloatRange, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_FloatRange, [](const FCk_FloatRange& InObj)
 {
     return ck::Format(TEXT("Min: [{}], Max: [{}]"), InObj.Get_Min(), InObj.Get_Max());
 });
@@ -81,7 +81,7 @@ public:
     CK_DEFINE_CONSTRUCTORS(FCk_IntRange, _Min, _Max);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_IntRange, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_IntRange, [](const FCk_IntRange& InObj)
 {
     return ck::Format(TEXT("Min: [{}], Max: [{}]"), InObj.Get_Min(), InObj.Get_Max());
 });
@@ -118,7 +118,7 @@ public:
     CK_PROPERTY_GET(_Value);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_FloatRange_0to1, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_FloatRange_0to1, [&]()
 {
     return ck::Format(TEXT("0 to 1: [{}]"), InObj.Get_Value());
 });
@@ -157,7 +157,7 @@ public:
     CK_PROPERTY_GET(_Value);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_FloatRange_Minus1to1, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_FloatRange_Minus1to1, [&]()
 {
     return ck::Format(TEXT("-1 to +1: [{}]"), InObj.Get_Value());
 });

--- a/Source/CkCore/Public/CkCore/Meter/CkMeter.h
+++ b/Source/CkCore/Public/CkCore/Meter/CkMeter.h
@@ -103,7 +103,7 @@ public:
     CK_PROPERTY_GET(_Params);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Meter, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Meter, [](const FCk_Meter& InObj)
 {
     return ck::Format
     (

--- a/Source/CkCore/Public/CkCore/Time/CkTime.h
+++ b/Source/CkCore/Public/CkCore/Time/CkTime.h
@@ -170,12 +170,12 @@ public:
 // --------------------------------------------------------------------------------------------------------------------
 // IsValid and Formatters
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Time, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Time, [](const FCk_Time& InObj)
 {
     return ck::Format(TEXT("{:.3f}s"), InObj.Get_Seconds());
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_WorldTime, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_WorldTime, [&]()
 {
     return ck::Format
     (
@@ -187,7 +187,7 @@ CK_DEFINE_CUSTOM_FORMATTER(FCk_WorldTime, [&]()
     );
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Time_Unreal, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Time_Unreal, [&]()
 {
     return ck::Format
     (

--- a/Source/CkEcs/Public/CkEcs/Entity/CkEntity.h
+++ b/Source/CkEcs/Public/CkEcs/Entity/CkEntity.h
@@ -97,7 +97,7 @@ static_assert
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Entity, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Entity, [](const FCk_Entity& InObj)
 {
     if (InObj.Get_IsTombstone())
     { return ck::Format(TEXT("TOMBSTONE")); }

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
@@ -501,6 +501,68 @@ namespace ck
 
 // --------------------------------------------------------------------------------------------------------------------
 
+CK_DEFINE_CUSTOM_FORMATTER_WITH_DETAILS(FCk_Handle, [](const FCk_Handle& InObj)
+{
+    if (InObj.Get_Entity().Get_IsTombstone())
+    { return ck::Format_UE(TEXT("{}"), InObj.Get_Entity()); }
+
+    const auto LifetimePhase = [&]()
+    {
+        if (InObj.Has<ck::FTag_DestroyEntity_Initiate>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate>(); }
+
+        if (InObj.Has<ck::FTag_DestroyEntity_Finalize>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Finalize>(); }
+
+        if (InObj.Has<ck::FTag_DestroyEntity_Initiate_Confirm>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate_Confirm>(); }
+
+        if (InObj.Has<ck::FTag_DestroyEntity_Await>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Await>(); }
+
+        if (InObj.Has<ck::FTag_EntityJustCreated>())
+        { return ck::Get_LifetimeTagString<ck::FTag_EntityJustCreated>(); }
+
+        if (InObj.IsValid(ck::IsValid_Policy_Default{}))
+        { return TEXT("Valid"); }
+
+        return TEXT("Invalid");
+    }();
+
+    return ck::Format_UE(TEXT("{}[{}]({})"), InObj.Get_Entity(), LifetimePhase, LifetimePhase, InObj.Get_DebugName());
+}, [](const FCk_Handle& InObj)
+{
+    if (InObj.Get_Entity().Get_IsTombstone())
+    { return ck::Format_UE(TEXT("{}"), InObj.Get_Entity()); }
+
+    const auto LifetimePhase = [&]()
+    {
+        if (InObj.Has<ck::FTag_DestroyEntity_Initiate>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate>(); }
+
+        if (InObj.Has<ck::FTag_DestroyEntity_Finalize>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Finalize>(); }
+
+        if (InObj.Has<ck::FTag_DestroyEntity_Initiate_Confirm>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate_Confirm>(); }
+
+        if (InObj.Has<ck::FTag_DestroyEntity_Await>())
+        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Await>(); }
+
+        if (InObj.Has<ck::FTag_EntityJustCreated>())
+        { return ck::Get_LifetimeTagString<ck::FTag_EntityJustCreated>(); }
+
+        if (InObj.IsValid(ck::IsValid_Policy_Default{}))
+        { return TEXT("Valid"); }
+
+        return TEXT("Invalid");
+    }();
+
+    return ck::Format_UE(TEXT("{}[{}][{}]({})"), InObj.Get_Entity(), LifetimePhase, InObj.Get_Registry(), InObj.Get_DebugName());
+});
+
+// --------------------------------------------------------------------------------------------------------------------
+
 // ReSharper disable once CppInconsistentNaming
 namespace UE::Net
 {

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -428,67 +428,7 @@ CK_DEFINE_CUSTOM_IS_VALID_INLINE(FCk_Handle, ck::IsValid_Policy_IncludePendingKi
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER_WITH_DETAILS(FCk_Handle,
-[&]()
-{
-    if (InObj.Get_Entity().Get_IsTombstone())
-    { return ck::Format(TEXT("{}"), InObj.Get_Entity()); }
-
-    const auto LifetimePhase = [&]()
-    {
-        if (InObj.Has<ck::FTag_DestroyEntity_Initiate>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate>(); }
-
-        if (InObj.Has<ck::FTag_DestroyEntity_Finalize>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Finalize>(); }
-
-        if (InObj.Has<ck::FTag_DestroyEntity_Initiate_Confirm>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate_Confirm>(); }
-
-        if (InObj.Has<ck::FTag_DestroyEntity_Await>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Await>(); }
-
-        if (InObj.Has<ck::FTag_EntityJustCreated>())
-        { return ck::Get_LifetimeTagString<ck::FTag_EntityJustCreated>(); }
-
-        if (InObj.IsValid(ck::IsValid_Policy_Default{}))
-        { return TEXT("Valid"); }
-
-        return TEXT("Invalid");
-    }();
-
-    return ck::Format(TEXT("{}[{}]({})"), InObj.Get_Entity(), LifetimePhase, LifetimePhase, InObj.Get_DebugName());
-},
-[&]()
-{
-    if (InObj.Get_Entity().Get_IsTombstone())
-    { return ck::Format(TEXT("{}"), InObj.Get_Entity()); }
-
-    const auto LifetimePhase = [&]()
-    {
-        if (InObj.Has<ck::FTag_DestroyEntity_Initiate>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate>(); }
-
-        if (InObj.Has<ck::FTag_DestroyEntity_Finalize>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Finalize>(); }
-
-        if (InObj.Has<ck::FTag_DestroyEntity_Initiate_Confirm>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Initiate_Confirm>(); }
-
-        if (InObj.Has<ck::FTag_DestroyEntity_Await>())
-        { return ck::Get_LifetimeTagString<ck::FTag_DestroyEntity_Await>(); }
-
-        if (InObj.Has<ck::FTag_EntityJustCreated>())
-        { return ck::Get_LifetimeTagString<ck::FTag_EntityJustCreated>(); }
-
-        if (InObj.IsValid(ck::IsValid_Policy_Default{}))
-        { return TEXT("Valid"); }
-
-        return TEXT("Invalid");
-    }();
-
-    return ck::Format(TEXT("{}[{}][{}]({})"), InObj._Entity, LifetimePhase, InObj.Get_Registry(), InObj.Get_DebugName());
-});
+CK_DECLARE_CUSTOM_FORMATTER_WITH_DETAILS(CKECS_API, FCk_Handle);
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_TypeSafe.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_TypeSafe.h
@@ -81,14 +81,14 @@ static_assert
 
 // we're NOT casting the derived Handle to the base FCk_Handle mainly for perf reasons (avoiding too many conversions when formatting and validating)
 #define CK_DEFINE_CUSTOM_ISVALID_AND_FORMATTER_HANDLE_TYPESAFE(_HandleType_)                                      \
-    CK_DEFINE_CUSTOM_FORMATTER_WITH_DETAILS(_HandleType_,                                                         \
-    [&]()                                                                                                         \
+    CK_DEFINE_CUSTOM_FORMATTER_WITH_DETAILS_INLINE(_HandleType_,                                                  \
+    [](const _HandleType_& InObj)                                                                                 \
     {                                                                                                             \
-        return ck::Format(TEXT("{}({})"), InObj.Get_Entity(), InObj.Get_DebugName());                             \
+        return ck::Format_UE(TEXT("{}({})"), InObj.Get_Entity(), InObj.Get_DebugName());                          \
     },                                                                                                            \
-    [&]()                                                                                                         \
+    [&](const _HandleType_& InObj)                                                                                \
     {                                                                                                             \
-        return ck::Format(TEXT("{}[{}]({})"), InObj.Get_Entity(), InObj.Get_Registry(), InObj.Get_DebugName());   \
+        return ck::Format_UE(TEXT("{}[{}]({})"), InObj.Get_Entity(), InObj.Get_Registry(), InObj.Get_DebugName());\
     });                                                                                                           \
     static_assert(sizeof(_HandleType_) == sizeof(FCk_Handle),                                                     \
         "Type-Safe Handle should be EXACTLY the same size as FCk_Handle");                                        \

--- a/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Fragment_Data.h
+++ b/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Fragment_Data.h
@@ -107,7 +107,7 @@ CK_DEFINE_CUSTOM_IS_VALID_INLINE(FCk_EntityOwningActor_BasicDetails, ck::IsValid
     return ck::IsValid(InBasicDetails.Get_Actor()) && ck::IsValid(InBasicDetails.Get_Handle());
 });
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_EntityOwningActor_BasicDetails, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_EntityOwningActor_BasicDetails, [](const FCk_EntityOwningActor_BasicDetails& InObj)
 {
     return ck::Format
     (

--- a/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
+++ b/Source/CkEcs/Public/CkEcs/Registry/CkRegistry.h
@@ -249,7 +249,7 @@ auto CKECS_API GetTypeHash(const FCk_Registry& InRegistry) -> uint32;
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Registry, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Registry, [](const FCk_Registry& InObj)
 {
     return ck::Format
     (

--- a/Source/CkEntityCollection/Public/CkEntityCollection/CkEntityCollection_Fragment_Data.h
+++ b/Source/CkEntityCollection/Public/CkEntityCollection/CkEntityCollection_Fragment_Data.h
@@ -5,6 +5,8 @@
 #include "CkCore/Macros/CkMacros.h"
 #include "CkCore/Format/CkFormat.h"
 
+#include <GameplayTags.h>
+
 #include "CkEntityCollection_Fragment_Data.generated.h"
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -85,7 +87,7 @@ public:
     CK_DEFINE_CONSTRUCTORS(FCk_EntityCollection_Content, _CollectionName, _EntitiesInCollection);
 };
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_EntityCollection_Content, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_EntityCollection_Content, [](const FCk_EntityCollection_Content& InObj)
 {
     return ck::Format(TEXT("Collection: {} | {}"), InObj.Get_CollectionName(), InObj.Get_EntitiesInCollection().Num());
 });

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Fragment_Data.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Fragment_Data.h
@@ -976,7 +976,7 @@ private:
 // --------------------------------------------------------------------------------------------------------------------
 // IsValid & Formatter
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Sensor_BeginOverlap_UnrealDetails, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Sensor_BeginOverlap_UnrealDetails, [](const FCk_Sensor_BeginOverlap_UnrealDetails& InObj)
 {
     return ck::Format
     (
@@ -989,7 +989,7 @@ CK_DEFINE_CUSTOM_FORMATTER(FCk_Sensor_BeginOverlap_UnrealDetails, [&]()
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_Sensor_EndOverlap_UnrealDetails, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_Sensor_EndOverlap_UnrealDetails, [](const FCk_Sensor_EndOverlap_UnrealDetails& InObj)
 {
     return ck::Format
     (

--- a/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Fragment.h
+++ b/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Fragment.h
@@ -13,7 +13,7 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER(FGenericTeamId, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FGenericTeamId, [](const FGenericTeamId& InObj)
 {
     return ck::Format(TEXT("{}"), InObj.GetId());
 });

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.h
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.h
@@ -321,7 +321,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
 // --------------------------------------------------------------------------------------------------------------------
 // IsValid and Formatters
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_ResourceLoader_ObjectReference_Soft, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_ResourceLoader_ObjectReference_Soft, [](const FCk_ResourceLoader_ObjectReference_Soft& InObj)
 {
     return ck::Format(TEXT("{}"), InObj.Get_SoftObjectPath());
 });
@@ -334,7 +334,7 @@ CK_DEFINE_CUSTOM_IS_VALID_INLINE(FCk_ResourceLoader_ObjectReference_Soft, ck::Is
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_ResourceLoader_ObjectReference_Hard, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_ResourceLoader_ObjectReference_Hard, [](const FCk_ResourceLoader_ObjectReference_Hard& InObj)
 {
     return ck::Format(TEXT("{}"), InObj.Get_Object());
 });
@@ -347,7 +347,7 @@ CK_DEFINE_CUSTOM_IS_VALID_INLINE(FCk_ResourceLoader_ObjectReference_Hard, ck::Is
 
 // --------------------------------------------------------------------------------------------------------------------
 
-CK_DEFINE_CUSTOM_FORMATTER(FCk_ResourceLoader_LoadedObject, [&]()
+CK_DEFINE_CUSTOM_FORMATTER_INLINE(FCk_ResourceLoader_LoadedObject, [](const FCk_ResourceLoader_LoadedObject& InObj)
 {
     return ck::Format
     (


### PR DESCRIPTION
*  CK_DEFINE_CUSTOM_FORMATTER and related macros now have versions to declare the macro in the header and define the validity check in the cpp file
   *  This helps reduce the amount of code included for formatting and puts most of the dependencies in the cpp file
   *  There is a CK_DEFINE_CUSTOM_FORMATTER_INLINE to declare and define in the same place like before
*  Moved ArgsForward definition to format defaults
   *  This makes sense since it requires format defaults pointer forwarding macros to be defined first
   *  If we don't do this, then including CkFormat_Defaults.h first then the ordering will define ArgsForward before the macros, causing a compiler error. We need to include CkFormat_Defaults.h first for CkFormat_Defaults.cpp to prevent a compiler error