### PR TITLE
fix: Change all headers to use CkEcs pre compiled header as a private…

### DIFF
--- a/Source/CkAbility/CkAbility.Build.cs
+++ b/Source/CkAbility/CkAbility.Build.cs
@@ -5,8 +5,7 @@ public class CkAbility : CkModuleRules
 {
     public CkAbility(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
 
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkAbilityEditor/CkAbilityEditor.Build.cs
+++ b/Source/CkAbilityEditor/CkAbilityEditor.Build.cs
@@ -5,8 +5,7 @@ public class CkAbilityEditor : CkModuleRules
 {
     public CkAbilityEditor(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkAbilityExt/CkAbilityExt.Build.cs
+++ b/Source/CkAbilityExt/CkAbilityExt.Build.cs
@@ -5,8 +5,7 @@ public class CkAbilityExt : CkModuleRules
 {
     public CkAbilityExt(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkActor/CkActor.Build.cs
+++ b/Source/CkActor/CkActor.Build.cs
@@ -5,8 +5,7 @@ public class CkActor : CkModuleRules
 {
     public CkActor(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkActorProxy/CkActorProxy.Build.cs
+++ b/Source/CkActorProxy/CkActorProxy.Build.cs
@@ -5,8 +5,7 @@ public class CkActorProxy : CkModuleRules
 {
     public CkActorProxy(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkAggro/CkAggro.Build.cs
+++ b/Source/CkAggro/CkAggro.Build.cs
@@ -5,8 +5,7 @@ public class CkAggro : CkModuleRules
 {
     public CkAggro(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkAi/CkAi.Build.cs
+++ b/Source/CkAi/CkAi.Build.cs
@@ -5,8 +5,7 @@ public class CkAi : CkModuleRules
 {
     public CkAi(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkAngelscriptGenerator/CkAngelscriptGenerator.Build.cs
+++ b/Source/CkAngelscriptGenerator/CkAngelscriptGenerator.Build.cs
@@ -5,8 +5,7 @@ public class CkAngelscriptGenerator : CkModuleRules
 {
     public CkAngelscriptGenerator(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkAnimation/CkAnimation.Build.cs
+++ b/Source/CkAnimation/CkAnimation.Build.cs
@@ -5,8 +5,7 @@ public class CkAnimation : CkModuleRules
 {
     public CkAnimation(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkAttribute/CkAttribute.Build.cs
+++ b/Source/CkAttribute/CkAttribute.Build.cs
@@ -5,8 +5,7 @@ public class CkAttribute : CkModuleRules
 {
     public CkAttribute(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkBallistics/CkBallistics.Build.cs
+++ b/Source/CkBallistics/CkBallistics.Build.cs
@@ -5,8 +5,7 @@ public class CkBallistics : CkModuleRules
 {
     public CkBallistics(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkCamera/CkCamera.Build.cs
+++ b/Source/CkCamera/CkCamera.Build.cs
@@ -5,8 +5,7 @@ public class CkCamera : CkModuleRules
 {
     public CkCamera(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkChaos/CkChaos.Build.cs
+++ b/Source/CkChaos/CkChaos.Build.cs
@@ -5,8 +5,7 @@ public class CkChaos : CkModuleRules
 {
     public CkChaos(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkCompositeAlgos/CkCompositeAlgos.Build.cs
+++ b/Source/CkCompositeAlgos/CkCompositeAlgos.Build.cs
@@ -5,8 +5,7 @@ public class CkCompositeAlgos : CkModuleRules
 {
     public CkCompositeAlgos(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkConsoleCommands/CkConsoleCommands.Build.cs
+++ b/Source/CkConsoleCommands/CkConsoleCommands.Build.cs
@@ -5,8 +5,7 @@ public class CkConsoleCommands : CkModuleRules
 {
     public CkConsoleCommands(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkDataViewer/CkDataViewer.Build.cs
+++ b/Source/CkDataViewer/CkDataViewer.Build.cs
@@ -5,8 +5,7 @@ public class CkDataViewer : CkModuleRules
 {
     public CkDataViewer(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEcs/CkEcs.build.cs
+++ b/Source/CkEcs/CkEcs.build.cs
@@ -6,7 +6,6 @@ public class CkEcs : CkModuleRules
 {
     public CkEcs(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
         PrivatePCHHeaderFile = "../CkEcs_PCH.h";
 
         PublicIncludePaths.AddRange(

--- a/Source/CkEcs/Public/CkEcs/Signal/CkSignal_Fragment.h
+++ b/Source/CkEcs/Public/CkEcs/Signal/CkSignal_Fragment.h
@@ -4,6 +4,7 @@
 #include "CkCore/TypeConverter/CkTypeConverter.h"
 
 #include "CkEcs/Tag/CkTag.h"
+#include <entt/entt.hpp>
 
 #include "CkEcs/Signal/CkSignal_Fragment_Data.h"
 

--- a/Source/CkEcsEditor/CkEcsEditor.Build.cs
+++ b/Source/CkEcsEditor/CkEcsEditor.Build.cs
@@ -5,8 +5,7 @@ public class CkEcsEditor : CkModuleRules
 {
     public CkEcsEditor(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEcsExt/CkEcsExt.Build.cs
+++ b/Source/CkEcsExt/CkEcsExt.Build.cs
@@ -5,8 +5,7 @@ public class CkEcsExt : CkModuleRules
 {
     public CkEcsExt(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEcsExtEditor/CkEcsExtEditor.Build.cs
+++ b/Source/CkEcsExtEditor/CkEcsExtEditor.Build.cs
@@ -5,8 +5,7 @@ public class CkEcsExtEditor : CkModuleRules
 {
     public CkEcsExtEditor(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEcsTemplate/CkEcsTemplate.Build.cs
+++ b/Source/CkEcsTemplate/CkEcsTemplate.Build.cs
@@ -5,8 +5,7 @@ public class CkEcsTemplate : CkModuleRules
 {
     public CkEcsTemplate(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEditorToolbar/CkEditorToolbar.Build.cs
+++ b/Source/CkEditorToolbar/CkEditorToolbar.Build.cs
@@ -5,8 +5,7 @@ public class CkEditorToolbar : CkModuleRules
 {
     public CkEditorToolbar(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEntityBridge/CkEntityBridge.Build.cs
+++ b/Source/CkEntityBridge/CkEntityBridge.Build.cs
@@ -5,8 +5,7 @@ public class CkEntityBridge : CkModuleRules
 {
     public CkEntityBridge(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEntityBridgeEditor/CkEntityBridgeEditor.Build.cs
+++ b/Source/CkEntityBridgeEditor/CkEntityBridgeEditor.Build.cs
@@ -5,8 +5,7 @@ public class CkEntityBridgeEditor : CkModuleRules
 {
     public CkEntityBridgeEditor(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEntityCollection/CkEntityCollection.Build.cs
+++ b/Source/CkEntityCollection/CkEntityCollection.Build.cs
@@ -5,8 +5,7 @@ public class CkEntityCollection : CkModuleRules
 {
     public CkEntityCollection(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEntityExtension/CkEntityExtension.Build.cs
+++ b/Source/CkEntityExtension/CkEntityExtension.Build.cs
@@ -5,8 +5,7 @@ public class CkEntityExtension : CkModuleRules
 {
     public CkEntityExtension(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkEntityTag/CkEntityTag.Build.cs
+++ b/Source/CkEntityTag/CkEntityTag.Build.cs
@@ -5,8 +5,7 @@ public class CkEntityTag : CkModuleRules
 {
     public CkEntityTag(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkFeedback/CkFeedback.Build.cs
+++ b/Source/CkFeedback/CkFeedback.Build.cs
@@ -5,8 +5,7 @@ public class CkFeedback : CkModuleRules
 {
     public CkFeedback(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkFx/CkFx.Build.cs
+++ b/Source/CkFx/CkFx.Build.cs
@@ -5,8 +5,7 @@ public class CkFx : CkModuleRules
 {
     public CkFx(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkGameSession/CkGameSession.Build.cs
+++ b/Source/CkGameSession/CkGameSession.Build.cs
@@ -5,8 +5,7 @@ public class CkGameSession : CkModuleRules
 {
     public CkGameSession(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkGraphics/CkGraphics.Build.cs
+++ b/Source/CkGraphics/CkGraphics.Build.cs
@@ -5,8 +5,7 @@ public class CkGraphics : CkModuleRules
 {
     public CkGraphics(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkGrid/CkGrid.Build.cs
+++ b/Source/CkGrid/CkGrid.Build.cs
@@ -5,8 +5,7 @@ public class CkGrid : CkModuleRules
 {
     public CkGrid(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkInput/CkInput.Build.cs
+++ b/Source/CkInput/CkInput.Build.cs
@@ -5,8 +5,7 @@ public class CkInput : CkModuleRules
 {
     public CkInput(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkInteraction/CkInteraction.Build.cs
+++ b/Source/CkInteraction/CkInteraction.Build.cs
@@ -5,8 +5,7 @@ public class CkInteraction : CkModuleRules
 {
     public CkInteraction(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkIsmRenderer/CkIsmRenderer.Build.cs
+++ b/Source/CkIsmRenderer/CkIsmRenderer.Build.cs
@@ -5,8 +5,7 @@ public class CkIsmRenderer : CkModuleRules
 {
     public CkIsmRenderer(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkK2Nodes/CkK2Nodes.Build.cs
+++ b/Source/CkK2Nodes/CkK2Nodes.Build.cs
@@ -5,8 +5,7 @@ public class CkK2Nodes : CkModuleRules
 {
     public CkK2Nodes(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkLabel/CkLabel.Build.cs
+++ b/Source/CkLabel/CkLabel.Build.cs
@@ -5,8 +5,7 @@ public class CkLabel : CkModuleRules
 {
     public CkLabel(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkMessaging/CkMessaging.Build.cs
+++ b/Source/CkMessaging/CkMessaging.Build.cs
@@ -5,8 +5,7 @@ public class CkMessaging : CkModuleRules
 {
     public CkMessaging(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkPhysics/CkPhysics.Build.cs
+++ b/Source/CkPhysics/CkPhysics.Build.cs
@@ -5,8 +5,7 @@ public class CkPhysics : CkModuleRules
 {
     public CkPhysics(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkProjectile/CkProjectile.Build.cs
+++ b/Source/CkProjectile/CkProjectile.Build.cs
@@ -5,8 +5,7 @@ public class CkProjectile : CkModuleRules
 {
     public CkProjectile(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkProvider/CkProvider.Build.cs
+++ b/Source/CkProvider/CkProvider.Build.cs
@@ -5,8 +5,7 @@ public class CkProvider : CkModuleRules
 {
     public CkProvider(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkRaySense/CkRaySense.Build.cs
+++ b/Source/CkRaySense/CkRaySense.Build.cs
@@ -5,8 +5,7 @@ public class CkRaySense : CkModuleRules
 {
     public CkRaySense(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkRecord/CkRecord.Build.cs
+++ b/Source/CkRecord/CkRecord.Build.cs
@@ -5,8 +5,7 @@ public class CkRecord : CkModuleRules
 {
     public CkRecord(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkRelationship/CkRelationship.Build.cs
+++ b/Source/CkRelationship/CkRelationship.Build.cs
@@ -5,8 +5,7 @@ public class CkRelationship : CkModuleRules
 {
     public CkRelationship(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkResolver/CkResolver.Build.cs
+++ b/Source/CkResolver/CkResolver.Build.cs
@@ -5,8 +5,7 @@ public class CkResolver : CkModuleRules
 {
     public CkResolver(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkResourceLoader/CkResourceLoader.Build.cs
+++ b/Source/CkResourceLoader/CkResourceLoader.Build.cs
@@ -5,8 +5,7 @@ public class CkResourceLoader : CkModuleRules
 {
     public CkResourceLoader(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkResourceLoaderEditor/CkResourceLoaderEditor.Build.cs
+++ b/Source/CkResourceLoaderEditor/CkResourceLoaderEditor.Build.cs
@@ -5,8 +5,7 @@ public class CkResourceLoaderEditor : CkModuleRules
 {
     public CkResourceLoaderEditor(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkShapes/CkShapes.Build.cs
+++ b/Source/CkShapes/CkShapes.Build.cs
@@ -5,8 +5,7 @@ public class CkShapes : CkModuleRules
 {
     public CkShapes(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkSpatialQuery/CkSpatialQuery.Build.cs
+++ b/Source/CkSpatialQuery/CkSpatialQuery.Build.cs
@@ -5,8 +5,7 @@ public class CkSpatialQuery : CkModuleRules
 {
     public CkSpatialQuery(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkSubstep/CkSubstep.Build.cs
+++ b/Source/CkSubstep/CkSubstep.Build.cs
@@ -5,8 +5,7 @@ public class CkSubstep : CkModuleRules
 {
     public CkSubstep(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkTargeting/CkTargeting.Build.cs
+++ b/Source/CkTargeting/CkTargeting.Build.cs
@@ -5,8 +5,7 @@ public class CkTargeting : CkModuleRules
 {
     public CkTargeting(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkTemplate/CkTemplate.Build.cs
+++ b/Source/CkTemplate/CkTemplate.Build.cs
@@ -5,8 +5,7 @@ public class CkTemplate : CkModuleRules
 {
     public CkTemplate(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkTimer/CkTimer.Build.cs
+++ b/Source/CkTimer/CkTimer.Build.cs
@@ -5,8 +5,7 @@ public class CkTimer : CkModuleRules
 {
     public CkTimer(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });

--- a/Source/CkUI/CkUI.build.cs
+++ b/Source/CkUI/CkUI.build.cs
@@ -5,6 +5,7 @@ public class CkUI : CkModuleRules
 {
     public CkUI(ReadOnlyTargetRules Target) : base(Target)
     {
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PublicIncludePaths.AddRange(
             new string[] {
                 // ... add public include paths required here ...

--- a/Source/CkVariables/CkVariables.Build.cs
+++ b/Source/CkVariables/CkVariables.Build.cs
@@ -5,8 +5,7 @@ public class CkVariables : CkModuleRules
 {
     public CkVariables(ReadOnlyTargetRules Target) : base(Target)
     {
-        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-        SharedPCHHeaderFile = "../CkEcs_PCH.h";
+        PrivatePCHHeaderFile = "../CkEcs_PCH.h";
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...
         });


### PR DESCRIPTION
… header instead of a shared header

*  This fixes an unknown compile issue on some machines
   *  The error is in the typesafe handle header in FAngelscriptBinds::FBind BindEquals_FCk_Handle
*  Remove PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs; since it's redundant with the base class