### PR TITLE
Feature/add tag command

### DIFF
--- a/Source/CkAnimation/Public/CkAnimation/CkAnimation_Utils.cpp
+++ b/Source/CkAnimation/Public/CkAnimation/CkAnimation_Utils.cpp
@@ -214,4 +214,21 @@ auto
 	return UPlayMontageCallbackProxy::CreateProxyObjectForPlayMontage(InSkeletalMeshComponent, MontageToPlay, PlayRate, StartingPosition, StartingSection, ShouldStopAllMontages);
 }
 
+auto
+    UCk_Utils_Animation_UE::
+    Get_RootMotion(
+        UAnimSequence* InAnimSequence)
+    -> FTransform
+{
+    CK_ENSURE_IF_NOT(InAnimSequence,
+		TEXT("Anim Sequence provided is NOT valid!"))
+    { return {}; }
+
+    const auto& DeltaTime = FDeltaTimeRecord{InAnimSequence->GetPlayLength()};
+    // Putting in 0.f as a literal tries to use the float constructor which is deprecated
+    static constexpr double ZeroAsADouble = 0.f;
+    const auto& ExtractionParams = FAnimExtractContext{ZeroAsADouble, true, DeltaTime, false};
+    return InAnimSequence->ExtractRootMotion(ExtractionParams);
+}
+
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAnimation/Public/CkAnimation/CkAnimation_Utils.h
+++ b/Source/CkAnimation/Public/CkAnimation/CkAnimation_Utils.h
@@ -166,6 +166,13 @@ public:
 		float StartingPosition = 0.f,
 		FName StartingSection = NAME_None,
 		bool ShouldStopAllMontages = true);
+
+    UFUNCTION(BlueprintCallable,
+              DisplayName="[Ck] Extract Root Motion",
+              Category = "Ck|Utils|Animation")
+    static FTransform
+    Get_RootMotion(
+        UAnimSequence* InAnimSequence);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCoreEditor/Public/CkCoreEditor/Console/CkGameplayTag_EditorConsoleCommands.cpp
+++ b/Source/CkCoreEditor/Public/CkCoreEditor/Console/CkGameplayTag_EditorConsoleCommands.cpp
@@ -1,0 +1,38 @@
+﻿#include "CkGameplayTag_EditorConsoleCommands.h"
+
+#include "CkCoreEditor/CkCoreEditor_Log.h"
+
+#include "HAL/IConsoleManager.h"
+
+// ----------------------------------------------------------------------------------------------------------------
+
+namespace ck
+{
+    static FAutoConsoleCommand AddGameplayTagCmd(
+        TEXT("AddGameplayTag"),
+        TEXT("AddGameplayTag <TagName> [OptionalDescription]\nAdds a gameplay tag. Can use '.' or '_' as separators."),
+        FConsoleCommandWithArgsDelegate::CreateLambda([](const TArray<FString>& Args)
+        {
+            if (Args.Num() < 1)
+            {
+                core_editor::Warning(TEXT("Usage: AddGameplayTag <TagName> [OptionalDescription]"));
+                return;
+            }
+
+            auto TagName = Args[0];
+            const auto& Description = Args.Num() > 1 ? Args[1] : TEXT("Added via AddGameplayTag console command");
+
+            // if no period separators, assume this is using Angelscript tag name format which separates with underscores instead
+            if (NOT TagName.Contains(TEXT(".")))
+            {
+                TagName = TagName.Replace(TEXT("_"), TEXT("."));
+            }
+
+            core_editor::Display(TEXT("Adding gameplay tag: [{}] (Description: [{}])"), TagName, Description);
+
+            UCk_Utils_GameplayTag_UE::ResolveGameplayTag(FName(TagName), Description);
+        })
+    );
+}
+
+// ----------------------------------------------------------------------------------------------------------------

--- a/Source/CkCoreEditor/Public/CkCoreEditor/Console/CkGameplayTag_EditorConsoleCommands.h
+++ b/Source/CkCoreEditor/Public/CkCoreEditor/Console/CkGameplayTag_EditorConsoleCommands.h
@@ -1,0 +1,1 @@
+﻿#pragma once


### PR DESCRIPTION
commit 4264a9a3d44541acb090c11ec7546256b6a583e2 (HEAD -> feature/add-tag-command, origin/feature/add-tag-command)
Author: AlexObatake <aobatake1515@gmail.com>
Date:   Wed Sep 24 13:07:46 2025 -0700

    feat: Getter for anim root motion

    Gets the total root motion of an animation in BP

commit b8eae55c4c3835811aab3d98c6bf417b07eb534e
Author: AlexObatake <aobatake1515@gmail.com>
Date:   Wed Sep 24 13:06:49 2025 -0700

    feat: Add console command to add Gameplay Tags

    *  Simple command to add a tag to default gameplay tags
    *  Can be run through editor console (doesn't need to be in PIE)
    *  Works with period or underscore separated names