### PR TITLE
fix(handle): guard against missing-fragment UB in static + dynamic fragment accessors

### DIFF
--- a/Source/CkDynamic/Public/CkDynamic/CkDynamic_Utils.cpp
+++ b/Source/CkDynamic/Public/CkDynamic/CkDynamic_Utils.cpp
@@ -42,6 +42,17 @@ namespace
             }
         }
     }
+
+    auto Get_InvalidSentinel_FragmentData(const UScriptStruct* InStructType) -> FInstancedStruct&
+    {
+        static TMap<const UScriptStruct*, FInstancedStruct> Sentinels;
+        auto& Instance = Sentinels.FindOrAdd(InStructType);
+        if (NOT Instance.IsValid() || Instance.GetScriptStruct() != InStructType)
+        {
+            Instance.InitializeAs(InStructType);
+        }
+        return Instance;
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -158,15 +169,15 @@ auto
         const UScriptStruct* InStructType)
     -> FInstancedStruct&
 {
-    static auto Invalid = FInstancedStruct{};
+    static auto InvalidNoType = FInstancedStruct{};
 
     CK_ENSURE_IF_NOT(ck::IsValid(InStructType),
         TEXT("Invalid Dynamic Fragment type passed. Unable to get Dynamic Fragment from [{}]"), InHandle)
-    { return Invalid; }
+    { return InvalidNoType; }
 
     CK_ENSURE_IF_NOT(ck::IsValid(InHandle),
         TEXT("Invalid Handle [{}] passed. Unable to get Dynamic Fragment [{}]"), InHandle, InStructType)
-    { return Invalid; }
+    { return Get_InvalidSentinel_FragmentData(InStructType); }
 
     const auto StorageId = Get_StorageId(InStructType);
     auto Handle = InHandle;
@@ -175,7 +186,7 @@ auto
 
     CK_ENSURE_IF_NOT(Storage.contains(Entity),
         TEXT("Entity [{}] does NOT have the Dynamic Fragment [{}]! Cannot retrieve it"), InHandle, InStructType)
-    { return Invalid; }
+    { return Get_InvalidSentinel_FragmentData(InStructType); }
 
     auto& Fragment = Storage.get(Entity);
     return Fragment.Get_StructData();
@@ -416,15 +427,15 @@ auto
         const UScriptStruct* InStructType)
     -> FScriptStructWildcard&
 {
-    static auto Invalid = FScriptStructWildcard{};
+    static auto InvalidNoType = FScriptStructWildcard{};
 
     CK_ENSURE_IF_NOT(ck::IsValid(InStructType),
         TEXT("Invalid Dynamic Fragment type passed. Unable to get Dynamic Fragment from [{}]"), InHandle)
-    { return Invalid; }
+    { return InvalidNoType; }
 
     CK_ENSURE_IF_NOT(ck::IsValid(InHandle),
         TEXT("Invalid Handle [{}] passed. Unable to get Dynamic Fragment [{}]"), InHandle, InStructType)
-    { return Invalid; }
+    { return *(FScriptStructWildcard*)Get_InvalidSentinel_FragmentData(InStructType).GetMutableMemory(); }
 
     const auto StorageId = Get_StorageId(InStructType);
     auto Handle = InHandle;
@@ -433,7 +444,7 @@ auto
 
     CK_ENSURE_IF_NOT(Storage.contains(Entity),
         TEXT("Entity [{}] does NOT have the Dynamic Fragment [{}]! Cannot retrieve it"), InHandle, InStructType)
-    { return Invalid; }
+    { return *(FScriptStructWildcard*)Get_InvalidSentinel_FragmentData(InStructType).GetMutableMemory(); }
 
     auto& Fragment = Storage.get(Entity);
     return *(FScriptStructWildcard*)Fragment.Get_StructData().GetMemory();

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.h
@@ -994,6 +994,11 @@ auto
         { return Invalid_Fragment; }
     }
 
+    CK_ENSURE_IF_NOT(_Registry->Has<T_Fragment>(_Entity),
+        TEXT("Handle [{}] is missing Fragment [{}]. Returning Invalid_Fragment."),
+        *this, ck::Get_RuntimeTypeToString<T_Fragment>())
+    { return Invalid_Fragment; }
+
     return _Registry->Get<T_Fragment>(_Entity);
 }
 
@@ -1026,6 +1031,11 @@ auto
             }())
         { return Invalid_Fragment; }
     }
+
+    CK_ENSURE_IF_NOT(_Registry->Has<T_Fragment>(_Entity),
+        TEXT("Handle [{}] is missing Fragment [{}]. Returning Invalid_Fragment."),
+        *this, ck::Get_RuntimeTypeToString<T_Fragment>())
+    { return Invalid_Fragment; }
 
     return _Registry->Get<T_Fragment>(_Entity);
 }


### PR DESCRIPTION
## Summary

Two related framework fixes surfaced while diagnosing a BusterBlock crash where dismissing a \`CastChecked\` ensure on a wrong-typed handle led to a hard crash in mimalloc (\`TScriptArray::ResizeGrow\` with a wild pointer \`0x8000000900000000\`).

- **\`FCk_Handle::Get<T>()\`** — was UB when called on a valid entity that lacked the requested fragment. Only the invalid-handle case was guarded; the fall-through called \`_Registry->Get<T_Fragment>(_Entity)\` directly, which is EnTT UB on missing components. Added a \`Has<T_Fragment>\` guard that ensures and returns the existing zero-init \`Invalid_Fragment\` static on miss.

- **\`UCk_Utils_DynamicFragment_UE::Get_Fragment\` / \`Get_Fragment_TypeUnsafe\`** — already ensured on invalid handle but returned a default-constructed \`FScriptStructWildcard\`/\`FInstancedStruct\` with **no backing memory**. AS-side callers that wrote into fields of the returned struct (e.g. \`RequestsFragment.FocusRequests.Add(...)\`) landed writes in unallocated memory and corrupted a \`TArray\`, crashing later. Replaced the shared empty sentinel with a per-\`UScriptStruct\` lazily-initialized \`FInstancedStruct\` map so the returned reference always has properly-sized throwaway storage.

Both preserve the existing dismiss-and-continue ensure contract.

## Test plan

- [x] Build CkFoundation as a Development Editor dependency of a consuming project (BusterBlock) and confirm no regressions on normal play.
- [x] Repro the original crash: temporarily remove any \`Has_Fragment\` guard at the call site, trigger a path that casts an entity to a typed handle it doesn't qualify for, and confirm:
  - Several dismissable ensures fire (CastChecked, Has_Fragment, Add_Fragment, Get_Fragment).
  - No crash — execution continues with sentinel data.
- [x] Verify an existing unit test (if any covers \`Get_Fragment\` / dynamic fragments) still passes.