### PR TITLE
fix: preserve narrow AS type for runtime-generated UPROPERTYs

### DIFF
--- a/Source/CkAngelscriptGenerator/CkAngelscriptGenerator_SharedUtils.cpp
+++ b/Source/CkAngelscriptGenerator/CkAngelscriptGenerator_SharedUtils.cpp
@@ -6,6 +6,12 @@
 #include <UObject/PropertyOptional.h>
 #include <UObject/UnrealType.h>
 
+#if WITH_ANGELSCRIPT_CK
+#include <AngelscriptType.h>
+#include <AngelscriptManager.h>
+#include <ClassGenerator/ASClass.h>
+#endif
+
 // --------------------------------------------------------------------------------------------------------------------
 
 auto
@@ -103,6 +109,43 @@ auto
 {
     if (ck::Is_NOT_Valid(InProperty, ck::IsValid_Policy_NullptrOnly{}))
     { return TEXT("void"); }
+
+#if WITH_ANGELSCRIPT_CK
+    // AngelScript-declared UPROPERTYs carry their narrow type (including dynamic typesafe
+    // handles like FCk_Handle_Trigger) only in AS's asITypeInfo — the FProperty itself
+    // collapses them to FCk_Handle. Walk owner UClass -> UASClass -> asITypeInfo to
+    // recover the full type declaration as written in source.
+    if ((InProperty->AngelscriptPropertyFlags & APF_RuntimeGenerated) != 0)
+    {
+        if (auto* OwnerClass = InProperty->GetOwner<UClass>())
+        {
+            if (auto* ASClass = UASClass::GetFirstASClass(OwnerClass))
+            {
+                if (auto* ScriptType = static_cast<asITypeInfo*>(ASClass->ScriptTypePtr))
+                {
+                    const auto PropName = InProperty->GetName();
+                    const auto PropCount = ScriptType->GetPropertyCount();
+                    for (asUINT i = 0; i < PropCount; ++i)
+                    {
+                        const char* AsPropName = nullptr;
+                        ScriptType->GetProperty(i, &AsPropName);
+                        if (AsPropName != nullptr && PropName.Equals(UTF8_TO_TCHAR(AsPropName)))
+                        {
+                            const auto Usage = FAngelscriptTypeUsage::FromProperty(ScriptType, i);
+                            if (Usage.IsValid() && Usage.Type.IsValid())
+                            {
+                                const auto Decl = Usage.GetAngelscriptDeclaration();
+                                if (NOT Decl.IsEmpty())
+                                { return Decl; }
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
 
     if (auto ArrayProp = CastField<FArrayProperty>(InProperty))
     {


### PR DESCRIPTION
## Summary
- Dynamic typesafe handles (e.g. `FCk_Handle_Trigger`, `FCk_Handle_Occupancy`) collapse to `FCk_Handle` at the `FProperty` layer — the narrow type survives only inside AngelScript's own `asITypeInfo`.
- `CkAngelscriptEntityScriptParamsGenerator` was falling through to `FProperty::GetCPPType()`, producing `FCk_Handle` in every generated `_EntitySpawnParams.as` struct for AS-declared entity scripts.
- Fix: in `Get_DetailedPropertyType`, for properties flagged `APF_RuntimeGenerated`, walk `UClass → UASClass → ScriptTypePtr` and look up the AS type per index via `FAngelscriptTypeUsage::FromProperty(asITypeInfo*, i)`. `GetAngelscriptDeclaration()` yields the full original declaration including container subtypes (e.g. `TArray<FCk_Handle_Trigger>`).

## Test plan
- [x] Rebuild `CkAngelscriptGenerator` editor module.
- [x] Delete a generated entry in `Script/Generated/<Plugin>_EntitySpawnParams.as` and re-run the generator.
- [x] Verify `FBb_OccupancyDriver_EntityScript_SpawnParams` emits `TArray<FCk_Handle_Trigger>` / `FCk_Handle_Occupancy` (not `FCk_Handle`).
- [x] Spot-check other AS entity scripts using typesafe handles regenerate correctly.
- [x] Confirm no regressions on primitives / enums / plain USTRUCTs.