### PR TITLE
Feature/unity build enable

### DIFF
--- a/Source/CkAssetExporter/CkAssetExporter.Build.cs
+++ b/Source/CkAssetExporter/CkAssetExporter.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkAssetExporter : CkModuleRules
 {
-    public CkAssetExporter(ReadOnlyTargetRules Target) : base(Target)
+    public CkAssetExporter(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
     {
         PrivateIncludePaths.AddRange(new string[] {
             ModuleDirectory,

--- a/Source/CkBuildConfig/CkBuildConfig.Build.cs
+++ b/Source/CkBuildConfig/CkBuildConfig.Build.cs
@@ -198,7 +198,7 @@ public class CkModuleRules : ModuleRules
         }
     }
 
-    public CkModuleRules(ReadOnlyTargetRules Target, bool UseUnityBuild = false) : base(Target)
+    public CkModuleRules(ReadOnlyTargetRules Target, bool UseUnityBuild = true) : base(Target)
     {
         bUseUnity = UseUnityBuild;
         CppStandard = CppStandardVersion.Cpp20;

--- a/Source/CkCueEditor/CkCueEditor.Build.cs
+++ b/Source/CkCueEditor/CkCueEditor.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkCueEditor : CkModuleRules
 {
-    public CkCueEditor(ReadOnlyTargetRules Target) : base(Target)
+    public CkCueEditor(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkInput/CkInput.Build.cs
+++ b/Source/CkInput/CkInput.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkInput : CkModuleRules
 {
-    public CkInput(ReadOnlyTargetRules Target) : base(Target)
+    public CkInput(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkPmg/CkPmg.Build.cs
+++ b/Source/CkPmg/CkPmg.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkPmg : CkModuleRules
 {
-    public CkPmg(ReadOnlyTargetRules Target) : base(Target)
+    public CkPmg(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkStateMachine/CkStateMachine.Build.cs
+++ b/Source/CkStateMachine/CkStateMachine.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkStateMachine : CkModuleRules
 {
-    public CkStateMachine(ReadOnlyTargetRules Target) : base(Target)
+    public CkStateMachine(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...


### PR DESCRIPTION
chore: enable unity build by default for all Ck

Flipping the UseUnityBuild default in CkModuleRules from false to true
drops cold/full rebuild times substantially by letting UBT batch source
files into unity blobs across the ~90 Ck modules. Per-module opt-out
via 'base(Target, UseUnityBuild: false)' is still available for modules
that cannot tolerate unity (see follow-up commits).

[chore: opt modules with latent ODR issues out of unity build](https://github.com/chainkemists/CkFoundation/commit/de816388b5dd44a5ea3656e46a39e6886bacb1d7) 

Five modules fail to compile under unity build because of pre-existing
symbol collisions that were masked by per-file compilation:

- CkInput: Get_EISubsystem anonymous-namespace helper duplicated
  across CkInput_Utils.cpp and CkKeyBinding_Utils.cpp.
- CkPmg: GetAxisRotation, ApplyAxisRotation, SetupMeshComponent,
  FinalizeMeshComponent anonymous-namespace helpers duplicated across
  the five processor .cpps (Basic/Angular/Flat/Directional/Symbol).
- CkStateMachine: ComputeTagFromClassName duplicated across the state,
  condition, and task entity-script .cpps.
- CkAssetExporter: ck::asset_exporter::DoExecuteExportAction defined
  in both CkEQSExporter_AssetAction.cpp and
  CkBehaviorTreeExporter_AssetAction.cpp — a real ODR violation in a
  *named* namespace, silently broken even without unity.
- CkCueEditor: FCk_CueToolbox_CueInfo struct defined in both
  CkCueToolbox.h and CkCueToolbox_EditorUtilityWidget.h.

Opting these out unblocks unity build for the other ~85 modules while
the underlying bugs are fixed. Follow-up work should rename the
anonymous-namespace helpers (or hoist them into a shared header), fix
the CkAssetExporter ODR violation regardless of unity, and consolidate
the duplicate FCk_CueToolbox_CueInfo declaration — then re-enable
unity for each module.