### PR TITLE
fix: re-enable unity build for 5 modules + add plane-axis rotation helpers to CkCore

### DIFF
--- a/Source/CkAssetExporter/CkAssetExporter.Build.cs
+++ b/Source/CkAssetExporter/CkAssetExporter.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkAssetExporter : CkModuleRules
 {
-    public CkAssetExporter(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
+    public CkAssetExporter(ReadOnlyTargetRules Target) : base(Target)
     {
         PrivateIncludePaths.AddRange(new string[] {
             ModuleDirectory,

--- a/Source/CkAssetExporter/Public/CkAssetExporter/AssetAction/CkBehaviorTreeExporter_AssetAction.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/AssetAction/CkBehaviorTreeExporter_AssetAction.cpp
@@ -72,7 +72,7 @@ static auto
 }
 
 static auto
-    DoExecuteExportAction()
+    DoExecuteExportAction_BehaviorTree()
     -> void
 {
     const auto BehaviorTrees = DoGetSelectedBehaviorTrees();
@@ -119,7 +119,7 @@ auto
                 FSlateIcon(),
                 FToolMenuExecuteAction::CreateLambda([](const FToolMenuContext& /*InContext*/)
                 {
-                    DoExecuteExportAction();
+                    DoExecuteExportAction_BehaviorTree();
                 })
             );
         })

--- a/Source/CkAssetExporter/Public/CkAssetExporter/AssetAction/CkEQSExporter_AssetAction.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/AssetAction/CkEQSExporter_AssetAction.cpp
@@ -72,7 +72,7 @@ static auto
 }
 
 static auto
-    DoExecuteExportAction()
+    DoExecuteExportAction_EQS()
     -> void
 {
     const auto Queries = DoGetSelectedEQSQueries();
@@ -119,7 +119,7 @@ auto
                 FSlateIcon(),
                 FToolMenuExecuteAction::CreateLambda([](const FToolMenuContext& /*InContext*/)
                 {
-                    DoExecuteExportAction();
+                    DoExecuteExportAction_EQS();
                 })
             );
         })

--- a/Source/CkCore/Public/CkCore/Math/Vector/CkVector_Utils.cpp
+++ b/Source/CkCore/Public/CkCore/Math/Vector/CkVector_Utils.cpp
@@ -780,6 +780,45 @@ auto
     };
 }
 
+auto
+    UCk_Utils_Vector3_UE::
+    Get_PlaneAxisRotation(
+        ECk_Plane_Axis InAxis)
+    -> FQuat
+{
+    switch (InAxis)
+    {
+        case ECk_Plane_Axis::XY: return FQuat::Identity;
+        case ECk_Plane_Axis::XZ: return FQuat(FVector::ForwardVector, PI * 0.5f);
+        case ECk_Plane_Axis::YZ: return FQuat(FVector::RightVector, -PI * 0.5f);
+        default: return FQuat::Identity;
+    }
+}
+
+auto
+    UCk_Utils_Vector3_UE::
+    ApplyPlaneAxisRotation(
+        TArray<FVector>& InOutVertices,
+        TArray<FVector>& InOutNormals,
+        ECk_Plane_Axis InAxis)
+    -> void
+{
+    if (InAxis == ECk_Plane_Axis::XY)
+    { return; }
+
+    const auto Rotation = Get_PlaneAxisRotation(InAxis);
+
+    for (auto& Vertex : InOutVertices)
+    {
+        Vertex = Rotation.RotateVector(Vertex);
+    }
+
+    for (auto& Normal : InOutNormals)
+    {
+        Normal = Rotation.RotateVector(Normal);
+    }
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 auto

--- a/Source/CkCore/Public/CkCore/Math/Vector/CkVector_Utils.h
+++ b/Source/CkCore/Public/CkCore/Math/Vector/CkVector_Utils.h
@@ -177,6 +177,13 @@ public:
         ECk_Plane_Axis InAxis);
 
     UFUNCTION(BlueprintPure,
+              DisplayName = "[Ck] Get Plane Axis Rotation",
+              Category = "Ck|Utils|Math|Vector3")
+    static FQuat
+    Get_PlaneAxisRotation(
+        ECk_Plane_Axis InAxis);
+
+    UFUNCTION(BlueprintPure,
               DisplayName = "[Ck] Get Is Length Greater Than (Vec3)",
               Category = "Ck|Utils|Math|Vector3",
               meta     = (KeyWords = ">"))
@@ -419,6 +426,18 @@ public:
         const FCk_FloatRange& InJitterRangeX,
         const FCk_FloatRange& InJitterRangeY,
         const FCk_FloatRange& InJitterRangeZ);
+
+    // C++-only (not UFUNCTION) — rotates two parallel arrays of vertices and
+    // normals in-place by the rotation for the given plane axis. Used by CkPmg
+    // processors to apply axis rotations to generated mesh data. Not exposed
+    // to Blueprint because the in/out TArray<FVector>& signature is awkward in
+    // BP and the parallel-array semantics are too specific to be generally
+    // useful there.
+    static void
+    ApplyPlaneAxisRotation(
+        TArray<FVector>& InOutVertices,
+        TArray<FVector>& InOutNormals,
+        ECk_Plane_Axis InAxis);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCueEditor/CkCueEditor.Build.cs
+++ b/Source/CkCueEditor/CkCueEditor.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkCueEditor : CkModuleRules
 {
-    public CkCueEditor(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
+    public CkCueEditor(ReadOnlyTargetRules Target) : base(Target)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkCueEditor/Public/CkCueEditor/Toolbox/CkCueToolbox.h
+++ b/Source/CkCueEditor/Public/CkCueEditor/Toolbox/CkCueToolbox.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "CkCue/CkCueSubsystem_Base.h"
+#include "CkCueToolbox_Common.h"
 #include "CkCueToolboxStyle.h"
+
+#include "CkCue/CkCueSubsystem_Base.h"
 
 #include <Widgets/SCompoundWidget.h>
 #include <Widgets/Views/SListView.h>
@@ -10,21 +12,6 @@
 #include <Widgets/Text/STextBlock.h>
 #include <Widgets/Input/SButton.h>
 #include <Widgets/Layout/SBorder.h>
-
-// --------------------------------------------------------------------------------------------------------------------
-
-struct CKCUEEDITOR_API FCk_CueToolbox_CueInfo
-{
-    FGameplayTag CueName;
-    TSubclassOf<UCk_CueBase_EntityScript> CueClass;
-    FString SubsystemName;
-    bool IsValid = true;
-    FString ValidationMessage;
-
-    FCk_CueToolbox_CueInfo() = default;
-    FCk_CueToolbox_CueInfo(const FGameplayTag& InCueName, TSubclassOf<UCk_CueBase_EntityScript> InCueClass, const FString& InSubsystemName)
-        : CueName(InCueName), CueClass(InCueClass), SubsystemName(InSubsystemName) {}
-};
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkCueEditor/Public/CkCueEditor/Toolbox/CkCueToolbox_Common.h
+++ b/Source/CkCueEditor/Public/CkCueEditor/Toolbox/CkCueToolbox_Common.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "CkCue/CkCueSubsystem_Base.h"
+
+#include <CoreMinimal.h>
+#include <GameplayTagContainer.h>
+#include <Templates/SubclassOf.h>
+
+#include "CkCueToolbox_Common.generated.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+USTRUCT(BlueprintType)
+struct CKCUEEDITOR_API FCk_CueToolbox_CueInfo
+{
+    GENERATED_BODY()
+
+public:
+    CK_GENERATED_BODY(FCk_CueToolbox_CueInfo);
+
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FGameplayTag CueName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    TSubclassOf<UCk_CueBase_EntityScript> CueClass;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FString SubsystemName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    bool IsValid = true;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    FString ValidationMessage;
+
+public:
+    FCk_CueToolbox_CueInfo() = default;
+    FCk_CueToolbox_CueInfo(const FGameplayTag& InCueName, TSubclassOf<UCk_CueBase_EntityScript> InCueClass, const FString& InSubsystemName)
+        : CueName(InCueName), CueClass(InCueClass), SubsystemName(InSubsystemName) {}
+};
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCueEditor/Public/CkCueEditor/UtilityWidget/CkCueToolbox_EditorUtilityWidget.h
+++ b/Source/CkCueEditor/Public/CkCueEditor/UtilityWidget/CkCueToolbox_EditorUtilityWidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkCueEditor/Toolbox/CkCueToolbox_Common.h"
+
 #include "EditorUtilityWidget.h"
 
 #include "CkCue/CkCueSubsystem_Base.h"
@@ -13,38 +15,6 @@
 #include "Engine/DataTable.h"
 
 #include "CkCueToolbox_EditorUtilityWidget.generated.h"
-
-// --------------------------------------------------------------------------------------------------------------------
-
-USTRUCT(BlueprintType)
-struct CKCUEEDITOR_API FCk_CueToolbox_CueInfo
-{
-    GENERATED_BODY()
-
-public:
-    CK_GENERATED_BODY(FCk_CueToolbox_CueInfo);
-
-public:
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FGameplayTag CueName;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    TSubclassOf<UCk_CueBase_EntityScript> CueClass;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FString SubsystemName;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    bool IsValid = true;
-
-    UPROPERTY(EditAnywhere, BlueprintReadWrite)
-    FString ValidationMessage;
-
-public:
-    FCk_CueToolbox_CueInfo() = default;
-    FCk_CueToolbox_CueInfo(const FGameplayTag& InCueName, TSubclassOf<UCk_CueBase_EntityScript> InCueClass, const FString& InSubsystemName)
-        : CueName(InCueName), CueClass(InCueClass), SubsystemName(InSubsystemName) {}
-};
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkInput/CkInput.Build.cs
+++ b/Source/CkInput/CkInput.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkInput : CkModuleRules
 {
-    public CkInput(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
+    public CkInput(ReadOnlyTargetRules Target) : base(Target)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkInput/Public/CkInput/CkInput_Utils.cpp
+++ b/Source/CkInput/Public/CkInput/CkInput_Utils.cpp
@@ -77,7 +77,7 @@ auto
 
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace
+namespace ck_input_utils
 {
     auto Get_EISubsystem(const APlayerController* InPlayerController) -> UEnhancedInputLocalPlayerSubsystem*
     {
@@ -105,7 +105,7 @@ auto
     CK_ENSURE_IF_NOT(ck::IsValid(InPlayerController), TEXT("Invalid Player Controller"))
     { return {}; }
 
-    auto* Subsystem = Get_EISubsystem(InPlayerController);
+    auto* Subsystem = ck_input_utils::Get_EISubsystem(InPlayerController);
     CK_ENSURE_IF_NOT(ck::IsValid(Subsystem), TEXT("Enhanced Input Local Player Subsystem not found"))
     { return {}; }
 
@@ -136,7 +136,7 @@ auto
     CK_ENSURE_IF_NOT(ck::IsValid(InPlayerController), TEXT("Invalid Player Controller"))
     { return {}; }
 
-    auto* Subsystem = Get_EISubsystem(InPlayerController);
+    auto* Subsystem = ck_input_utils::Get_EISubsystem(InPlayerController);
     CK_ENSURE_IF_NOT(ck::IsValid(Subsystem), TEXT("Enhanced Input Local Player Subsystem not found"))
     { return {}; }
 
@@ -169,7 +169,7 @@ auto
     CK_ENSURE_IF_NOT(ck::IsValid(NewContext), TEXT("Invalid New Context"))
     { return {}; }
 
-    auto* Subsystem = Get_EISubsystem(InPlayerController);
+    auto* Subsystem = ck_input_utils::Get_EISubsystem(InPlayerController);
     CK_ENSURE_IF_NOT(ck::IsValid(Subsystem), TEXT("Enhanced Input Local Player Subsystem not found"))
     { return {}; }
 

--- a/Source/CkInput/Public/CkInput/CkKeyBinding_Utils.cpp
+++ b/Source/CkInput/Public/CkInput/CkKeyBinding_Utils.cpp
@@ -10,20 +10,13 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
+namespace ck_input_utils
+{
+    auto Get_EISubsystem(const APlayerController* InPlayerController) -> UEnhancedInputLocalPlayerSubsystem*;
+}
+
 namespace
 {
-    auto Get_EISubsystem(const APlayerController* InPlayerController) -> UEnhancedInputLocalPlayerSubsystem*
-    {
-        if (ck::Is_NOT_Valid(InPlayerController))
-        { return nullptr; }
-
-        const auto* LocalPlayer = InPlayerController->GetLocalPlayer();
-        if (ck::Is_NOT_Valid(LocalPlayer))
-        { return nullptr; }
-
-        return LocalPlayer->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>();
-    }
-
     auto Get_CurrentProfile(UEnhancedInputUserSettings* InSettings) -> UEnhancedPlayerMappableKeyProfile*
     {
         if (ck::Is_NOT_Valid(InSettings))
@@ -48,7 +41,7 @@ auto
     CK_ENSURE_IF_NOT(ck::IsValid(InPlayerController), TEXT("Invalid Player Controller"))
     { return {}; }
 
-    auto* Subsystem = Get_EISubsystem(InPlayerController);
+    auto* Subsystem = ck_input_utils::Get_EISubsystem(InPlayerController);
     CK_ENSURE_IF_NOT(ck::IsValid(Subsystem), TEXT("Enhanced Input Local Player Subsystem not found"))
     { return {}; }
 

--- a/Source/CkPmg/CkPmg.Build.cs
+++ b/Source/CkPmg/CkPmg.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkPmg : CkModuleRules
 {
-    public CkPmg(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
+    public CkPmg(ReadOnlyTargetRules Target) : base(Target)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkPmg/Public/CkPmg/CkPmg_Processor_AngularShapes.cpp
+++ b/Source/CkPmg/Public/CkPmg/CkPmg_Processor_AngularShapes.cpp
@@ -1,6 +1,7 @@
 #include "CkPmg_Processor_AngularShapes.h"
 
 #include "CkCore/Debug/CkDebugDraw_Utils.h"
+#include "CkCore/Math/Vector/CkVector_Utils.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 
 #include "CkPmg/CkPmg_Log.h"
@@ -9,52 +10,12 @@
 #include <ProceduralMeshComponent.h>
 
 // --------------------------------------------------------------------------------------------------------------------
-// Axis Rotation Helpers
-// --------------------------------------------------------------------------------------------------------------------
-
-namespace
-{
-    auto GetAxisRotation(ECk_Plane_Axis InAxis) -> FQuat
-    {
-        switch (InAxis)
-        {
-            case ECk_Plane_Axis::XY: return FQuat::Identity;
-            case ECk_Plane_Axis::XZ: return FQuat(FVector::ForwardVector, PI * 0.5f);
-            case ECk_Plane_Axis::YZ: return FQuat(FVector::RightVector, -PI * 0.5f);
-            default: return FQuat::Identity;
-        }
-    }
-
-    auto ApplyAxisRotation(
-        TArray<FVector>& InOutVertices,
-        TArray<FVector>& InOutNormals,
-        ECk_Plane_Axis InAxis)
-        -> void
-    {
-        if (InAxis == ECk_Plane_Axis::XY)
-        { return; }
-
-        const auto Rotation = GetAxisRotation(InAxis);
-
-        for (auto& Vertex : InOutVertices)
-        {
-            Vertex = Rotation.RotateVector(Vertex);
-        }
-
-        for (auto& Normal : InOutNormals)
-        {
-            Normal = Rotation.RotateVector(Normal);
-        }
-    }
-}
-
-// --------------------------------------------------------------------------------------------------------------------
 // Mesh Component Setup Helpers
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace
 {
-    auto SetupMeshComponent(
+    auto SetupMeshComponent_Angular(
         FCk_Handle_Pmg_DebugShape InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
         ck::FFragment_Pmg_DebugShape_Current& InCurrent,
@@ -88,7 +49,7 @@ namespace
         return MeshComponent;
     }
 
-    auto FinalizeMeshComponent(
+    auto FinalizeMeshComponent_Angular(
         UProceduralMeshComponent* InMeshComponent,
         const FCk_Handle& InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
@@ -193,7 +154,7 @@ namespace
             Triangles.Add(BottomCenterIndex + i + 1);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -294,7 +255,7 @@ namespace
             Triangles.Add(BaseIndex + 3);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -399,7 +360,7 @@ namespace
             Triangles.Add(SideStart + 5);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -419,11 +380,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Angular(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Wedge(MeshComponent, InParams.Get_Radius(), InParams.Get_StartAngle(), InParams.Get_EndAngle(), InParams.Get_Segments(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Angular(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -485,11 +446,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Angular(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Arc(MeshComponent, InParams.Get_Radius(), InParams.Get_StartAngle(), InParams.Get_EndAngle(), InParams.Get_Thickness(), InParams.Get_Segments(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Angular(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -565,11 +526,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Angular(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_WedgeCone(MeshComponent, InParams.Get_Radius(), InParams.Get_Height(), InParams.Get_StartAngle(), InParams.Get_EndAngle(), InParams.Get_Segments(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Angular(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {

--- a/Source/CkPmg/Public/CkPmg/CkPmg_Processor_BasicShapes.cpp
+++ b/Source/CkPmg/Public/CkPmg/CkPmg_Processor_BasicShapes.cpp
@@ -1,52 +1,13 @@
 #include "CkPmg_Processor_BasicShapes.h"
 
 #include "CkCore/Debug/CkDebugDraw_Utils.h"
+#include "CkCore/Math/Vector/CkVector_Utils.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 
 #include "CkPmg/CkPmg_Log.h"
 
 #include <MaterialDomain.h>
 #include <ProceduralMeshComponent.h>
-
-// --------------------------------------------------------------------------------------------------------------------
-// Axis Rotation Helpers
-// --------------------------------------------------------------------------------------------------------------------
-
-namespace
-{
-    auto GetAxisRotation(ECk_Plane_Axis InAxis) -> FQuat
-    {
-        switch (InAxis)
-        {
-            case ECk_Plane_Axis::XY: return FQuat::Identity;
-            case ECk_Plane_Axis::XZ: return FQuat(FVector::ForwardVector, PI * 0.5f); break;
-            case ECk_Plane_Axis::YZ: return FQuat(FVector::RightVector, -PI * 0.5f);
-            default: return FQuat::Identity;
-        }
-    }
-
-    auto ApplyAxisRotation(
-        TArray<FVector>& InOutVertices,
-        TArray<FVector>& InOutNormals,
-        ECk_Plane_Axis InAxis)
-        -> void
-    {
-        if (InAxis == ECk_Plane_Axis::XY)
-        { return; }
-
-        const auto Rotation = GetAxisRotation(InAxis);
-
-        for (auto& Vertex : InOutVertices)
-        {
-            Vertex = Rotation.RotateVector(Vertex);
-        }
-
-        for (auto& Normal : InOutNormals)
-        {
-            Normal = Rotation.RotateVector(Normal);
-        }
-    }
-}
 
 // --------------------------------------------------------------------------------------------------------------------
 // Shape Generation Functions
@@ -105,7 +66,7 @@ namespace
             }
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -166,7 +127,7 @@ namespace
             Triangles.Add(BaseIndex + 3);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -238,7 +199,7 @@ namespace
             Triangles.Add(BaseCenter + i + 2);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -334,7 +295,7 @@ namespace
             Triangles.Add(TopCenter + i + 1);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -464,7 +425,7 @@ namespace
             }
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -540,7 +501,7 @@ namespace
         Triangles.Add(BaseStart + 2);
         Triangles.Add(BaseStart + 3);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -618,7 +579,7 @@ namespace
             Triangles.Add(BaseCenter + i + 2);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -686,7 +647,7 @@ namespace
             }
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -700,7 +661,7 @@ namespace
 
 namespace
 {
-    auto SetupMeshComponent(
+    auto SetupMeshComponent_Basic(
         FCk_Handle_Pmg_DebugShape InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
         ck::FFragment_Pmg_DebugShape_Current& InCurrent,
@@ -734,7 +695,7 @@ namespace
         return MeshComponent;
     }
 
-    auto FinalizeMeshComponent(
+    auto FinalizeMeshComponent_Basic(
         UProceduralMeshComponent* InMeshComponent,
         FCk_Handle_Pmg_DebugShape InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
@@ -792,11 +753,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Sphere(MeshComponent, InParams.Get_Radius(), InParams.Get_Segments(), InParams.Get_Rings(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -808,7 +769,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rot = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rot * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;
@@ -881,11 +842,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Box(MeshComponent, InParams.Get_Extent(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -897,7 +858,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rotation = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rotation * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;
@@ -915,11 +876,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Cone(MeshComponent, InParams.Get_Radius(), InParams.Get_Height(), InParams.Get_Segments(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -931,7 +892,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rot = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rot * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;
@@ -977,11 +938,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Cylinder(MeshComponent, InParams.Get_Radius(), InParams.Get_Height(), InParams.Get_Segments(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -993,7 +954,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rot = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rot * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;
@@ -1053,11 +1014,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Capsule(MeshComponent, InParams.Get_Radius(), InParams.Get_HalfHeight(), InParams.Get_Segments(), InParams.Get_Rings(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -1069,7 +1030,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rotation = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rotation * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;
@@ -1088,11 +1049,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Pyramid(MeshComponent, InParams.Get_BaseSize(), InParams.Get_Height(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -1104,7 +1065,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rot = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rot * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;
@@ -1138,11 +1099,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Hemisphere(MeshComponent, InParams.Get_Radius(), InParams.Get_Segments(), InParams.Get_Rings(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -1154,7 +1115,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rot = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rot * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;
@@ -1226,11 +1187,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Basic(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Torus(MeshComponent, InParams.Get_MajorRadius(), InParams.Get_MinorRadius(), InParams.Get_MajorSegments(), InParams.Get_MinorSegments(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Basic(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -1242,7 +1203,7 @@ namespace ck
                 const auto& Transform = InHandle.Get<FFragment_Transform>();
                 const auto Center = Transform.Get_Transform().GetLocation();
                 const auto Rot = Transform.Get_Transform().GetRotation();
-                const auto AxisRot = GetAxisRotation(InParams.Get_Axis());
+                const auto AxisRot = UCk_Utils_Vector3_UE::Get_PlaneAxisRotation(InParams.Get_Axis());
                 const auto CombinedRot = Rot * AxisRot;
                 auto LineColor = InCommon.Get_Color();
                 LineColor.A = 1.0f;

--- a/Source/CkPmg/Public/CkPmg/CkPmg_Processor_DirectionalShapes.cpp
+++ b/Source/CkPmg/Public/CkPmg/CkPmg_Processor_DirectionalShapes.cpp
@@ -1,6 +1,7 @@
 #include "CkPmg_Processor_DirectionalShapes.h"
 
 #include "CkCore/Debug/CkDebugDraw_Utils.h"
+#include "CkCore/Math/Vector/CkVector_Utils.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 
 #include "CkPmg/CkPmg_Log.h"
@@ -9,46 +10,6 @@
 
 #include <MaterialDomain.h>
 #include <ProceduralMeshComponent.h>
-
-// --------------------------------------------------------------------------------------------------------------------
-// Axis Rotation Helpers
-// --------------------------------------------------------------------------------------------------------------------
-
-namespace
-{
-    auto GetAxisRotation(ECk_Plane_Axis InAxis) -> FQuat
-    {
-        switch (InAxis)
-        {
-            case ECk_Plane_Axis::XY: return FQuat::Identity;
-            case ECk_Plane_Axis::XZ: return FQuat(FVector::ForwardVector, PI * 0.5f);
-            case ECk_Plane_Axis::YZ: return FQuat(FVector::RightVector, -PI * 0.5f);
-            default: return FQuat::Identity;
-        }
-    }
-
-    auto ApplyAxisRotation(
-        TArray<FVector>& InOutVertices,
-        TArray<FVector>& InOutNormals,
-        ECk_Plane_Axis InAxis)
-        -> void
-    {
-        if (InAxis == ECk_Plane_Axis::XY)
-        { return; }
-
-        const auto Rotation = GetAxisRotation(InAxis);
-
-        for (auto& Vertex : InOutVertices)
-        {
-            Vertex = Rotation.RotateVector(Vertex);
-        }
-
-        for (auto& Normal : InOutNormals)
-        {
-            Normal = Rotation.RotateVector(Normal);
-        }
-    }
-}
 
 // --------------------------------------------------------------------------------------------------------------------
 // Shape Generation Functions
@@ -120,7 +81,7 @@ namespace
         UVs.Add(FVector2D(0, 0)); UVs.Add(FVector2D(0.5f, 1)); UVs.Add(FVector2D(1, 0));
         Triangles.Add(BaseIdx + 0); Triangles.Add(BaseIdx + 2); Triangles.Add(BaseIdx + 1);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -140,7 +101,7 @@ namespace
 
 namespace
 {
-    auto SetupMeshComponent(
+    auto SetupMeshComponent_Directional(
         FCk_Handle_Pmg_DebugShape InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
         ck::FFragment_Pmg_DebugShape_Current& InCurrent,
@@ -174,7 +135,7 @@ namespace
         return MeshComponent;
     }
 
-    auto FinalizeMeshComponent(
+    auto FinalizeMeshComponent_Directional(
         UProceduralMeshComponent* InMeshComponent,
         FCk_Handle_Pmg_DebugShape InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
@@ -232,12 +193,12 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Directional(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Arrow(MeshComponent, InParams.Get_Length(), InParams.Get_ShaftWidth(),
                                  InParams.Get_ArrowHeadRatio(), InParams.Get_ArrowHeadWidthMultiplier(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Directional(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {

--- a/Source/CkPmg/Public/CkPmg/CkPmg_Processor_FlatShapes.cpp
+++ b/Source/CkPmg/Public/CkPmg/CkPmg_Processor_FlatShapes.cpp
@@ -1,52 +1,13 @@
 #include "CkPmg_Processor_FlatShapes.h"
 
 #include "CkCore/Debug/CkDebugDraw_Utils.h"
+#include "CkCore/Math/Vector/CkVector_Utils.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 
 #include "CkPmg/CkPmg_Log.h"
 
 #include <MaterialDomain.h>
 #include <ProceduralMeshComponent.h>
-
-// --------------------------------------------------------------------------------------------------------------------
-// Axis Rotation Helpers
-// --------------------------------------------------------------------------------------------------------------------
-
-namespace
-{
-    auto GetAxisRotation(ECk_Plane_Axis InAxis) -> FQuat
-    {
-        switch (InAxis)
-        {
-            case ECk_Plane_Axis::XY: return FQuat::Identity;
-            case ECk_Plane_Axis::XZ: return FQuat(FVector::ForwardVector, PI * 0.5f);
-            case ECk_Plane_Axis::YZ: return FQuat(FVector::RightVector, -PI * 0.5f);
-            default: return FQuat::Identity;
-        }
-    }
-
-    auto ApplyAxisRotation(
-        TArray<FVector>& InOutVertices,
-        TArray<FVector>& InOutNormals,
-        ECk_Plane_Axis InAxis)
-        -> void
-    {
-        if (InAxis == ECk_Plane_Axis::XY)
-        { return; }
-
-        const auto Rotation = GetAxisRotation(InAxis);
-
-        for (auto& Vertex : InOutVertices)
-        {
-            Vertex = Rotation.RotateVector(Vertex);
-        }
-
-        for (auto& Normal : InOutNormals)
-        {
-            Normal = Rotation.RotateVector(Normal);
-        }
-    }
-}
 
 // --------------------------------------------------------------------------------------------------------------------
 // Shape Generation Functions
@@ -138,7 +99,7 @@ namespace
             Triangles.Add(BottomDirectionStartIndex + 0); Triangles.Add(BottomDirectionStartIndex + 3); Triangles.Add(BottomDirectionStartIndex + 2);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -193,7 +154,7 @@ namespace
 
         Triangles.Add(BottomStart + 0); Triangles.Add(BottomStart + 2); Triangles.Add(BottomStart + 1);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -248,7 +209,7 @@ namespace
         Triangles.Add(BottomStart + 0); Triangles.Add(BottomStart + 2); Triangles.Add(BottomStart + 1);
         Triangles.Add(BottomStart + 0); Triangles.Add(BottomStart + 3); Triangles.Add(BottomStart + 2);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -329,7 +290,7 @@ namespace
             Triangles.Add(Next + 1);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -400,7 +361,7 @@ namespace
         Triangles.Add(BaseIdx + 0); Triangles.Add(BaseIdx + 2); Triangles.Add(BaseIdx + 1);
         Triangles.Add(BaseIdx + 0); Triangles.Add(BaseIdx + 3); Triangles.Add(BaseIdx + 2);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -479,7 +440,7 @@ namespace
             Triangles.Add(BottomCenterIndex + i + 1);
         }
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -562,7 +523,7 @@ namespace
         AddQuad(C0, C1, D1p, D0p);    // long stroke
 
         // Rotate into desired axis like your other shapes
-        ApplyAxisRotation(V, N, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(V, N, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, V, T, N, UV,
@@ -633,7 +594,7 @@ namespace
         Triangles.Add(BottomStart + 0); Triangles.Add(BottomStart + 4); Triangles.Add(BottomStart + 3);
         Triangles.Add(BottomStart + 0); Triangles.Add(BottomStart + 1); Triangles.Add(BottomStart + 4);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -647,7 +608,7 @@ namespace
 
 namespace
 {
-    auto SetupMeshComponent(
+    auto SetupMeshComponent_Flat(
         FCk_Handle_Pmg_DebugShape InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
         ck::FFragment_Pmg_DebugShape_Current& InCurrent,
@@ -682,7 +643,7 @@ namespace
     }
 
     auto
-    FinalizeMeshComponent(
+    FinalizeMeshComponent_Flat(
         UProceduralMeshComponent* InMeshComponent,
         FCk_Handle_Pmg_DebugShape InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
@@ -743,11 +704,11 @@ namespace ck
             FFragment_Pmg_DebugShape_Current& InCurrent)
         -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Circle(MeshComponent, InParams.Get_Radius(), InParams.Get_Segments(), InParams.Get_DrawDirectionLine(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -791,11 +752,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Triangle(MeshComponent, InParams.Get_Size(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -844,11 +805,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Plane(MeshComponent, InParams.Get_Width(), InParams.Get_Height(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -893,11 +854,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Ring(MeshComponent, InParams.Get_InnerRadius(), InParams.Get_OuterRadius(), InParams.Get_Segments(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -928,11 +889,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Cross(MeshComponent, InParams.Get_Size(), InParams.Get_Thickness(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -992,11 +953,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Star(MeshComponent, InParams.Get_OuterRadius(), InParams.Get_Points(), InParams.Get_InnerRadiusRatio(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -1054,11 +1015,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Checkmark(MeshComponent, InParams.Get_Size(), InParams.Get_Thickness(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -1112,11 +1073,11 @@ namespace ck
         const FFragment_Pmg_DebugShape_Common& InCommon,
         FFragment_Pmg_DebugShape_Current& InCurrent) -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Flat(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Diamond(MeshComponent, InParams.Get_Width(), InParams.Get_Height(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Flat(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {

--- a/Source/CkPmg/Public/CkPmg/CkPmg_Processor_SymbolShapes.cpp
+++ b/Source/CkPmg/Public/CkPmg/CkPmg_Processor_SymbolShapes.cpp
@@ -1,6 +1,7 @@
 #include "CkPmg_Processor_SymbolShapes.h"
 
 #include "CkCore/Debug/CkDebugDraw_Utils.h"
+#include "CkCore/Math/Vector/CkVector_Utils.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 
 #include "CkPmg/CkPmg_Log.h"
@@ -14,7 +15,7 @@
 
 namespace
 {
-    auto SetupMeshComponent(
+    auto SetupMeshComponent_Symbol(
         FCk_Handle InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
         ck::FFragment_Pmg_DebugShape_Current& InCurrent,
@@ -49,7 +50,7 @@ namespace
         return MeshComponent;
     }
 
-    auto FinalizeMeshComponent(
+    auto FinalizeMeshComponent_Symbol(
         UProceduralMeshComponent* InMeshComponent,
         FCk_Handle InHandle,
         const ck::FFragment_Pmg_DebugShape_Common& InCommon,
@@ -99,46 +100,6 @@ namespace
             const auto& Transform = InHandle.Get<ck::FFragment_Transform>();
             const auto& CurrentTransform = Transform.Get_Transform();
             InMeshComponent->SetWorldTransform(CurrentTransform);
-        }
-    }
-}
-
-// --------------------------------------------------------------------------------------------------------------------
-// Axis Rotation Helpers
-// --------------------------------------------------------------------------------------------------------------------
-
-namespace
-{
-    auto GetAxisRotation(ECk_Plane_Axis InAxis) -> FQuat
-    {
-        switch (InAxis)
-        {
-            case ECk_Plane_Axis::XY: return FQuat::Identity;
-            case ECk_Plane_Axis::XZ: return FQuat(FVector::ForwardVector, PI * 0.5f);
-            case ECk_Plane_Axis::YZ: return FQuat(FVector::RightVector, -PI * 0.5f);
-            default: return FQuat::Identity;
-        }
-    }
-
-    auto ApplyAxisRotation(
-        TArray<FVector>& InOutVertices,
-        TArray<FVector>& InOutNormals,
-        ECk_Plane_Axis InAxis)
-        -> void
-    {
-        if (InAxis == ECk_Plane_Axis::XY)
-        { return; }
-
-        const auto Rotation = GetAxisRotation(InAxis);
-
-        for (auto& Vertex : InOutVertices)
-        {
-            Vertex = Rotation.RotateVector(Vertex);
-        }
-
-        for (auto& Normal : InOutNormals)
-        {
-            Normal = Rotation.RotateVector(Normal);
         }
     }
 }
@@ -204,7 +165,7 @@ namespace
         Triangles.Add(HandleIdx + 0); Triangles.Add(HandleIdx + 1); Triangles.Add(HandleIdx + 2);
         Triangles.Add(HandleIdx + 0); Triangles.Add(HandleIdx + 2); Triangles.Add(HandleIdx + 3);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -280,7 +241,7 @@ namespace
         Triangles.Add(DotIdx + 0); Triangles.Add(DotIdx + 2); Triangles.Add(DotIdx + 3);
         Triangles.Add(DotIdx + 0); Triangles.Add(DotIdx + 3); Triangles.Add(DotIdx + 1);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -327,7 +288,7 @@ namespace
         Triangles.Add(DotIdx + 0); Triangles.Add(DotIdx + 2); Triangles.Add(DotIdx + 3);
         Triangles.Add(DotIdx + 0); Triangles.Add(DotIdx + 3); Triangles.Add(DotIdx + 1);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -369,7 +330,7 @@ namespace
         UVs.Add(FVector2D(0, 1)); UVs.Add(FVector2D(1, 0.5f)); UVs.Add(FVector2D(0, 0));
         Triangles.Add(FlagIdx + 0); Triangles.Add(FlagIdx + 1); Triangles.Add(FlagIdx + 2);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -432,7 +393,7 @@ namespace
         UVs.Add(FVector2D(0, 1)); UVs.Add(FVector2D(1, 1)); UVs.Add(FVector2D(0.5f, 0));
         Triangles.Add(PointIdx + 0); Triangles.Add(PointIdx + 1); Triangles.Add(PointIdx + 2);
 
-        ApplyAxisRotation(Vertices, Normals, InAxis);
+        UCk_Utils_Vector3_UE::ApplyPlaneAxisRotation(Vertices, Normals, InAxis);
 
         InMeshComponent->CreateMeshSection_LinearColor(
             0, Vertices, Triangles, Normals, UVs,
@@ -454,11 +415,11 @@ namespace ck
         FFragment_Pmg_DebugShape_Current& InCurrent)
         -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Symbol(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_MagnifyingGlass(MeshComponent, InParams.Get_Size(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Symbol(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -526,11 +487,11 @@ namespace ck
         FFragment_Pmg_DebugShape_Current& InCurrent)
         -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Symbol(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_QuestionMark(MeshComponent, InParams.Get_Size(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Symbol(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -618,11 +579,11 @@ namespace ck
         FFragment_Pmg_DebugShape_Current& InCurrent)
         -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Symbol(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_ExclamationMark(MeshComponent, InParams.Get_Size(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Symbol(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -684,11 +645,11 @@ namespace ck
         FFragment_Pmg_DebugShape_Current& InCurrent)
         -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Symbol(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Flag(MeshComponent, InParams.Get_Size(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Symbol(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {
@@ -749,11 +710,11 @@ namespace ck
         FFragment_Pmg_DebugShape_Current& InCurrent)
         -> void
     {
-        auto MeshComponent = SetupMeshComponent(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        auto MeshComponent = SetupMeshComponent_Symbol(InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
         if (ck::Is_NOT_Valid(MeshComponent)) { return; }
 
         GenerateDebugShape_Pin(MeshComponent, InParams.Get_Size(), InParams.Get_Axis());
-        FinalizeMeshComponent(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
+        FinalizeMeshComponent_Symbol(MeshComponent, InHandle, InCommon, InCurrent, InDeltaT.Get_Seconds());
 
         if (InCommon.Get_DrawLines())
         {

--- a/Source/CkStateMachine/CkStateMachine.Build.cs
+++ b/Source/CkStateMachine/CkStateMachine.Build.cs
@@ -3,7 +3,7 @@ using UnrealBuildTool;
 
 public class CkStateMachine : CkModuleRules
 {
-    public CkStateMachine(ReadOnlyTargetRules Target) : base(Target, UseUnityBuild: false)
+    public CkStateMachine(ReadOnlyTargetRules Target) : base(Target)
     {
         PrivateIncludePaths.AddRange(new string[] {
             // ... add other private include paths required here ...

--- a/Source/CkStateMachine/Public/CkStateMachine/EntityScripts/CkSmCondition_EntityScript.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/EntityScripts/CkSmCondition_EntityScript.cpp
@@ -101,20 +101,9 @@ auto
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static auto
-    ComputeTagFromClassName(
-        const FString& InClassName,
-        const FString& InComment)
-    -> FGameplayTag
+namespace ck_state_machine_entity_script
 {
-    auto ClassName = InClassName;
-
-    if (ClassName.EndsWith(TEXT("_C")))
-    { ClassName = ClassName.LeftChop(2); }
-
-    ClassName = ClassName.Replace(TEXT("_"), TEXT("."));
-
-    return UCk_Utils_GameplayTag_UE::ResolveGameplayTag(*ClassName, InComment);
+    auto ComputeTagFromClassName(const FString& InClassName, const FString& InComment) -> FGameplayTag;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -124,7 +113,7 @@ auto
     Get_ConditionTag() const
     -> FGameplayTag
 {
-    return ComputeTagFromClassName(
+    return ck_state_machine_entity_script::ComputeTagFromClassName(
         GetClass()->GetName(),
         ck::Format_UE(TEXT("Auto-generated condition tag for {}"), GetClass()));
 }
@@ -141,7 +130,7 @@ auto
         TEXT("Invalid condition class in Get_ConditionTagForClass"))
     { return {}; }
 
-    return ComputeTagFromClassName(
+    return ck_state_machine_entity_script::ComputeTagFromClassName(
         InClass->GetName(),
         ck::Format_UE(TEXT("Auto-generated condition tag for {}"), *InClass->GetName()));
 }

--- a/Source/CkStateMachine/Public/CkStateMachine/EntityScripts/CkSmState_EntityScript.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/EntityScripts/CkSmState_EntityScript.cpp
@@ -273,20 +273,23 @@ auto
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static auto
-    ComputeTagFromClassName(
-        const FString& InClassName,
-        const FString& InComment)
-    -> FGameplayTag
+namespace ck_state_machine_entity_script
 {
-    auto ClassName = InClassName;
+    auto
+        ComputeTagFromClassName(
+            const FString& InClassName,
+            const FString& InComment)
+        -> FGameplayTag
+    {
+        auto ClassName = InClassName;
 
-    if (ClassName.EndsWith(TEXT("_C")))
-    { ClassName = ClassName.LeftChop(2); }
+        if (ClassName.EndsWith(TEXT("_C")))
+        { ClassName = ClassName.LeftChop(2); }
 
-    ClassName = ClassName.Replace(TEXT("_"), TEXT("."));
+        ClassName = ClassName.Replace(TEXT("_"), TEXT("."));
 
-    return UCk_Utils_GameplayTag_UE::ResolveGameplayTag(*ClassName, InComment);
+        return UCk_Utils_GameplayTag_UE::ResolveGameplayTag(*ClassName, InComment);
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -296,7 +299,7 @@ auto
     Get_StateTag() const
     -> FGameplayTag
 {
-    return ComputeTagFromClassName(
+    return ck_state_machine_entity_script::ComputeTagFromClassName(
         GetClass()->GetName(),
         ck::Format_UE(TEXT("Auto-generated state tag for {}"), GetClass()));
 }
@@ -313,7 +316,7 @@ auto
         TEXT("Invalid state class in Get_StateTagForClass"))
     { return {}; }
 
-    return ComputeTagFromClassName(
+    return ck_state_machine_entity_script::ComputeTagFromClassName(
         InClass->GetName(),
         ck::Format_UE(TEXT("Auto-generated state tag for {}"), *InClass->GetName()));
 }

--- a/Source/CkStateMachine/Public/CkStateMachine/EntityScripts/CkSmTask_EntityScript.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/EntityScripts/CkSmTask_EntityScript.cpp
@@ -78,20 +78,9 @@ auto
 
 // --------------------------------------------------------------------------------------------------------------------
 
-static auto
-    ComputeTagFromClassName(
-        const FString& InClassName,
-        const FString& InComment)
-    -> FGameplayTag
+namespace ck_state_machine_entity_script
 {
-    auto ClassName = InClassName;
-
-    if (ClassName.EndsWith(TEXT("_C")))
-    { ClassName = ClassName.LeftChop(2); }
-
-    ClassName = ClassName.Replace(TEXT("_"), TEXT("."));
-
-    return UCk_Utils_GameplayTag_UE::ResolveGameplayTag(*ClassName, InComment);
+    auto ComputeTagFromClassName(const FString& InClassName, const FString& InComment) -> FGameplayTag;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -101,7 +90,7 @@ auto
     Get_TaskTag() const
     -> FGameplayTag
 {
-    return ComputeTagFromClassName(
+    return ck_state_machine_entity_script::ComputeTagFromClassName(
         GetClass()->GetName(),
         ck::Format_UE(TEXT("Auto-generated task tag for {}"), GetClass()));
 }
@@ -118,7 +107,7 @@ auto
         TEXT("Invalid task class in Get_TaskTagForClass"))
     { return {}; }
 
-    return ComputeTagFromClassName(
+    return ck_state_machine_entity_script::ComputeTagFromClassName(
         InClass->GetName(),
         ck::Format_UE(TEXT("Auto-generated task tag for {}"), *InClass->GetName()));
 }


### PR DESCRIPTION
## Summary

Fixes the root-cause ODR collisions in CkInput, CkPmg, CkStateMachine, CkAssetExporter, and CkCueEditor so they can re-enter unity build (follow-up to the earlier opt-out PR). Each module got the fix that best matched existing Ck conventions:

- **CkInput / CkStateMachine** — byte-identical duplicated helpers unified under `namespace ck_input_utils` / `ck_state_machine_entity_script`, matching the existing `ck_cue_subsystem_base` / `ck_probe` pattern used elsewhere for cross-`.cpp` helper sharing.
- **CkPmg** — `GetAxisRotation` / `ApplyAxisRotation` were generic vector math, not PMG-specific. Promoted to public API on `UCk_Utils_Vector3_UE` in CkCore (`Get_PlaneAxisRotation` as BlueprintPure, `ApplyPlaneAxisRotation` as C++-only). The divergent `SetupMeshComponent` / `FinalizeMeshComponent` helpers stayed file-local, renamed per shape family (`_Basic`, `_Angular`, `_Flat`, `_Directional`, `_Symbol`).
- **CkAssetExporter** — `DoExecuteExportAction` had semantically different bodies per asset type (can't unify). Renamed to `_EQS` / `_BehaviorTree`.
- **CkCueEditor** — duplicated *struct* `FCk_CueToolbox_CueInfo` extracted to a new `CkCueToolbox_Common.h` header, matching the framework's existing `*_Common.h` naming convention.

Six atomic commits (5 ODR fixes + 1 CkCore feat). Each commit bundles its fix with the corresponding `Build.cs` unity re-enablement, so reverting any single commit cleanly restores that module's opted-out state without affecting the others.

## Companion PR

CkEcsDebugger fix lives in its own submodule: https://github.com/chainkemists/CkGameplayDebugger/pull/new/fix/unity-build-odr-collisions

Both PRs should land together; the main `CkPlugins` repo will need a submodule-pointer-bump commit afterwards.

## Test plan

- [ ] Clean build of `CkPluginsEditor | Win64 | Development` — expected: all 5 modules compile under unity (look for `Module.Ck<Name>.N.cpp` blobs in the log).
- [ ] Touch-test adaptive unity: edit one file in each re-enabled module, rebuild, confirm it compiles standalone.
- [ ] Runtime smoke: keybinding UI, PMG debug shapes (all 5 families × XY/XZ/YZ), state machine tag resolution, EQS/BT asset export actions, Cue Toolbox widget.
- [ ] Run CkTests suite.
