### PR TITLE
fix(inventory): dedupe item traits by class in DoConstruct

### DIFF
--- a/Source/CkInventory/Public/CkInventory/Item/CkItem_Definition.cpp
+++ b/Source/CkInventory/Public/CkInventory/Item/CkItem_Definition.cpp
@@ -20,10 +20,22 @@ auto
 {
     InHandle.Add<ck::FFragment_InventoryItem>(TWeakObjectPtr(this));
 
+    // Guard against duplicate-class entries in _ItemTraits. The Get_ItemTrait<T> /
+    // Has_ItemTrait<T> API treats one-trait-per-class as invariant (returns the
+    // first match), so any duplicate is dead weight whose only effect is to
+    // double-apply trait setup (e.g. add the same StackCount/TagSet twice and
+    // trip CkEnsure). AS asset-body hot-reload can populate the CDO array with
+    // appended duplicates; this loop tolerates that without breaking the entity.
+    auto SeenTraitClasses = TSet<const UClass*>{};
     for (const auto& ItemTrait : _ItemTraits)
     {
         CK_ENSURE_IF_NOT(ck::IsValid(ItemTrait),
             TEXT("DoConstruct: Invalid ItemTrait on Definition [{}]."), this->GetFName())
+        { continue; }
+
+        bool AlreadySeen = false;
+        SeenTraitClasses.Add(ItemTrait->GetClass(), &AlreadySeen);
+        if (AlreadySeen)
         { continue; }
 
         Request_Construct_Instanced(InHandle, ItemTrait.Get());


### PR DESCRIPTION
## Summary
- `UCk_InventoryItem_Definition::DoConstruct_Implementation` now skips trait entries whose class has already been constructed on the entity, eliminating duplicate StackCount / TagSet creation when `_ItemTraits` contains repeats.
- Aligns the construction loop with the existing one-trait-per-class invariant already enforced by `Get_ItemTrait<T>` / `Has_ItemTrait<T>` and `PostEditChangeProperty`.

## Root cause
AS `asset` bodies re-run on hot-reload against the same CDO. Item defs use `_ItemTraits.Add(...)` in their initializer, so each AS recompile leaves the CDO with appended duplicates (e.g. `[Stackable, Tags, Stackable, Tags]`). The trait loop then double-applied each trait's setup. Discovered while diagnosing 7 inventory AutoTests failing on these CkEnsure warnings:
- `Cannot Connect RecordEntry [...StackCount]... already an entry`
- `Fragment [FFragment_TagSet] already exists in Entity`

## Test plan
- [x] `UCk_AutoTest_Inventory_DataOnly_AddItem` — passes
- [x] `UCk_AutoTest_Inventory_DataOnly_BoundedReject` — passes
- [x] `UCk_AutoTest_Inventory_DataOnly_OverrideBounds` — passes
- [x] `UCk_AutoTest_Inventory_DataOnly_RemoveItem` — passes
- [x] `UCk_AutoTest_Inventory_DataOnly_Unbounded` — passes
- [x] `UCk_AutoTest_Inventory_TagsTrait_AddTag` — still passes (no regression)
- [x] `UCk_AutoTest_Inventory_TagsTrait_RemoveTag` — still passes (no regression)
- [x] `Inventory_StackableTrait_*` — both warnings no longer fire; remaining failures are the pre-existing Amount-parameter / count-semantic anomaly called out in those tests' banners (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)