### PR TITLE
fix: Fix linker error if handle header is included but module is not …

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_TypeSafe_AngelScript.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_TypeSafe_AngelScript.h
@@ -42,7 +42,10 @@ private:
         const FBindFlags Flags;                                                                                              \
         auto FBindingHandle_ = FAngelscriptBinds::ValueClass<_HandleType_>(#_HandleType_, Flags);                            \
         FBindingHandle_.Method("bool opEquals(const " #_HandleType_ "& Other) const",                                        \
-        METHODPR_TRIVIAL(bool, _HandleType_, operator==, (const _HandleType_&) const));                                      \
+        [](const _HandleType_& In1, const _HandleType_& In2)                                                                 \
+	    {                                                                                                                    \
+		    return In1.ConvertToHandle() == In2.ConvertToHandle();                                                           \
+	    });                                                                                                                  \
     });                                                                                                                      \
     inline AS_FORCE_LINK const FAngelscriptBinds::FBind BindEquals_##_HandleType_##_To_FCk_Handle (                         \
         FAngelscriptBinds::EOrder::Early, []                                                                                \


### PR DESCRIPTION
…a direct dependency

*  Uses a lambda instead of a pointer to == operator to avoid linker error
*  This occurs when the header is included in a module that doesn't directly add the header's module as a dependency.
   *  Example: Module A depends on B depends on C (publicly). Module A includes a header for typesafe handle in C. Previously this would cause a linker error even if A does not use the typesafe handle from C