### PR TITLE
fix(dynamic): ensure on duplicate Add_Fragment instead of silent overwrite

### DIFF
--- a/Source/CkDynamic/Public/CkDynamic/CkDynamic_Utils.cpp
+++ b/Source/CkDynamic/Public/CkDynamic/CkDynamic_Utils.cpp
@@ -75,10 +75,12 @@ auto
     auto&& Storage = InHandle->Storage<ck::FFragment_DynamicFragment_Data>(StorageId);
     const auto Entity = InHandle.Get_Entity().Get_ID();
 
-    if (Storage.contains(Entity))
-    {
-        Storage.remove(Entity);
-    }
+    CK_ENSURE_IF_NOT(NOT Storage.contains(Entity),
+        TEXT("Fragment [{}] already exists in Entity [{}]. ")
+        TEXT("Call AddOrGet_Fragment if you want replace-on-duplicate semantics, ")
+        TEXT("or compose this feature on a child entity instead."),
+        InFragmentData.GetScriptStruct(), InHandle)
+    { return InHandle; }
 
     Storage.emplace(Entity, std::move(Fragment));
 


### PR DESCRIPTION
## Summary

- `UCk_Utils_DynamicFragment_UE::Add_Fragment` silently did a remove-then-re-insert when the fragment type was already present on the entity — so composing the same feature onto the same entity twice (e.g. calling a `utils_X::Add` helper twice) would silently clobber state instead of erroring.
- The C++ `FCk_Handle::Add<T>` → `FCk_Registry::Add<T>` path already ensures on duplicate. The AngelScript and Blueprint path (which both route through `UCk_Utils_DynamicFragment_UE::Add_Fragment`) now matches that semantics.
- Callers that legitimately want replace-on-duplicate should use `AddOrGet_Fragment` or explicit remove-then-add.

## Background

Discovered while debugging a BusterBlock StoreDriver gym: composing two Doors onto the same station entity silently merged their `FBb_Fragment_Door_State` and `FBb_Fragment_Door_Signals`, producing confusing gameplay symptoms (occupancy count stuck at 1, no diagnostic). With this fix the duplicate add trips a modal on the second call with a clear message pointing to the remediation.

## Screenshot

Repro'd in the BB StoreDriver MultiEntry gym with two `utils_door::Add` calls on the same station transform. The ensure fires at construct time with the fragment type, the offending entity, and a full AS callstack pointing at the duplicate `utils_door::Add` call site:

<img width="1026" height="384" alt="BusterBlockEditor_IMR0mhWi1f" src="https://github.com/user-attachments/assets/41e839fe-5a07-418b-9a5a-d049a38591c5" />

## Audit

Every existing `Add_Fragment` caller across CkFoundation and the BusterBlock project is an "add-once" idiom (one `utils_X::Add` helper composing a fresh feature per entity). Zero hits on any conditional / remove-then-add / replace-on-duplicate pattern. CkStateMachine does not use the DynamicFragment path at all. So nothing was relying on the old silent-overwrite behavior.

## Test plan

- [x] Reproduced the original bug in a BusterBlock gym (two `utils_door::Add` on the same entity)
- [x] Confirmed the new ensure fires with the expected message + AS callstack pointing at the duplicate-add call site
- [x] Confirmed the fixed call pattern (one Door per child entity) runs cleanly with no spurious ensures
- [x] Re-run CkFoundation gyms to spot any regression from the tightened semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)