### PR TITLE
fix: skip WithActor replication setup outside networked authority to avoid GC cascade

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Processor.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Processor.cpp
@@ -156,11 +156,24 @@ namespace ck
                 auto* OwningActor = UCk_Utils_OwningActor_UE::Get_EntityOwningActor(NewEntity);
                 auto* World = OwningActor->GetWorld();
 
-                const auto IsClient = World->IsNetMode(NM_Client);
+                const auto IsNetworkedAuthority =
+                    World->IsNetMode(NM_DedicatedServer) || World->IsNetMode(NM_ListenServer);
 
-                ck::ecs::Display(TEXT("[REP_DEBUG] SpawnProcessor — WithActor path, IsClient=[{}]"), IsClient);
+                ck::ecs::Display(TEXT("[REP_DEBUG] SpawnProcessor — WithActor path, IsNetworkedAuthority=[{}]"),
+                    IsNetworkedAuthority);
 
-                if (NOT IsClient)
+                // Only set up replication on an actual networked authority. In NM_Standalone
+                // (single-player) there is no network driver, and in NM_Client we have no
+                // authority. The block below force-sets Replicates/ClientAndHost net params
+                // which bypass the internal guards in TryAddReplicatedFragment and create a
+                // UCk_Fragment_EntityReplicationDriver_Rep UObject. That UObject is registered
+                // via AddReplicatedSubObject, but without a net driver it is not reliably
+                // GC-pinned. The next GC pass collects it, its BeginDestroy() calls
+                // Request_DestroyEntity on _AssociatedEntity, and the entire WithActor entity
+                // (and everything hanging off it) is torn down — appearing to the user as
+                // level-wide garbage collection after ~60s (or immediately with
+                // gc.CollectGarbageEveryFrame 1).
+                if (IsNetworkedAuthority)
                 {
                     const auto NetMode = World->IsNetMode(NM_DedicatedServer)
                         ? ECk_Net_NetModeType::Host


### PR DESCRIPTION
## Summary

- Regression from `2a50d7bf`: the WithActor `SpawnProcessor` block was guarded with `NOT IsClient`, which is also true in `NM_Standalone`. In single-player that block wipes and re-adds net params as `Replicates`/`ClientAndHost`, **bypassing** the `DoesNotReplicate` / `IsHost` early-outs in `TryAddReplicatedFragment` (`CkNet_Utils.h:390-394`) and creating a `UCk_Fragment_EntityReplicationDriver_Rep` UObject.
- With no net driver in SP, that replicated UObject is not reliably GC-pinned. The next GC pass collects it, `BeginDestroy` calls `Request_DestroyEntity(_AssociatedEntity)`, and the WithActor entity (and everything hanging off it) is torn down — level-wide collapse ~60 s after PIE starts, or immediately with `gc.CollectGarbageEveryFrame 1`.
- Fix: gate the block on an explicit `IsNetworkedAuthority` check (`NM_DedicatedServer || NM_ListenServer`) instead of `NOT IsClient`. The dedicated/listen server paths are byte-identical to before.

Bisected from the CkPlugins2 gym reproduction across the 28 commits between `c59ebb2..80ffed38`.

## Test plan

- [x] SP gym with `gc.CollectGarbageEveryFrame 1` → level stable, player movement intact, skybox present. Verified with the CkPlugins2 gym reproduction that originally exposed the regression.
- [ ] **Not verified: multiplayer**. The replicated gym currently has a pre-existing rendering issue on `dev` (nothing draws after jumping into the gym) — reproduced on a second, independent checkout unaffected by this change. Because of that pre-existing breakage, this PR cannot demonstrate that MP behavior is unchanged end-to-end. However, the fix is scoped to the `NM_Standalone` branch only; the `NM_DedicatedServer` and `NM_ListenServer` paths produce byte-identical code to before. MP regressions are therefore not expected from this change, and the pre-existing MP issue should be tracked separately.
