### PR TITLE
feat: clarify entity destruction pipeline naming and add lifecycle ev…

### DIFF
--- a/Config/DefaultCkFoundation.ini
+++ b/Config/DefaultCkFoundation.ini
@@ -299,6 +299,8 @@
 +FunctionRedirects=(OldName="/Script/CkInteraction.Ck_Utils_InteractTarget_UE.Get_CustomValidation",NewName="/Script/CkInteraction.Ck_Utils_InteractTarget_UE.RunCustomValidation")
 +EnumRedirects=(OldName="/Script/CkInteraction.ECk_CanInteractWithResult",ValueChanges=(("MultipleInteractionsDisabledForTarget","TargetRejectedSecondInteraction")))
 +EnumRedirects=(OldName="/Script/CkInteraction.ECk_CanInteractWithResult",ValueChanges=(("MultipleInteractionsDisabledForSource","SourceRejectedSecondInteraction")))
++EnumRedirects=(OldName="/Script/CkEcs.ECk_EntityLifetime_DestructionPhase",ValueChanges=(("Confirmed","TearingDown")))
++EnumRedirects=(OldName="/Script/CkEcs.ECk_EntityLifetime_DestructionPhase",ValueChanges=(("InitiatedOrConfirmed","Destroyed")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
+++ b/Source/CkAbility/Public/CkAbility/AbilityOwner/CkAbilityOwner_Processor.cpp
@@ -690,7 +690,7 @@ namespace ck
                 return;
             }
 
-            if (UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InAbilityToActivateEntity, ECk_EntityLifetime_DestructionPhase::InitiatedOrConfirmed))
+            if (UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InAbilityToActivateEntity, ECk_EntityLifetime_DestructionPhase::Destroyed))
             {
                 ability::Verbose
                 (

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Fragment.h
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Fragment.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "CkEcs/Tag/CkTag.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Fragment_Data.h"
@@ -9,18 +9,98 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 /*
- * Destruction Pipeline:
- * => Entity Destruction Request = DestroyEntity_Initiate (Entity is still valid)
+ * Entity Destruction Pipeline
+ * ===========================
  *
- * ---> Processors have a chance to reason about an Entity that has initiated destruction
+ * When Destroy(Entity) is called, the entity goes through a multi-frame destruction process
+ * to ensure all systems have proper opportunity to clean up before the entity is invalidated.
  *
- * => End of Frame = DestroyEntity_Initiate_Confirm (Entity is still valid)
- *     - Initiate_Confirm is needed to guarantee that 'Initiate' will last 1 full frame
+ * Overview:
+ * ---------
+ * Frame N:     DestroyEntity_Initiate → DestroyEntity_Initiate_Confirm (at end of frame)
+ * Frame N+1:   DestroyEntity_Initiate_Confirm → DestroyEntity_Await (at start of frame)
+ * Frame N+2:   DestroyEntity_Await → DestroyEntity_Finalize (sequential at start of frame)
  *
- * ---> Teardown Processors can hook in here as this is their last chance to deal with an Entity that is about to be Invalidated
  *
- * => Start of Frame = DestroyEntity_Initiate CONVERTS TO DestroyEntity_Await (Entity is now Invalid)
- * => Start of NEXT Frame = DestroyEntity_Initiate CONVERT TO DestroyEntity_Finalize
+ * Detailed Flow:
+ * ==============
+ *
+ * Frame N                    Frame N+1                    Frame N+2
+ * ┌──────────────────┐      ┌──────────────────────-┐     ┌────────────────────┐
+ * │ DestroyEntity_   │      │ DestroyEntity_        │     │ Sequential at      │
+ * │ Initiate         │      │ Initiate_Confirm      │     │ start of frame:    │
+ * │                  │      │        │              │     │                    │
+ * │ Entity VALID     │      │        ▼              │     │ Await →            │
+ * │                  │      │ Teardown processors   │     │ Finalize →         │
+ * │ Regular          │      │ run here (between     │ ───►│ Entity Destroyed   │
+ * │ processors       │      │ Initiate_Confirm      │     │                    │
+ * │ MAY run          │      │ and Await)            │     │ Entity INVALID     │
+ * │ (timing          │      │        │              │     │ Memory reclaimed   │
+ * │ dependent)       │      │        ▼              │     │                    │
+ * │                  │      │ DestroyEntity_        │     │                    │
+ * │        │         │      │ Await                 │     │                    │
+ * │        ▼         │      │                       │     │                    │
+ * │ At END of frame: │      │ Entity handle VALID   │     │                    │
+ * │ Initiate →       │      │ but component data    │     │                    │
+ * │ Initiate_Confirm │ ────►│ may be torn down      │     │                    │
+ * │                  │      │                       │     │                    │
+ * │                  │      │ Processors can access │     │                    │
+ * │                  │      │ with Await entities   │     │                    │
+ * │                  │      │ but must handle       │     │                    │
+ * │                  │      │ missing/invalid data  │     │                    │
+ * └──────────────────┘      └──────────────────────-┘     └────────────────────┘
+ *
+ *    Destroy(Entity)         Initiate_Confirm only        Sequential processing:
+ *    called anytime          seen by processors            JustBeforeDestruction
+ *    during frame            injected BEFORE the           → Await → Finalize
+ *                           Confirm→Await conversion       → Entity Destroyed
+ *
+ *
+ * Processor Execution Order (within each frame):
+ * ==============================================
+ *
+ * JustBeforeDestruction Injection Point:
+ * ├── FProcessor_OwningActor_Destroy
+ * ├── FProcessor_EntityLifetime_DestructionPhase_Finalize
+ * └── FProcessor_EntityLifetime_DestructionPhase_Await
+ *
+ * ... (other regular processors and gameplay pump) ...
+ *
+ * End of Frame Processors:
+ * ├── FProcessor_EntityLifetime_EntityJustCreated
+ * ├── FProcessor_EntityLifetime_DestroyEntity
+ * └── FProcessor_EntityLifetime_DestructionPhase_InitiateConfirm
+ *
+ *
+ * Key Guarantees & Design Rationale:
+ * ==================================
+ *
+ * 1. INITIATE Phase (Frame N):
+ *    - Entity remains valid
+ *    - Destroy() can be called anytime during frame
+ *    - Not all regular processors guaranteed to run with Initiate state (timing dependent)
+ *    - At END of frame: Initiate → Initiate_Confirm transition occurs
+ *
+ * 2. INITIATE_CONFIRM Phase (Frame N+1):
+ *    - "Helper phase" for cascading destruction edge case
+ *    - Problem: When teardown processors run, they may trigger destruction of OTHER entities
+ *    - Without Initiate_Confirm, those newly-destroyed entities would skip to Await immediately
+ *    - Solution: Initiate_Confirm ensures cascading destructions still get proper processor treatment
+ *    - Only seen by processors injected BEFORE Initiate_Confirm → Await conversion
+ *    - Most processors won't see this phase
+ *
+ * 3. AWAIT Phase (Frame N+1 → N+2):
+ *    - The ONLY guaranteed full-frame destruction phase
+ *    - Teardown processors run between Initiate_Confirm → Await transition
+ *    - Entity handle remains VALID but component data may be torn down
+ *    - Processors can work with Await entities but must handle missing/invalid data gracefully
+ *    - Entity data has no guarantees after teardown processors have run
+ *
+ * 4. FINALIZE Phase (Frame N+2):
+ *    - Sequential processing: Await → Finalize → Entity Destroyed (all at start of frame)
+ *    - Entity becomes INVALID and memory is reclaimed
+ *    - No processors run between these sequential operations
+ *
  */
 
 namespace ck
@@ -84,7 +164,9 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    CK_DEFINE_SIGNAL_AND_UTILS_WITH_DELEGATE(CKECS_API, EntityDestroyed, FCk_Delegate_Lifetime_OnDestroy_MC, FCk_Handle);
+    CK_DEFINE_SIGNAL_AND_UTILS_WITH_DELEGATE(CKECS_API, OnEntityBeginDestroy, FCk_Delegate_OnBeginDestroy_MC, FCk_Handle);
+    CK_DEFINE_SIGNAL_AND_UTILS_WITH_DELEGATE(CKECS_API, OnEntityTeardown, FCk_Delegate_OnTeardown_MC, FCk_Handle);
+    CK_DEFINE_SIGNAL_AND_UTILS_WITH_DELEGATE(CKECS_API, OnEntityDestroyed, FCk_Delegate_OnDestroy_MC, FCk_Entity);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Fragment_Data.h
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Fragment_Data.h
@@ -34,9 +34,9 @@ enum class ECk_EntityLifetime_DestructionPhase : uint8
     // Entity is still Valid for the remainder of THIS frame
     Initiated,
     // Entity has been invalidated and is no longer safe to mutate
-    Confirmed,
+    TearingDown,
     // Entity may be in any destruction phase
-    InitiatedOrConfirmed
+    Destroyed
 };
 
 CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_EntityLifetime_DestructionPhase);
@@ -44,11 +44,27 @@ CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_EntityLifetime_DestructionPhase);
 // --------------------------------------------------------------------------------------------------------------------
 
 DECLARE_DYNAMIC_DELEGATE_OneParam(
-    FCk_Delegate_Lifetime_OnDestroy,
+    FCk_Delegate_OnBeginDestroy,
     FCk_Handle, InHandle);
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
-    FCk_Delegate_Lifetime_OnDestroy_MC,
+    FCk_Delegate_OnBeginDestroy_MC,
     FCk_Handle, InHandle);
+
+DECLARE_DYNAMIC_DELEGATE_OneParam(
+    FCk_Delegate_OnTeardown,
+    FCk_Handle, InHandle);
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FCk_Delegate_OnTeardown_MC,
+    FCk_Handle, InHandle);
+
+DECLARE_DYNAMIC_DELEGATE_OneParam(
+    FCk_Delegate_OnDestroyed,
+    FCk_Entity, InHandle);
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
+    FCk_Delegate_OnDestroy_MC,
+    FCk_Entity, InHandle);
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
@@ -39,6 +39,11 @@ namespace ck
     {
         ecs::VeryVerbose(TEXT("[DESTRUCTION] Entity [{}] set to 'Awaiting Destruction'"), InHandle);
         InHandle.Add<FTag_DestroyEntity_Initiate_Confirm>();
+
+        if (ck::UUtils_Signal_OnEntityTeardown::Has(InHandle))
+        {
+            ck::UUtils_Signal_OnEntityTeardown::Broadcast(InHandle, ck::MakePayload(InHandle));
+        }
     }
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -139,9 +144,9 @@ namespace ck
                 });
         }
 
-        if (ck::UUtils_Signal_EntityDestroyed::Has(InHandle))
+        if (ck::UUtils_Signal_OnEntityDestroyed::Has(InHandle))
         {
-            ck::UUtils_Signal_EntityDestroyed::Broadcast(InHandle, ck::MakePayload(InHandle));
+            ck::UUtils_Signal_OnEntityDestroyed::Broadcast(InHandle, ck::MakePayload(InHandle.Get_Entity()));
         }
 
         _EntitiesToDestroy.Emplace(InHandle.Get_Entity());

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -53,6 +53,12 @@ auto
 
     auto LifetimeDependents = Get_LifetimeDependents(InHandle);
     Request_DestroyEntities(LifetimeDependents);
+
+    // broadcast AFTER walking the dependents since destruction order should be leaf-to-root
+    if (ck::UUtils_Signal_OnEntityBeginDestroy::Has(InHandle))
+    {
+        ck::UUtils_Signal_OnEntityBeginDestroy::Broadcast(InHandle, ck::MakePayload(InHandle));
+    }
 }
 
 auto
@@ -155,15 +161,15 @@ auto
     {
         case ECk_EntityLifetime_DestructionPhase::Initiated:
         {
-            return InHandle.Has_Any<ck::FTag_DestroyEntity_Initiate>();
+            return InHandle.Has_Any<ck::FTag_DestroyEntity_Initiate_Confirm>();
         }
-        case ECk_EntityLifetime_DestructionPhase::Confirmed:
+        case ECk_EntityLifetime_DestructionPhase::TearingDown:
         {
             return InHandle.Has_Any<ck::FTag_DestroyEntity_Await, ck::FTag_DestroyEntity_Finalize>();
         }
-        case ECk_EntityLifetime_DestructionPhase::InitiatedOrConfirmed:
+        case ECk_EntityLifetime_DestructionPhase::Destroyed:
         {
-            return InHandle.Has_Any<ck::FTag_DestroyEntity_Initiate, ck::FTag_DestroyEntity_Await, ck::FTag_DestroyEntity_Finalize>();
+            return InHandle.Has_Any<ck::FTag_DestroyEntity_Initiate_Confirm, ck::FTag_DestroyEntity_Await, ck::FTag_DestroyEntity_Finalize>();
         }
         default:
         {
@@ -235,7 +241,7 @@ auto
     BindTo_OnDestroy(
         FCk_Handle& InHandle,
         ECk_Signal_BindingPolicy InBehavior,
-        const FCk_Delegate_Lifetime_OnDestroy& InDelegate)
+        const FCk_Delegate_OnDestroyed& InDelegate)
     -> void
 {
     ck::UUtils_Signal_EntityDestroyed::Bind(InHandle, InDelegate, InBehavior);
@@ -245,7 +251,7 @@ auto
     UCk_Utils_EntityLifetime_UE::
     UnbindFrom_OnDestroy(
         FCk_Handle& InHandle,
-        const FCk_Delegate_Lifetime_OnDestroy& InDelegate)
+        const FCk_Delegate_OnDestroyed& InDelegate)
     -> void
 {
     ck::UUtils_Signal_EntityDestroyed::Unbind(InHandle, InDelegate);

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.h
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.h
@@ -112,7 +112,7 @@ public:
     static bool
     Get_IsPendingDestroy(
         const FCk_Handle& InHandle,
-        ECk_EntityLifetime_DestructionPhase InDestructionPhase = ECk_EntityLifetime_DestructionPhase::Confirmed);
+        ECk_EntityLifetime_DestructionPhase InDestructionPhase = ECk_EntityLifetime_DestructionPhase::TearingDown);
 
     UFUNCTION(BlueprintPure,
               DisplayName = "[Ck][Lifetime] Is Transient Entity?",
@@ -146,7 +146,7 @@ public:
     BindTo_OnDestroy(
         UPARAM(ref) FCk_Handle& InHandle,
         ECk_Signal_BindingPolicy InBehavior,
-        const FCk_Delegate_Lifetime_OnDestroy& InDelegate);
+        const FCk_Delegate_OnDestroyed& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Lifetime",
@@ -154,7 +154,7 @@ public:
     static void
     UnbindFrom_OnDestroy(
         UPARAM(ref) FCk_Handle& InHandle,
-        const FCk_Delegate_Lifetime_OnDestroy& InDelegate);
+        const FCk_Delegate_OnDestroyed& InDelegate);
 
 public:
     // These functions already exist on Net_Utils (which are now a pass-through). The reason they exist on this


### PR DESCRIPTION
…ents

- rename destruction phases: Confirmed→TearingDown, InitiatedOrConfirmed→Destroyed
- add comprehensive documentation explaining the existing multi-frame destruction flow
- add EntityBeginDestroy and EntityTeardown events alongside existing EntityDestroyed
- fix destruction phase detection logic to use correct tag checks
- update delegate parameter types for consistency (FCk_Entity vs FCk_Handle)
- add config redirects for renamed enum values to maintain compatibility