### PR TITLE
fix(probe): drop Setup's FTag_Transform_Updated exclusion

### DIFF
--- a/Source/CkSpatialQuery/Public/CkSpatialQuery/Probe/CkProbe_Processor.h
+++ b/Source/CkSpatialQuery/Public/CkSpatialQuery/Probe/CkProbe_Processor.h
@@ -50,7 +50,6 @@ namespace ck::details
             ck::TReadWrite<FFragment_Probe_Current>,
             ck::TReadOnly<FFragment_Transform>,
             FTag_Probe_NeedsSetup,
-            TExclude<FTag_Transform_Updated>,
             TExclude<FTag_SceneNode_RelativeTransformUpdated>,
             CK_IGNORE_PENDING_KILL>
     {
@@ -62,7 +61,6 @@ namespace ck::details
             ck::TReadWrite<FFragment_Probe_Current>,
             ck::TReadOnly<FFragment_Transform>,
             FTag_Probe_NeedsSetup,
-            TExclude<FTag_Transform_Updated>,
             TExclude<FTag_SceneNode_RelativeTransformUpdated>,
             CK_IGNORE_PENDING_KILL>;
 


### PR DESCRIPTION
## Summary

`TProcessor_ProbeSetup` was excluded from running on entities with `FTag_Transform_Updated` present. The intent was defensive — wait for the entity's transform to settle before creating the Jolt body, so the body is positioned at a stable snapshot rather than mid-mutation.

In practice this created a **permanent starvation** for continuously-moving entities:

1. The transform pipeline re-adds `FTag_Transform_Updated` every frame a `Request_SetLocation` / `Request_SetTransform` is applied.
2. A tween-driven entity (e.g. a `CkTween::Yoyo` loop on an entity's transform) issues a new SetLocation on every processor tick.
3. The tag never clears long enough for the exclusion to release, so Setup never runs, so the Jolt body is never created.
4. Probe is "alive" from the fragment's perspective but has no backing body — overlaps silently never fire.

## Discovery

Surfaced while building the BB StoreDriver gym's tween-driven ball fleet (separate repo, BusterBlock's `feature/store-rework/step-2-area`). Balls with Kinematic probes would never register as inside a Trigger's Static-probe volume. Debugged by dropping to Jolt's body list and confirming zero probe bodies for the moving balls.

Worked around temporarily by adding an artificial 0.5s "warmup delay" before starting the tween — giving Setup a quiet window. That delay is now unnecessary and has been dropped from the BB side.

## Why removing the exclusion is safe

Setup reads `FFragment_Transform` exactly once to position the new body. The value it reads is, at worst, one frame stale relative to what the entity's transform will settle to — and the very next tick, `FProcessor_Probe_UpdateTransform` catches any drift (it's already gated on `FTag_Transform_Updated` to push entity transform → body). The removed exclusion was protecting against a race that the Update processor already handles.

## Scope

One file, two lines removed. Only the templated `TProcessor_ProbeSetup<T_ShapeFragment>` class is touched — it serves Box / Sphere / Capsule / Cylinder via template instantiation, so one fix covers all four probe shapes.

`FTag_SceneNode_RelativeTransformUpdated` exclusion is preserved — scene-node reparenting is a different class of transform flux (structural, not just positional) and has its own settling semantics.

## Test plan

- [ ] Existing CkTests gyms that use static probes still work (Trigger gym, any other probe-based gym that spawns probes on stationary entities).
- [ ] CkTests Probe gym's nested-scene-node station: probe at the end of a scene-node chain is created correctly and its body tracks the root as expected.
- [ ] Downstream BB StoreDriver gym: moving balls with Kinematic probes reliably fire overlaps against the Trigger volumes without the warmup-delay workaround.