### PR TITLE
fix(StateMachine): prevent debug graph-walk temp entities from running gameplay side effects

### DIFF
--- a/Source/CkStateMachine/Public/CkStateMachine/Condition/CkSmCondition_Utils.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/Condition/CkSmCondition_Utils.cpp
@@ -2,6 +2,7 @@
 
 #include "CkStateMachine/Condition/EntityScripts/CkSmCondition_EntityScript.h"
 #include "CkStateMachine/Condition/EntityScripts/CkSmCondition_Polled.h"
+#include "CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h"
 #include "CkStateMachine/Transition/CkSmTransition_Fragment.h"
 #include "CkStateMachine/Transition/CkSmTransition_Utils.h"
 #include "CkStateMachine/StateMachine/CkStateMachine_Fragment.h"
@@ -59,6 +60,9 @@ auto
     ConditionEntity.Add<ck::FFragment_SmCondition_Params>(InConditionClass);
 
     auto ConditionEntityTyped = CastChecked(ConditionEntity);
+
+    if (InOwnerTransition.Has<ck::FTag_Sm_Debug_GraphWalkEntity>())
+    { ConditionEntity.Add<ck::FTag_Sm_Debug_GraphWalkEntity>(); }
 
     UCk_Utils_StateMachine_UE::RecordOfSmConditions_Utils::AddIfMissing(InOwnerTransition);
     UCk_Utils_StateMachine_UE::RecordOfSmConditions_Utils::Request_Connect(

--- a/Source/CkStateMachine/Public/CkStateMachine/Condition/EntityScripts/CkSmCondition_EntityScript.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/Condition/EntityScripts/CkSmCondition_EntityScript.cpp
@@ -2,6 +2,7 @@
 
 #include "CkStateMachine/CkStateMachine_Log.h"
 #include "CkStateMachine/Condition/CkSmCondition_Utils.h"
+#include "CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h"
 #include "CkStateMachine/StateMachine/CkStateMachine_Fragment.h"
 
 #include "CkEcs/ContextOwner/CkContextOwner_Utils.h"
@@ -27,6 +28,13 @@ auto
     -> void
 {
     Super::BeginPlay();
+
+    // See UCk_SmState_EntityScript::BeginPlay for rationale. Graph-walk temp conditions
+    // must not activate — their DoEnterCondition can have observable side effects
+    // (e.g. capturing world time for a dwell timer) and FTag_SmCondition_Active would
+    // admit them to the polled evaluation loop.
+    if (_AssociatedEntity.Has<ck::FTag_Sm_Debug_GraphWalkEntity>())
+    { return; }
 
     auto Self = UCk_Utils_SmCondition_UE::CastChecked(_AssociatedEntity);
     EnterCondition(Self);

--- a/Source/CkStateMachine/Public/CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h
+++ b/Source/CkStateMachine/Public/CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h
@@ -5,6 +5,23 @@
 #include "CkCore/Macros/CkMacros.h"
 #include "CkEcs/Tag/CkTag.h"
 
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ck
+{
+    // Marker for temp state / transition / condition / task entities created by the graph-walk
+    // processor to extract the sub-SM's static structure. Defined unconditionally (cheap) so
+    // utility-level propagation checks in SmTransition/SmCondition/SmTask Create can reference
+    // it without bracketing every call site with #if CK_BUILD_SM_GRAPH_WALK. When the graph
+    // walk is compiled out, the tag is never stamped and every check is a no-op.
+    //
+    // Entities carrying this tag must be excluded from the normal runtime evaluation pipeline:
+    // processors must TExclude it; EntityScript BeginPlay must skip Enter*. Otherwise the
+    // task side effects (e.g. signal broadcasts, Request_Stop) execute on what is supposed to
+    // be inert reflection data and corrupt the real SM.
+    CK_DEFINE_ECS_TAG(FTag_Sm_Debug_GraphWalkEntity);
+}
+
 #if CK_BUILD_SM_GRAPH_WALK
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkStateMachine/Public/CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Processor.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Processor.cpp
@@ -76,6 +76,10 @@ namespace ck
 
             auto TempEntity = UCk_Utils_SmState_UE::Create(InSmHandle, StateClass);
 
+            // Tag before the deferred script attach runs so DefineState's children
+            // (transitions/conditions/tasks) cascade the tag via their Create utilities.
+            TempEntity.Add<FTag_Sm_Debug_GraphWalkEntity>();
+
             auto PendingEntry = FFragment_Sm_Debug_GraphWalk_Progress::FPendingEntity{};
             PendingEntry.StateClass = StateClass;
             PendingEntry.EntityHandle = TempEntity;

--- a/Source/CkStateMachine/Public/CkStateMachine/State/EntityScripts/CkSmState_EntityScript.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/State/EntityScripts/CkSmState_EntityScript.cpp
@@ -1,6 +1,7 @@
 #include "CkSmState_EntityScript.h"
 
 #include "CkStateMachine/CkStateMachine_Log.h"
+#include "CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h"
 #include "CkStateMachine/State/CkSmState_Fragment.h"
 #include "CkStateMachine/StateMachine/CkStateMachine_Fragment.h"
 
@@ -44,6 +45,14 @@ auto
     -> void
 {
     Super::BeginPlay();
+
+    // Graph-walk temp entities exist only to let DefineState populate the SM's static
+    // structure for the debugger. They must not activate — EnterState stamps
+    // FTag_SmState_Active which would admit them to the runtime evaluation loop and
+    // cause their tasks' DoEnterTask to run real gameplay side effects on an SM that
+    // is not supposed to be advancing.
+    if (_AssociatedEntity.Has<ck::FTag_Sm_Debug_GraphWalkEntity>())
+    { return; }
 
     const auto Self = UCk_Utils_SmState_UE::CastChecked(_AssociatedEntity);
     EnterState(Self);

--- a/Source/CkStateMachine/Public/CkStateMachine/Task/CkSmTask_Utils.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/Task/CkSmTask_Utils.cpp
@@ -1,5 +1,6 @@
 #include "CkSmTask_Utils.h"
 
+#include "CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h"
 #include "CkStateMachine/Task/EntityScripts/CkSmTask_EntityScript.h"
 #include "CkStateMachine/StateMachine/CkStateMachine_Fragment.h"
 #include "CkStateMachine/StateMachine/CkStateMachine_Utils.h"
@@ -53,6 +54,9 @@ auto
     TaskEntity.Add<ck::FFragment_SmTask_Params>(InTaskClass);
 
     auto TaskEntityTyped = CastChecked(TaskEntity);
+
+    if (InOwnerState.Has<ck::FTag_Sm_Debug_GraphWalkEntity>())
+    { TaskEntity.Add<ck::FTag_Sm_Debug_GraphWalkEntity>(); }
 
     UCk_Utils_StateMachine_UE::RecordOfSmTasks_Utils::AddIfMissing(InOwnerState);
     UCk_Utils_StateMachine_UE::RecordOfSmTasks_Utils::Request_Connect(

--- a/Source/CkStateMachine/Public/CkStateMachine/Task/EntityScripts/CkSmTask_EntityScript.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/Task/EntityScripts/CkSmTask_EntityScript.cpp
@@ -3,6 +3,7 @@
 #include "CkCore/Time/CkTime.h"
 #include "CkEcs/ContextOwner/CkContextOwner_Utils.h"
 #include "CkStateMachine/CkStateMachine_Log.h"
+#include "CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h"
 #include "CkStateMachine/StateMachine/CkStateMachine_Fragment.h"
 #include "CkStateMachine/Task/CkSmTask_Fragment.h"
 #include "CkStateMachine/Task/CkSmTask_Utils.h"
@@ -27,6 +28,13 @@ auto
     -> void
 {
     Super::BeginPlay();
+
+    // See UCk_SmState_EntityScript::BeginPlay for rationale. Skipping EnterTask here
+    // is the critical guard — tasks like UBb_Hfsm_Task_TerminateOwningSm issue
+    // Request_Stop on the owning SM during DoEnterTask, which would kill the real
+    // sub-SM when the graph-walk temp-entity reaches the terminal state.
+    if (_AssociatedEntity.Has<ck::FTag_Sm_Debug_GraphWalkEntity>())
+    { return; }
 
     auto Self = UCk_Utils_SmTask_UE::CastChecked(_AssociatedEntity);
     EnterTask(Self);

--- a/Source/CkStateMachine/Public/CkStateMachine/Transition/CkSmTransition_Utils.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/Transition/CkSmTransition_Utils.cpp
@@ -1,6 +1,7 @@
 #include "CkSmTransition_Utils.h"
 
 #include "CkStateMachine/Condition/CkSmCondition_Utils.h"
+#include "CkStateMachine/Debug/CkStateMachine_Debug_GraphWalk_Fragment.h"
 #include "CkStateMachine/State/CkSmState_Fragment.h"
 #include "CkStateMachine/State/CkSmState_Utils.h"
 #include "CkStateMachine/State/EntityScripts/CkSmState_EntityScript.h"
@@ -44,6 +45,9 @@ auto
 
     auto TransitionEntityTyped = CastChecked(TransitionEntity);
     TransitionEntityTyped.Add<ck::FTag_SmTransition_FullyEventDriven>();
+
+    if (InOwnerState.Has<ck::FTag_Sm_Debug_GraphWalkEntity>())
+    { TransitionEntity.Add<ck::FTag_Sm_Debug_GraphWalkEntity>(); }
 
     UCk_Utils_StateMachine_UE::RecordOfSmTransitions_Utils::AddIfMissing(InOwnerState);
     UCk_Utils_StateMachine_UE::RecordOfSmTransitions_Utils::Request_Connect(


### PR DESCRIPTION
## Summary

- Debug graph-walk processor was creating live ECS state entities whose tasks' `DoEnterTask` bodies ran real gameplay side effects (signal broadcasts, `Request_Stop` on owning SM, external writes) before the entities were destroyed. Most SMs hid the bug because task side effects were idempotent; the first multi-state sub-SM with an externally-visible enter-body (broadcasting signals + `TerminateOwningSm`) hit it head-on and appeared to advance through all states in ~150ms.
- Introduces `FTag_Sm_Debug_GraphWalkEntity`, stamped on temp states at creation and propagated to children via `SmTransition_Utils::Create` / `SmCondition_Utils::Create` / `SmTask_Utils::Create`. The three EntityScript base-class `BeginPlay`s short-circuit before `Enter*` when the tag is present, so `FTag_*_Active` is never added and the runtime processors (already gated on Active) skip these entities.
- `DefineState` still runs during `Construct` so the debugger gets the structure it needs. Only the activation side effects are suppressed.

## Context

Surfaced while implementing a 7-state sub-SM for BusterBlock's CheckoutCounter. The sub-SM appeared to bypass polled-condition results — `AlwaysFalse_DEBUG.DoEvaluate` returned false and the transition fired anyway. Root cause turned out to be unrelated to condition evaluation: the graph-walk's temp Exit-state was firing `UBb_Hfsm_Task_TerminateOwningSm::DoEnterTask`, which called `Request_Stop` on the real sub-SM.

Top-level SMs with the same polled-condition pattern worked fine because their task enter-bodies only wrote to attributes that the real current state immediately overwrote.

## Test plan

- [x] Rebuild CkFoundation with `CK_BUILD_SM_GRAPH_WALK` enabled (editor/development).
- [x] BusterBlock CheckoutCounter repro: sub-SM dwells in `Enter` indefinitely with `AlwaysFalse_DEBUG`; with `StateDwellTimer` each state dwells ~2s and the full transaction takes ~12s. Verify no orphan condition polling after `SubSmFinished`.
- [ ] Verify `CkStateMachine_TestStates_Complex` top-level gym still passes (no regression on the non-buggy path).
- [x] Verify the graph-walk debugger cache still populates — open a SM in the debugger panel and confirm transitions / conditions / tasks render.
- [x] Quick smoke: existing player/NPC HFSMs still tick normally (attribute-driven transitions fire, tasks' DoTickTask runs for Tick-mode tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)