### PR TITLE
fix(StateMachine): gate Evaluate on PendingExit to prevent divergence-point duplicate state/task

### DIFF
--- a/Source/CkStateMachine/Public/CkStateMachine/State/CkSmState_Processor.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/State/CkSmState_Processor.cpp
@@ -83,6 +83,22 @@ namespace ck
     {
         InHandle.Try_Remove<FTag_SmState_NeedsEvaluation>();
 
+        // A state that has been Request_Exit'd must not produce more transitions.
+        // Request_Exit adds FTag_SmState_PendingExit and queues a deferred destroy,
+        // but the state entity stays alive (and so do its transitions/conditions)
+        // for at least one more frame. Without this gate, a polled condition
+        // re-firing on the soon-to-die state's chosen transition wakes the parent
+        // state's Evaluate again, which finds the cached Pass result and calls
+        // Request_Transition a second time — producing a duplicate next-state +
+        // task entity. This shows up as the "first-added branch's target task
+        // fires twice" bug at sub-SM divergence points: only the chosen branch's
+        // transition keeps a cached Pass (non-chosen ones get Request_ResetTransition
+        // on Fail, so Frame N+1 sees them Undetermined and Break's before the
+        // chosen one), and only the first-added among the iterated transitions
+        // is reachable before Break.
+        if (InHandle.Has<FTag_SmState_PendingExit>())
+        { return; }
+
         auto StateMachine = TUtils_Sm_OwningStateMachine::Get_StoredEntity(InHandle);
 
         if (ck::Is_NOT_Valid(StateMachine))

--- a/Source/CkStateMachine/Public/CkStateMachine/Transition/CkSmTransition_Processor.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/Transition/CkSmTransition_Processor.cpp
@@ -43,6 +43,16 @@ namespace ck
     {
         InHandle.Remove<MarkedDirtyBy>();
 
+        // Companion gate to FProcessor_SmState_Evaluate's PendingExit check. A
+        // transition belonging to a Request_Exit'd state is itself Request_Exit'd
+        // (FProcessor_SmState_Exit cascades), but the entity stays alive until
+        // the deferred destroy runs. Without this, a polled condition wake-up
+        // on the dying transition would call Request_Evaluate(ParentState) — the
+        // state-side gate already blocks that work, but skipping the transition
+        // work too keeps the ECS quieter and avoids spurious Pass result writes.
+        if (InHandle.Has<FTag_SmTransition_PendingExit>())
+        { return; }
+
         const auto Conditions = UCk_Utils_StateMachine_UE::RecordOfSmConditions_Utils::Get_ValidEntries(InHandle);
         auto ParentState = TUtils_Sm_ParentState::Get_StoredEntity(InHandle);
 


### PR DESCRIPTION
## Summary

A state that has been `Request_Exit`'d still has its entity (and its transition entities, with their cached evaluation results) alive for at least one more frame while the deferred destroy works through the lifetime processor. Without a gate, `FProcessor_SmState_Evaluate` fires on that dying state on the next tick — finds a cached `Pass` result on one of its transitions — and calls `Request_Transition` a second time, producing a duplicate next-state and next-task entity.

## What the fix does

Two early-return gates added to processors:

- **`FProcessor_SmState_Evaluate`** ([CkSmState_Processor.cpp](https://github.com/chainkemists/CkFoundation/blob/fix/sm-duplicate-firstbranch-task-instance/Source/CkStateMachine/Public/CkStateMachine/State/CkSmState_Processor.cpp)) — early-returns if `InHandle.Has<FTag_SmState_PendingExit>()`. A state that's been `Request_Exit`'d must not produce more `Request_Transition` calls before its deferred destroy runs.
- **`FProcessor_SmTransition_Evaluate`** ([CkSmTransition_Processor.cpp](https://github.com/chainkemists/CkFoundation/blob/fix/sm-duplicate-firstbranch-task-instance/Source/CkStateMachine/Public/CkStateMachine/Transition/CkSmTransition_Processor.cpp)) — early-returns if `InHandle.Has<FTag_SmTransition_PendingExit>()`. Companion gate — transitions on a dying state are themselves `Request_Exit`'d; skipping their work avoids spurious `Pass` writes and `Request_Evaluate(source)` calls during teardown.

The fix is **broader than the symptom that surfaced it** — it gates *any* dying state from continuing to drive transitions, not just states with multiple outgoing edges. See "Where this surfaced" below for why we only have a demonstrable repro at divergence points.

## Where this surfaced

The bug was first hit at sub-SM divergence points (states with two or more outgoing transitions): when the chosen branch was the **first-added** transition, its target state-task chain got constructed twice (two distinct state entities, two distinct task entities firing real `DoEnterTask`). The doubling tracked `AddTransition` order — swap the order of `AddTransition` calls and the doubling followed the new first-added branch.

That symmetric pattern (chosen-and-first-added doubles, anything else doesn't) is fully explained by `FProcessor_SmState_Evaluate`'s iteration logic:

```cpp
case ECk_SmTransitionResult::Fail:
{
    UCk_Utils_SmTransition_UE::Request_ResetTransition(InTransition);  // resets polled conds
    return ECk_Record_ForEachIterationResult::Continue;
}
case ECk_SmTransitionResult::Pass:
{
    UCk_Utils_StateMachine_UE::Request_Transition(StateMachine, TargetStateClass);
    return ECk_Record_ForEachIterationResult::Break;  // no reset
}
```

`Fail` resets the cache via `Request_ResetTransition`. `Pass` doesn't. So at a divergence point on Frame N+1:

- The chosen-first-added transition retains its cached `Pass` with no reset path → fires `Request_Transition` again → duplicate.
- The non-chosen first-added transition was `Fail` on Frame N → reset to `Undetermined` → on Frame N+1 the iterator hits `Undetermined` and `Break`s without reaching the chosen second-added sibling → can't double.
- A chosen second-added transition is always shielded by its `Undetermined` first-added sibling `Break`ing the iteration first → can't double.

So the divergence-point bug is what made the race observable through a clean, reproducible signal.

## What we don't fully know

By the same Frame-N+1 model, a single-transition state with a cached `Pass` should *also* be vulnerable. Empirically it doesn't reproduce — single-transition states never showed a duplicate `Request_Transition` even with the bug present. The most likely explanation is processor-scheduling: a smaller record (one task, one transition, no polled conditions) lets the destroy cascade complete within Frame N, so the source state entity is gone before Frame N+1's `Update→Evaluate` cycle can reach it; a divergence state with a richer dependency graph (multiple transitions, polled-condition children still ticking) pushes the cascade an extra tick. We did not reverse-engineer the scheduler to prove this.

The fix doesn't depend on which side is right — gating any `PendingExit` state from re-firing transitions is correct regardless of whether single-transition states would *ever* race in practice. If they would, this also fixes them; if they wouldn't, the gate is a no-op for that case.

## Verification

Diagnostic logs (added during investigation, stripped from this PR) caught the duplicate cleanly. Pre-fix, one Credit-cycle through a `Scanning -+-> Credit -> Finish / +-> Cash -/` sub-SM with `[ToCredit, ToCash]` add-order:

```
[57] SM transition queued to [Credit]
[57] State Create [Credit]   ← Credit state #1
[57] Task Create [Credit]    ← Credit task #1 (DoEnterTask fires)
[58] SM transition queued to [Credit]   ← duplicate, 1 frame later
[58] State Create [Credit]   ← Credit state #2
[58] Task Create [Credit]    ← Credit task #2 (DoEnterTask fires again)
```

Post-fix, same cycle produces a single `transition queued`, a single state, a single task. Verified across multiple consecutive cycles, both choice directions, both AddTransition orders.

## Test plan

- [x] Manual repro on a sub-SM with a divergence-point state, both branch directions, both AddTransition orders
- [x] Verified the cached-Pass path on `Request_ResetTransition`-eligible (non-chosen) branches still resets correctly across cycles
- [x] Verified `FProcessor_SmTransition_Evaluate`'s vacuous-Pass and timer-Pass paths still fire for fresh transitions (the gate only catches `PendingExit`)
- [x] Run existing `CkStateMachine` test gym stations end-to-end (Auto Cycle, Pause/Resume, Complex, Hierarchical, Graph-Walk Regression) — should be unaffected; gates only kick in once a state has been `Request_Exit`'d
- [x] Add permanent regression station(s) to `CkTests` exercising the divergence-point shape — drafted in a companion branch on `CkTests`, separate PR

## Out of scope

- The original report mentioned a stuck-state correlation after several consecutive doubled cycles (`CkEnsure: ck::IsValid(Driver)`). With the duplicates eliminated, the leak pressure goes away; if the ensure still reproduces it has a separate root cause and should be tracked as its own bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)