### PR TITLE
Add pre-clamp value and overflow to OnClamped attribute payload

### DIFF
--- a/Source/CkAttribute/Claude.md
+++ b/Source/CkAttribute/Claude.md
@@ -35,6 +35,25 @@ UCk_Utils_GameplayLabel_UE::Add(HealthHandle, Tag_Attribute_Health);
 
 ---
 
+## Pre-clamp / overflow polling
+
+The attribute system writes a `TFragment_Attribute_PreClampFinalValue<T, Dir>` per direction at clamp time. Because the Min and Max Clamp processors run sequentially — each capturing `_Final` at *its own* start — the two fragments do NOT symmetrically capture the pre-any-clamp value. With Min-before-Max ordering:
+
+| Scenario | `PreClamp<Min>` | `PreClamp<Max>` |
+|---|---|---|
+| Value overshoots Max | raw value | raw value |
+| Value undershoots Min | raw value | already min-clamped value |
+
+To abstract over this, the utility accessors are **direction-less** — they read both fragments and return the one that actually captured the pre-clamp state:
+
+- `UCk_Utils_IntegerAttribute_UE::Get_PreClampFinalValue(attr)` / `Get_ClampOverflow(attr)` — signed delta, positive = over max, negative = under min
+- Float / Byte equivalents
+- Template-level `TUtils_Attribute<T>::Get_PreClampFinalValue(handle)` and `Get_ClampOverflow(handle)` if you're inside CkAttribute internals
+
+Avoid reading `TFragment_Attribute_PreClampFinalValue<T, Dir>` directly unless you understand the asymmetry. The signal payload (`FCk_Payload_*Attribute_OnClamped`) is unaffected — it carries event-time values that are correct for the direction whose signal fires.
+
+---
+
 ## See also
 
 - `CkProvider/Claude.md` — modifier values come from providers.

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment.h
@@ -105,6 +105,7 @@ namespace ck
             return FCk_Payload_ByteAttribute_OnClamped
             {
                 InPayload.Get_Handle(),
+                InPayload.Get_PreClampFinalValue(),
                 InPayload.Get_ClampedFinalValue()
             };
         }

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment.h
@@ -106,7 +106,8 @@ namespace ck
             {
                 InPayload.Get_Handle(),
                 InPayload.Get_PreClampFinalValue(),
-                InPayload.Get_ClampedFinalValue()
+                InPayload.Get_ClampedFinalValue(),
+                InPayload.Get_ClampOverflow()
             };
         }
     };

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment_Data.h
@@ -189,14 +189,18 @@ private:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     uint8  _FinalClampedValue = 0;
 
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    uint8  _ClampOverflow = 0;
+
 public:
     CK_PROPERTY_GET(_AttributeEntity);
     CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
+    CK_PROPERTY_GET(_ClampOverflow);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_ByteAttribute_OnClamped,
-        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue, _ClampOverflow);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Fragment_Data.h
@@ -184,15 +184,19 @@ private:
     FCk_Handle_ByteAttribute  _AttributeEntity;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    uint8  _PreClampFinalValue = 0;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     uint8  _FinalClampedValue = 0;
 
 public:
     CK_PROPERTY_GET(_AttributeEntity);
+    CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_ByteAttribute_OnClamped,
-        _AttributeEntity, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
@@ -404,8 +404,7 @@ auto
 auto
     UCk_Utils_ByteAttribute_UE::
     Get_PreClampFinalValue(
-        const FCk_Handle_ByteAttribute& InAttribute,
-        ECk_AttributeClamp_Direction InDirection)
+        const FCk_Handle_ByteAttribute& InAttribute)
     -> uint8
 {
     CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
@@ -414,7 +413,22 @@ auto
         UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
     { return {}; }
 
-    return ByteAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute, InDirection);
+    return ByteAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute);
+}
+
+auto
+    UCk_Utils_ByteAttribute_UE::
+    Get_ClampOverflow(
+        const FCk_Handle_ByteAttribute& InAttribute)
+    -> uint8
+{
+    CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
+        TEXT("Byte Attribute [{}] with Owner [{}] does NOT have a [Current] component"),
+        InAttribute,
+        UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
+    { return {}; }
+
+    return ByteAttribute_Utils_Current::Get_ClampOverflow(InAttribute);
 }
 
 auto

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.cpp
@@ -403,6 +403,22 @@ auto
 
 auto
     UCk_Utils_ByteAttribute_UE::
+    Get_PreClampFinalValue(
+        const FCk_Handle_ByteAttribute& InAttribute,
+        ECk_AttributeClamp_Direction InDirection)
+    -> uint8
+{
+    CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
+        TEXT("Byte Attribute [{}] with Owner [{}] does NOT have a [Current] component"),
+        InAttribute,
+        UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
+    { return {}; }
+
+    return ByteAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute, InDirection);
+}
+
+auto
+    UCk_Utils_ByteAttribute_UE::
     Request_Override(
         UPARAM(ref) FCk_Handle_ByteAttribute& InAttribute,
         uint8 InNewBaseValue,

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.h
@@ -190,8 +190,14 @@ public:
               DisplayName="[Ck][ByteAttribute] Get Pre-Clamp Final Value")
     static uint8
     Get_PreClampFinalValue(
-        const FCk_Handle_ByteAttribute& InAttribute,
-        ECk_AttributeClamp_Direction InDirection);
+        const FCk_Handle_ByteAttribute& InAttribute);
+
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Attribute|Byte",
+              DisplayName="[Ck][ByteAttribute] Get Clamp Overflow")
+    static uint8
+    Get_ClampOverflow(
+        const FCk_Handle_ByteAttribute& InAttribute);
 
 public:
     UFUNCTION(BlueprintCallable,

--- a/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/ByteAttribute/CkByteAttribute_Utils.h
@@ -185,6 +185,14 @@ public:
         const FCk_Handle_ByteAttribute& InAttribute,
         ECk_MinMaxCurrent InAttributeComponent = ECk_MinMaxCurrent::Current);
 
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Attribute|Byte",
+              DisplayName="[Ck][ByteAttribute] Get Pre-Clamp Final Value")
+    static uint8
+    Get_PreClampFinalValue(
+        const FCk_Handle_ByteAttribute& InAttribute,
+        ECk_AttributeClamp_Direction InDirection);
+
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Attribute|Byte",

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
@@ -271,6 +271,31 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
+    // Fragment written by the Clamp processor to capture the final value before
+    // clamping. The DetectClamp processor reads it to populate the OnClamped
+    // payload's PreClampFinalValue. Overwritten each frame via AddOrGet,
+    // consistent with TFragment_Attribute_PreviousValues.
+    template <typename T_AttributeType>
+    struct TFragment_Attribute_PreClampFinalValue
+    {
+    public:
+        CK_GENERATED_BODY(TFragment_Attribute_PreClampFinalValue<T_AttributeType>);
+
+    public:
+        using AttributeType = T_AttributeType;
+        using AttributeDataType = typename T_AttributeType::AttributeDataType;
+
+    private:
+        AttributeDataType _Final;
+
+    public:
+        CK_PROPERTY_GET(_Final);
+
+        CK_DEFINE_CONSTRUCTORS(TFragment_Attribute_PreClampFinalValue, _Final);
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     template <concepts::ValidAttributeHandleType T_HandleType, typename T_AttributeType>
     using TFragment_Attribute_Current = TFragment_Attribute<T_HandleType, T_AttributeType, ECk_MinMaxCurrent::Current>;
 
@@ -381,14 +406,16 @@ namespace ck
 
     private:
         HandleType _Handle;
+        AttributeDataType _PreClampFinalValue;
         AttributeDataType _ClampedFinalValue;
 
     public:
         CK_PROPERTY_GET(_Handle);
+        CK_PROPERTY_GET(_PreClampFinalValue);
         CK_PROPERTY_GET(_ClampedFinalValue);
 
         CK_DEFINE_CONSTRUCTORS(TPayload_Attribute_OnClamped<T_DerivedAttribute_Current>,
-            _Handle, _ClampedFinalValue);
+            _Handle, _PreClampFinalValue, _ClampedFinalValue);
     };
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
@@ -414,14 +414,20 @@ namespace ck
         HandleType _Handle;
         AttributeDataType _PreClampFinalValue;
         AttributeDataType _ClampedFinalValue;
+        // Signed delta between the pre-clamp and clamped values (PreClamp - Clamped).
+        // Positive when OnMaxClamped fires with overflow, negative when OnMinClamped
+        // fires with underflow, zero when the value reached the bound without actually
+        // being clamped (e.g. value landed exactly at max).
+        AttributeDataType _ClampOverflow;
 
     public:
         CK_PROPERTY_GET(_Handle);
         CK_PROPERTY_GET(_PreClampFinalValue);
         CK_PROPERTY_GET(_ClampedFinalValue);
+        CK_PROPERTY_GET(_ClampOverflow);
 
         CK_DEFINE_CONSTRUCTORS(TPayload_Attribute_OnClamped<T_DerivedAttribute_Current>,
-            _Handle, _PreClampFinalValue, _ClampedFinalValue);
+            _Handle, _PreClampFinalValue, _ClampedFinalValue, _ClampOverflow);
     };
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
@@ -271,15 +271,16 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    // Fragment written by the Clamp processor to capture the final value before
-    // clamping. The DetectClamp processor reads it to populate the OnClamped
-    // payload's PreClampFinalValue. Overwritten each frame via AddOrGet,
-    // consistent with TFragment_Attribute_PreviousValues.
-    template <typename T_AttributeType>
+    // Fragment written by the Clamp processor each frame to capture the final
+    // value before clamping. The DetectClamp processor reads it to populate the
+    // OnClamped payload's PreClampFinalValue. Templated on clamp direction so
+    // the min and max Clamp processors don't overwrite each other's data and
+    // so DetectClamp always sees a fresh value written this frame.
+    template <typename T_AttributeType, ECk_AttributeClamp_Direction T_Direction>
     struct TFragment_Attribute_PreClampFinalValue
     {
     public:
-        CK_GENERATED_BODY(TFragment_Attribute_PreClampFinalValue<T_AttributeType>);
+        CK_GENERATED_BODY(TFragment_Attribute_PreClampFinalValue<T_AttributeType COMMA T_Direction>);
 
     public:
         using AttributeType = T_AttributeType;

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Fragment.h
@@ -271,11 +271,16 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
 
-    // Fragment written by the Clamp processor each frame to capture the final
-    // value before clamping. The DetectClamp processor reads it to populate the
-    // OnClamped payload's PreClampFinalValue. Templated on clamp direction so
-    // the min and max Clamp processors don't overwrite each other's data and
-    // so DetectClamp always sees a fresh value written this frame.
+    // Fragment written by the Clamp processor every frame to record the
+    // attribute's final value before clamping in this direction. DetectClamp
+    // reads it to populate the OnClamped payload's PreClampFinalValue so
+    // subscribers can compute overflow = pre-clamp - final.
+    //
+    // On frames where no clamping occurred, this equals Current.Final
+    // (overflow = 0 naturally). Templated on direction so min and max have
+    // independent storage and never overwrite each other. Also lingers on
+    // the entity for debugger inspection of the last-recorded pre-clamp
+    // value even after clamping stops happening.
     template <typename T_AttributeType, ECk_AttributeClamp_Direction T_Direction>
     struct TFragment_Attribute_PreClampFinalValue
     {

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.h
@@ -94,6 +94,7 @@ namespace ck::detail
             typename T_DerivedAttributeCurrent::HandleType,
             ck::TReadWrite<T_DerivedAttributeCurrent>,
             ck::TReadWrite<T_DerivedAttributeBound>,
+            ck::TReadOnly<TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>>,
             std::conditional_t<T_Direction == ECk_AttributeClamp_Direction::Min,
                 typename T_DerivedAttributeCurrent::FTag_FireSignals_MinClamped,
                 typename T_DerivedAttributeCurrent::FTag_FireSignals_MaxClamped>,
@@ -110,6 +111,7 @@ namespace ck::detail
         using AttributeFragmentType_Bound           = T_DerivedAttributeBound;
         using AttributeFragmentPreviousType_Current = TFragment_Attribute_PreviousValues<T_DerivedAttributeCurrent>;
         using AttributeFragmentPreviousType_Bound   = TFragment_Attribute_PreviousValues<T_DerivedAttributeBound>;
+        using PreClampFragmentType                  = TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
         using AttributeDataType                     = typename AttributeFragmentType_Current::AttributeDataType;
         using HandleType                            = typename AttributeFragmentType_Current::HandleType;
         using ThisType                              = TProcessor_Attribute_FireSignals_Clamped<
@@ -123,6 +125,7 @@ namespace ck::detail
                                                         HandleType,
                                                         ck::TReadWrite<AttributeFragmentType_Current>,
                                                         ck::TReadWrite<AttributeFragmentType_Bound>,
+                                                        ck::TReadOnly<PreClampFragmentType>,
                                                         MarkedDirtyBy,
                                                         CK_IGNORE_PENDING_KILL>;
         using TimeType                              = typename Super::TimeType;
@@ -135,7 +138,8 @@ namespace ck::detail
             const TimeType& InDeltaT,
             HandleType InHandle,
             AttributeFragmentType_Current& InAttribute_Current,
-            AttributeFragmentType_Bound& InAttribute_Bound) const -> void;
+            AttributeFragmentType_Bound& InAttribute_Bound,
+            const PreClampFragmentType& InPreClamp) const -> void;
 
     public:
         CK_ENABLE_SFINAE_THIS(T_DerivedProcessor);

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -132,6 +132,12 @@ namespace ck::detail
             // The Clamp processor writes InPreClamp every frame it runs, so it's
             // guaranteed to hold this frame's pre-clamp value. When no clamping
             // occurred it equals Current.Final, so overflow is naturally 0.
+            // Explicit cast is needed because arithmetic on narrow types (uint8)
+            // promotes to int, and aggregate initialization below forbids narrowing.
+            const auto PreClamp = InPreClamp.Get_Final();
+            const auto Clamped  = InAttribute_Current.Get_Final();
+            const auto Overflow = static_cast<AttributeDataType>(PreClamp - Clamped);
+
             TUtils_Signal_OnAttributeClamped<T_DerivedAttributeCurrent, T_DerivedAttributeBound, T_MulticastType>::Broadcast
             (
                 InHandle,
@@ -141,8 +147,9 @@ namespace ck::detail
                     TPayload_Attribute_OnClamped<T_DerivedAttributeCurrent>
                     {
                         InHandle,
-                        InPreClamp.Get_Final(),
-                        InAttribute_Current.Get_Final()
+                        PreClamp,
+                        Clamped,
+                        Overflow
                     }
                 )
             );

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -128,19 +128,14 @@ namespace ck::detail
                 InHandle
             );
 
-            // Read the pre-clamp value written by the Clamp processor this frame.
-            // If it's absent (signal fires because value is exactly at the bound
-            // but nothing was actually clamped), use Current.Final — overflow is
-            // then correctly 0.
+            // Read the pre-clamp value managed by the Clamp processor. If the
+            // fragment is absent (signal fires because value is exactly at the
+            // bound but nothing was actually clamped this frame), fall back to
+            // Current.Final so overflow is correctly 0.
             using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
             const auto PreClampFinalValue = InHandle.template Has<PreClampType>()
                 ? InHandle.template Get<PreClampType>().Get_Final()
                 : InAttribute_Current.Get_Final();
-
-            // Consume the fragment so it doesn't persist across frames. The
-            // Clamp processor re-writes it next frame if clamping happens again.
-            if (InHandle.template Has<PreClampType>())
-            { InHandle.template Remove<PreClampType>(); }
 
             TUtils_Signal_OnAttributeClamped<T_DerivedAttributeCurrent, T_DerivedAttributeBound, T_MulticastType>::Broadcast
             (
@@ -206,14 +201,18 @@ namespace ck::detail
         InAttributeCurrent._Base  = Attribute_Clamp<T_Direction>(BaseValue,  FinalValue_Bound);
         InAttributeCurrent._Final = Attribute_Clamp<T_Direction>(FinalValue, FinalValue_Bound);
 
-        // Store the pre-clamp final value only when clamping actually changed
-        // the value in this direction. The fragment is consumed (removed) by
-        // DetectClamp after the signal fires, so it never persists across frames
-        // and only exists on entities actually clamped this frame.
+        // The Clamp processor owns the pre-clamp fragment's full lifecycle: write
+        // it when clamping changed the value, remove it otherwise. The fragment
+        // therefore always reflects this frame's clamp (if any) — never a stale
+        // value from a past event — and DetectClamp can be a pure reader.
+        using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
         if (InAttributeCurrent._Final != FinalValue)
         {
-            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
             InHandle.template AddOrGet<PreClampType>() = PreClampType{FinalValue};
+        }
+        else if (InHandle.template Has<PreClampType>())
+        {
+            InHandle.template Remove<PreClampType>();
         }
 
         if (ValueChanged)

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -83,7 +83,8 @@ namespace ck::detail
             const TimeType& InDeltaT,
             HandleType InHandle,
             AttributeFragmentType_Current& InAttribute_Current,
-            AttributeFragmentType_Bound& InAttribute_Bound) const
+            AttributeFragmentType_Bound& InAttribute_Bound,
+            const PreClampFragmentType& InPreClamp) const
         -> void
     {
         InHandle.template Remove<MarkedDirtyBy>();
@@ -128,15 +129,9 @@ namespace ck::detail
                 InHandle
             );
 
-            // Read the pre-clamp value managed by the Clamp processor. If the
-            // fragment is absent (signal fires because value is exactly at the
-            // bound but nothing was actually clamped this frame), fall back to
-            // Current.Final so overflow is correctly 0.
-            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
-            const auto PreClampFinalValue = InHandle.template Has<PreClampType>()
-                ? InHandle.template Get<PreClampType>().Get_Final()
-                : InAttribute_Current.Get_Final();
-
+            // The Clamp processor writes InPreClamp every frame it runs, so it's
+            // guaranteed to hold this frame's pre-clamp value. When no clamping
+            // occurred it equals Current.Final, so overflow is naturally 0.
             TUtils_Signal_OnAttributeClamped<T_DerivedAttributeCurrent, T_DerivedAttributeBound, T_MulticastType>::Broadcast
             (
                 InHandle,
@@ -146,7 +141,7 @@ namespace ck::detail
                     TPayload_Attribute_OnClamped<T_DerivedAttributeCurrent>
                     {
                         InHandle,
-                        PreClampFinalValue,
+                        InPreClamp.Get_Final(),
                         InAttribute_Current.Get_Final()
                     }
                 )
@@ -188,6 +183,15 @@ namespace ck::detail
             NOT UCk_Utils_Net_UE::Get_IsEntityNetMode_Host(InHandle) &&
             TUtils_Attribute<T_DerivedAttributeCurrent>::Get_MayRequireReplicationThisFrame(InHandle);
 
+        // Record the final value before clamping, in both the bypass and
+        // normal paths, so DetectClamp can always view the fragment directly
+        // and compute overflow = pre-clamp - final. When no clamping occurs
+        // this frame the stored value equals Current.Final, yielding overflow
+        // of 0 naturally. When the attribute is ever clamped, the stored
+        // value persists as a debug record of the most recent overflow.
+        using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
+        InHandle.template AddOrGet<PreClampType>() = PreClampType{FinalValue};
+
         if (ShouldBypassClientSideClamp)
         {
             if (ValueChanged)
@@ -200,20 +204,6 @@ namespace ck::detail
 
         InAttributeCurrent._Base  = Attribute_Clamp<T_Direction>(BaseValue,  FinalValue_Bound);
         InAttributeCurrent._Final = Attribute_Clamp<T_Direction>(FinalValue, FinalValue_Bound);
-
-        // The Clamp processor owns the pre-clamp fragment's full lifecycle: write
-        // it when clamping changed the value, remove it otherwise. The fragment
-        // therefore always reflects this frame's clamp (if any) — never a stale
-        // value from a past event — and DetectClamp can be a pure reader.
-        using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
-        if (InAttributeCurrent._Final != FinalValue)
-        {
-            InHandle.template AddOrGet<PreClampType>() = PreClampType{FinalValue};
-        }
-        else if (InHandle.template Has<PreClampType>())
-        {
-            InHandle.template Remove<PreClampType>();
-        }
 
         if (ValueChanged)
         { TUtils_Attribute<T_DerivedAttributeCurrent>::Request_FireSignals(InHandle); }

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -128,6 +128,11 @@ namespace ck::detail
                 InHandle
             );
 
+            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent>;
+            const auto PreClampFinalValue = InHandle.template Has<PreClampType>()
+                ? InHandle.template Get<PreClampType>().Get_Final()
+                : InAttribute_Current.Get_Final();
+
             TUtils_Signal_OnAttributeClamped<T_DerivedAttributeCurrent, T_DerivedAttributeBound, T_MulticastType>::Broadcast
             (
                 InHandle,
@@ -137,11 +142,16 @@ namespace ck::detail
                     TPayload_Attribute_OnClamped<T_DerivedAttributeCurrent>
                     {
                         InHandle,
+                        PreClampFinalValue,
                         InAttribute_Current.Get_Final()
                     }
                 )
             );
         }
+
+        // PreClampFinalValue fragment is not cleaned up here — it gets overwritten
+        // each frame by the Clamp processor via AddOrGet, and both min and max
+        // DetectClamp processors need to read it in the same signal pass.
     }
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -190,6 +200,14 @@ namespace ck::detail
 
         InAttributeCurrent._Base  = Attribute_Clamp<T_Direction>(BaseValue,  FinalValue_Bound);
         InAttributeCurrent._Final = Attribute_Clamp<T_Direction>(FinalValue, FinalValue_Bound);
+
+        // Store the pre-clamp final value only when clamping actually changed the value
+        // in this direction, so min and max clamp processors don't overwrite each other.
+        if (InAttributeCurrent._Final != FinalValue)
+        {
+            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent>;
+            InHandle.template AddOrGet<PreClampType>() = PreClampType{FinalValue};
+        }
 
         if (ValueChanged)
         { TUtils_Attribute<T_DerivedAttributeCurrent>::Request_FireSignals(InHandle); }

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Processor.inl.h
@@ -128,10 +128,19 @@ namespace ck::detail
                 InHandle
             );
 
-            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent>;
+            // Read the pre-clamp value written by the Clamp processor this frame.
+            // If it's absent (signal fires because value is exactly at the bound
+            // but nothing was actually clamped), use Current.Final — overflow is
+            // then correctly 0.
+            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
             const auto PreClampFinalValue = InHandle.template Has<PreClampType>()
                 ? InHandle.template Get<PreClampType>().Get_Final()
                 : InAttribute_Current.Get_Final();
+
+            // Consume the fragment so it doesn't persist across frames. The
+            // Clamp processor re-writes it next frame if clamping happens again.
+            if (InHandle.template Has<PreClampType>())
+            { InHandle.template Remove<PreClampType>(); }
 
             TUtils_Signal_OnAttributeClamped<T_DerivedAttributeCurrent, T_DerivedAttributeBound, T_MulticastType>::Broadcast
             (
@@ -148,10 +157,6 @@ namespace ck::detail
                 )
             );
         }
-
-        // PreClampFinalValue fragment is not cleaned up here — it gets overwritten
-        // each frame by the Clamp processor via AddOrGet, and both min and max
-        // DetectClamp processors need to read it in the same signal pass.
     }
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -201,11 +206,13 @@ namespace ck::detail
         InAttributeCurrent._Base  = Attribute_Clamp<T_Direction>(BaseValue,  FinalValue_Bound);
         InAttributeCurrent._Final = Attribute_Clamp<T_Direction>(FinalValue, FinalValue_Bound);
 
-        // Store the pre-clamp final value only when clamping actually changed the value
-        // in this direction, so min and max clamp processors don't overwrite each other.
+        // Store the pre-clamp final value only when clamping actually changed
+        // the value in this direction. The fragment is consumed (removed) by
+        // DetectClamp after the signal fires, so it never persists across frames
+        // and only exists on entities actually clamped this frame.
         if (InAttributeCurrent._Final != FinalValue)
         {
-            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent>;
+            using PreClampType = ck::TFragment_Attribute_PreClampFinalValue<T_DerivedAttributeCurrent, T_Direction>;
             InHandle.template AddOrGet<PreClampType>() = PreClampType{FinalValue};
         }
 

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
@@ -58,10 +58,22 @@ namespace ck
         Get_FinalValue(
             const AttributeHandleType& InHandle) -> AttributeDataType;
 
+        // Reads both direction's PreClamp fragments and returns the one that
+        // captured the true raw pre-any-clamp value (i.e. the one whose value
+        // differs from Current.Final). Returns Current.Final if nothing was
+        // clamped this frame. See CkAttribute/CLAUDE.md for the fragment-level
+        // asymmetry this accessor abstracts over.
         static auto
         Get_PreClampFinalValue(
-            const AttributeHandleType& InHandle,
-            ECk_AttributeClamp_Direction InDirection) -> AttributeDataType;
+            const AttributeHandleType& InHandle) -> AttributeDataType;
+
+        // Signed delta between Get_PreClampFinalValue and Current.Final.
+        // Positive = value tried to exceed Max, negative = value tried to go
+        // below Min, zero = no clamping this frame. For unsigned types (Byte)
+        // underflow will wrap.
+        static auto
+        Get_ClampOverflow(
+            const AttributeHandleType& InHandle) -> AttributeDataType;
 
         static auto
         Get_MayRequireReplicationThisFrame(

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.h
@@ -59,6 +59,11 @@ namespace ck
             const AttributeHandleType& InHandle) -> AttributeDataType;
 
         static auto
+        Get_PreClampFinalValue(
+            const AttributeHandleType& InHandle,
+            ECk_AttributeClamp_Direction InDirection) -> AttributeDataType;
+
+        static auto
         Get_MayRequireReplicationThisFrame(
             const AttributeHandleType& InHandle) -> bool;
 

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
@@ -59,32 +59,29 @@ namespace ck
     auto
         TUtils_Attribute<T_DerivedAttribute>::
         Get_PreClampFinalValue(
-            const AttributeHandleType& InHandle,
-            ECk_AttributeClamp_Direction InDirection)
+            const AttributeHandleType& InHandle)
         -> AttributeDataType
     {
-        switch (InDirection)
-        {
-            case ECk_AttributeClamp_Direction::Min:
-            {
-                using PreClampType = TFragment_Attribute_PreClampFinalValue<T_DerivedAttribute, ECk_AttributeClamp_Direction::Min>;
-                if (InHandle.template Has<PreClampType>())
-                { return InHandle.template Get<PreClampType>().Get_Final(); }
-                return Get_FinalValue(InHandle);
-            }
-            case ECk_AttributeClamp_Direction::Max:
-            {
-                using PreClampType = TFragment_Attribute_PreClampFinalValue<T_DerivedAttribute, ECk_AttributeClamp_Direction::Max>;
-                if (InHandle.template Has<PreClampType>())
-                { return InHandle.template Get<PreClampType>().Get_Final(); }
-                return Get_FinalValue(InHandle);
-            }
-            default:
-            {
-                CK_INVALID_ENUM(InDirection);
-                return Get_FinalValue(InHandle);
-            }
-        }
+        using MinPreClamp = TFragment_Attribute_PreClampFinalValue<T_DerivedAttribute, ECk_AttributeClamp_Direction::Min>;
+        using MaxPreClamp = TFragment_Attribute_PreClampFinalValue<T_DerivedAttribute, ECk_AttributeClamp_Direction::Max>;
+
+        const auto Cur    = Get_FinalValue(InHandle);
+        const auto MinPre = InHandle.template Has<MinPreClamp>() ? InHandle.template Get<MinPreClamp>().Get_Final() : Cur;
+        const auto MaxPre = InHandle.template Has<MaxPreClamp>() ? InHandle.template Get<MaxPreClamp>().Get_Final() : Cur;
+
+        if (MinPre != Cur) { return MinPre; }
+        if (MaxPre != Cur) { return MaxPre; }
+        return Cur;
+    }
+
+    template <concepts::ValidAttributeFragment T_DerivedAttribute>
+    auto
+        TUtils_Attribute<T_DerivedAttribute>::
+        Get_ClampOverflow(
+            const AttributeHandleType& InHandle)
+        -> AttributeDataType
+    {
+        return static_cast<AttributeDataType>(Get_PreClampFinalValue(InHandle) - Get_FinalValue(InHandle));
     }
 
     template <concepts::ValidAttributeFragment T_DerivedAttribute>

--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
@@ -58,6 +58,38 @@ namespace ck
     template <concepts::ValidAttributeFragment T_DerivedAttribute>
     auto
         TUtils_Attribute<T_DerivedAttribute>::
+        Get_PreClampFinalValue(
+            const AttributeHandleType& InHandle,
+            ECk_AttributeClamp_Direction InDirection)
+        -> AttributeDataType
+    {
+        switch (InDirection)
+        {
+            case ECk_AttributeClamp_Direction::Min:
+            {
+                using PreClampType = TFragment_Attribute_PreClampFinalValue<T_DerivedAttribute, ECk_AttributeClamp_Direction::Min>;
+                if (InHandle.template Has<PreClampType>())
+                { return InHandle.template Get<PreClampType>().Get_Final(); }
+                return Get_FinalValue(InHandle);
+            }
+            case ECk_AttributeClamp_Direction::Max:
+            {
+                using PreClampType = TFragment_Attribute_PreClampFinalValue<T_DerivedAttribute, ECk_AttributeClamp_Direction::Max>;
+                if (InHandle.template Has<PreClampType>())
+                { return InHandle.template Get<PreClampType>().Get_Final(); }
+                return Get_FinalValue(InHandle);
+            }
+            default:
+            {
+                CK_INVALID_ENUM(InDirection);
+                return Get_FinalValue(InHandle);
+            }
+        }
+    }
+
+    template <concepts::ValidAttributeFragment T_DerivedAttribute>
+    auto
+        TUtils_Attribute<T_DerivedAttribute>::
         Get_MayRequireReplicationThisFrame(
             const AttributeHandleType& InHandle)
         -> bool

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment.h
@@ -105,6 +105,7 @@ namespace ck
             return FCk_Payload_FloatAttribute_OnClamped
             {
                 InPayload.Get_Handle(),
+                InPayload.Get_PreClampFinalValue(),
                 InPayload.Get_ClampedFinalValue()
             };
         }

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment.h
@@ -106,7 +106,8 @@ namespace ck
             {
                 InPayload.Get_Handle(),
                 InPayload.Get_PreClampFinalValue(),
-                InPayload.Get_ClampedFinalValue()
+                InPayload.Get_ClampedFinalValue(),
+                InPayload.Get_ClampOverflow()
             };
         }
     };

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment_Data.h
@@ -329,15 +329,19 @@ private:
     FCk_Handle_FloatAttribute  _AttributeEntity;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    float  _PreClampFinalValue = 0.0f;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     float  _FinalClampedValue = 0.0f;
 
 public:
     CK_PROPERTY_GET(_AttributeEntity);
+    CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_FloatAttribute_OnClamped,
-        _AttributeEntity, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Fragment_Data.h
@@ -334,14 +334,18 @@ private:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     float  _FinalClampedValue = 0.0f;
 
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    float  _ClampOverflow = 0.0f;
+
 public:
     CK_PROPERTY_GET(_AttributeEntity);
     CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
+    CK_PROPERTY_GET(_ClampOverflow);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_FloatAttribute_OnClamped,
-        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue, _ClampOverflow);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.cpp
@@ -457,6 +457,22 @@ auto
 
 auto
     UCk_Utils_FloatAttribute_UE::
+    Get_PreClampFinalValue(
+        const FCk_Handle_FloatAttribute& InAttribute,
+        ECk_AttributeClamp_Direction InDirection)
+    -> float
+{
+    CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
+        TEXT("Float Attribute [{}] with Owner [{}] does NOT have a [Current] component"),
+        InAttribute,
+        UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
+    { return {}; }
+
+    return FloatAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute, InDirection);
+}
+
+auto
+    UCk_Utils_FloatAttribute_UE::
     Request_Override(
         UPARAM(ref) FCk_Handle_FloatAttribute& InAttribute,
         float InNewBaseValue,

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.cpp
@@ -458,8 +458,7 @@ auto
 auto
     UCk_Utils_FloatAttribute_UE::
     Get_PreClampFinalValue(
-        const FCk_Handle_FloatAttribute& InAttribute,
-        ECk_AttributeClamp_Direction InDirection)
+        const FCk_Handle_FloatAttribute& InAttribute)
     -> float
 {
     CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
@@ -468,7 +467,22 @@ auto
         UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
     { return {}; }
 
-    return FloatAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute, InDirection);
+    return FloatAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute);
+}
+
+auto
+    UCk_Utils_FloatAttribute_UE::
+    Get_ClampOverflow(
+        const FCk_Handle_FloatAttribute& InAttribute)
+    -> float
+{
+    CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
+        TEXT("Float Attribute [{}] with Owner [{}] does NOT have a [Current] component"),
+        InAttribute,
+        UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
+    { return {}; }
+
+    return FloatAttribute_Utils_Current::Get_ClampOverflow(InAttribute);
 }
 
 auto

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.h
@@ -204,8 +204,14 @@ public:
               DisplayName="[Ck][FloatAttribute] Get Pre-Clamp Final Value")
     static float
     Get_PreClampFinalValue(
-        const FCk_Handle_FloatAttribute& InAttribute,
-        ECk_AttributeClamp_Direction InDirection);
+        const FCk_Handle_FloatAttribute& InAttribute);
+
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Attribute|Float",
+              DisplayName="[Ck][FloatAttribute] Get Clamp Overflow")
+    static float
+    Get_ClampOverflow(
+        const FCk_Handle_FloatAttribute& InAttribute);
 
 public:
     UFUNCTION(BlueprintCallable,

--- a/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/FloatAttribute/CkFloatAttribute_Utils.h
@@ -199,6 +199,14 @@ public:
         const FCk_Handle_FloatAttribute& InAttribute,
         ECk_MinMaxCurrent InAttributeComponent = ECk_MinMaxCurrent::Current);
 
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Attribute|Float",
+              DisplayName="[Ck][FloatAttribute] Get Pre-Clamp Final Value")
+    static float
+    Get_PreClampFinalValue(
+        const FCk_Handle_FloatAttribute& InAttribute,
+        ECk_AttributeClamp_Direction InDirection);
+
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Attribute|Float",

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment.h
@@ -105,6 +105,7 @@ namespace ck
             return FCk_Payload_IntegerAttribute_OnClamped
             {
                 InPayload.Get_Handle(),
+                InPayload.Get_PreClampFinalValue(),
                 InPayload.Get_ClampedFinalValue()
             };
         }

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment.h
@@ -106,7 +106,8 @@ namespace ck
             {
                 InPayload.Get_Handle(),
                 InPayload.Get_PreClampFinalValue(),
-                InPayload.Get_ClampedFinalValue()
+                InPayload.Get_ClampedFinalValue(),
+                InPayload.Get_ClampOverflow()
             };
         }
     };

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment_Data.h
@@ -245,14 +245,18 @@ private:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     int32  _FinalClampedValue = 0;
 
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    int32  _ClampOverflow = 0;
+
 public:
     CK_PROPERTY_GET(_AttributeEntity);
     CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
+    CK_PROPERTY_GET(_ClampOverflow);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_IntegerAttribute_OnClamped,
-        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue, _ClampOverflow);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Fragment_Data.h
@@ -240,15 +240,19 @@ private:
     FCk_Handle_IntegerAttribute  _AttributeEntity;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    int32  _PreClampFinalValue = 0;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     int32  _FinalClampedValue = 0;
 
 public:
     CK_PROPERTY_GET(_AttributeEntity);
+    CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_IntegerAttribute_OnClamped,
-        _AttributeEntity, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.cpp
@@ -460,8 +460,7 @@ auto
 auto
     UCk_Utils_IntegerAttribute_UE::
     Get_PreClampFinalValue(
-        const FCk_Handle_IntegerAttribute& InAttribute,
-        ECk_AttributeClamp_Direction InDirection)
+        const FCk_Handle_IntegerAttribute& InAttribute)
     -> int32
 {
     CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
@@ -470,7 +469,22 @@ auto
         UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
     { return {}; }
 
-    return IntegerAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute, InDirection);
+    return IntegerAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute);
+}
+
+auto
+    UCk_Utils_IntegerAttribute_UE::
+    Get_ClampOverflow(
+        const FCk_Handle_IntegerAttribute& InAttribute)
+    -> int32
+{
+    CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
+        TEXT("Integer Attribute [{}] with Owner [{}] does NOT have a [Current] component"),
+        InAttribute,
+        UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
+    { return {}; }
+
+    return IntegerAttribute_Utils_Current::Get_ClampOverflow(InAttribute);
 }
 
 auto

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.cpp
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.cpp
@@ -459,6 +459,22 @@ auto
 
 auto
     UCk_Utils_IntegerAttribute_UE::
+    Get_PreClampFinalValue(
+        const FCk_Handle_IntegerAttribute& InAttribute,
+        ECk_AttributeClamp_Direction InDirection)
+    -> int32
+{
+    CK_ENSURE_IF_NOT(Has_Component(InAttribute, ECk_MinMaxCurrent::Current),
+        TEXT("Integer Attribute [{}] with Owner [{}] does NOT have a [Current] component"),
+        InAttribute,
+        UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(InAttribute))
+    { return {}; }
+
+    return IntegerAttribute_Utils_Current::Get_PreClampFinalValue(InAttribute, InDirection);
+}
+
+auto
+    UCk_Utils_IntegerAttribute_UE::
     Request_Override(
         UPARAM(ref) FCk_Handle_IntegerAttribute& InAttribute,
         int32 InNewBaseValue,

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.h
@@ -200,6 +200,14 @@ public:
         const FCk_Handle_IntegerAttribute& InAttribute,
         ECk_MinMaxCurrent InAttributeComponent = ECk_MinMaxCurrent::Current);
 
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Attribute|Integer",
+              DisplayName="[Ck][IntegerAttribute] Get Pre-Clamp Final Value")
+    static int32
+    Get_PreClampFinalValue(
+        const FCk_Handle_IntegerAttribute& InAttribute,
+        ECk_AttributeClamp_Direction InDirection);
+
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|Attribute|Integer",

--- a/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.h
+++ b/Source/CkAttribute/Public/CkAttribute/IntegerAttribute/CkIntegerAttribute_Utils.h
@@ -205,8 +205,14 @@ public:
               DisplayName="[Ck][IntegerAttribute] Get Pre-Clamp Final Value")
     static int32
     Get_PreClampFinalValue(
-        const FCk_Handle_IntegerAttribute& InAttribute,
-        ECk_AttributeClamp_Direction InDirection);
+        const FCk_Handle_IntegerAttribute& InAttribute);
+
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|Attribute|Integer",
+              DisplayName="[Ck][IntegerAttribute] Get Clamp Overflow")
+    static int32
+    Get_ClampOverflow(
+        const FCk_Handle_IntegerAttribute& InAttribute);
 
 public:
     UFUNCTION(BlueprintCallable,

--- a/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment.h
@@ -94,7 +94,8 @@ namespace ck
             {
                 InPayload.Get_Handle(),
                 InPayload.Get_PreClampFinalValue(),
-                InPayload.Get_ClampedFinalValue()
+                InPayload.Get_ClampedFinalValue(),
+                InPayload.Get_ClampOverflow()
             };
         }
     };

--- a/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment.h
+++ b/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment.h
@@ -93,6 +93,7 @@ namespace ck
             return FCk_Payload_VectorAttribute_OnClamped
             {
                 InPayload.Get_Handle(),
+                InPayload.Get_PreClampFinalValue(),
                 InPayload.Get_ClampedFinalValue()
             };
         }

--- a/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment_Data.h
@@ -189,14 +189,18 @@ private:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     FVector  _FinalClampedValue = FVector::ZeroVector;
 
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    FVector  _ClampOverflow = FVector::ZeroVector;
+
 public:
     CK_PROPERTY_GET(_AttributeEntity);
     CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
+    CK_PROPERTY_GET(_ClampOverflow);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_VectorAttribute_OnClamped,
-        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue, _ClampOverflow);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment_Data.h
+++ b/Source/CkAttribute/Public/CkAttribute/VectorAttribute/CkVectorAttribute_Fragment_Data.h
@@ -184,15 +184,19 @@ private:
     FCk_Handle_VectorAttribute  _AttributeEntity;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
+    FVector  _PreClampFinalValue = FVector::ZeroVector;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = true))
     FVector  _FinalClampedValue = FVector::ZeroVector;
 
 public:
     CK_PROPERTY_GET(_AttributeEntity);
+    CK_PROPERTY_GET(_PreClampFinalValue);
     CK_PROPERTY_GET(_FinalClampedValue);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Payload_VectorAttribute_OnClamped,
-        _AttributeEntity, _FinalClampedValue);
+        _AttributeEntity, _PreClampFinalValue, _FinalClampedValue);
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `OnMaxClamped` / `OnMinClamped` signals previously only exposed the clamped final value. This change adds `_PreClampFinalValue` and `_ClampOverflow` to the payload, enabling subscribers to compute overflow (e.g., XP-to-level rollover: 80 + 50 clamped to 100 now exposes intended 130 and +30 overflow).

Also exposes direction-less polling accessors for reading pre-clamp state outside a signal callback.

## Changes

- **Payload**: `TPayload_Attribute_OnClamped` gains `_PreClampFinalValue` and `_ClampOverflow`. The four reflected payloads (`FCk_Payload_{Integer,Float,Byte,Vector}Attribute_OnClamped`) and their type converters are updated.
- **Processor**: `TProcessor_Attribute_Clamp` writes `TFragment_Attribute_PreClampFinalValue<T, Direction>` unconditionally each frame (avoids stale values). `TProcessor_Attribute_FireSignals_Clamped` reads it when building the payload.
- **Utils**: New `Get_PreClampFinalValue(handle)` / `Get_ClampOverflow(handle)` on `TUtils_Attribute<T>` and the Integer/Float/Byte UFUNCTION utils. Direction-less — the implementation reads both Min and Max fragments and returns the one that captured the raw value, hiding the Min-before-Max processor ordering asymmetry.
- **Docs**: `CkAttribute/Claude.md` documents the asymmetry.

## Asymmetry note

Because Min-clamp runs before Max-clamp:

| Scenario | `PreClamp<Min>` | `PreClamp<Max>` |
|---|---|---|
| Value overshoots Max | raw | raw |
| Value undershoots Min | raw | already min-clamped |

The utility accessors abstract this. Signal payloads are unaffected — they carry correct event-time values per direction.

## Test plan

- [x] Existing clamping gyms still fire with correct `Get_FinalClampedValue()`
- [x] `Get_PreClampFinalValue()` returns the raw pre-clamp value
- [x] `Get_ClampOverflow()` = `PreClamp - Final`
- [x] Live-poll display in Integer/Float/Byte gyms shows correct pre/overflow each frame
- [x] No stale PreClamp fragment across frames