### PR TITLE
fix: AS literal-asset re-init duplicates Instanced containers on hot-reload

### DIFF
--- a/Source/CkCore/Public/CkCore/IO/CkDeferredAssetInit_AngelScript.cpp
+++ b/Source/CkCore/Public/CkCore/IO/CkDeferredAssetInit_AngelScript.cpp
@@ -8,17 +8,15 @@
 
 #if WITH_ANGELSCRIPT_CK
 #include <AngelscriptManager.h>
+#include <ClassGenerator/AngelscriptClassGenerator.h>
 #include <ClassGenerator/ASClass.h>
 #include <as_context.h>
 #endif
 
 // --------------------------------------------------------------------------------------------------------------------
-// Registrar
-//
-// FCoreDelegates::OnFEngineLoopInitComplete fires once at engine init — that's when we re-run
-// first-pass AS inits that had to return nullptr from assets::load:: because blocking loads
-// weren't yet safe. The AS plugin's own hot-reload path already recreates CDOs/literal assets
-// with working blocking-loads, so we don't need to bind to OnPostReload.
+// Registrar — bind both the boot-complete and AS-hot-reload entry points. The hot-reload bind
+// is essential: the AS plugin re-runs __Init_<Name> on cached instances without resetting,
+// so `_Arr.Add(...)` in asset bodies would accumulate across reloads.
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace
@@ -29,6 +27,11 @@ namespace
         {
             FCoreDelegates::OnFEngineLoopInitComplete.AddStatic(
                 &UCk_DeferredAssetInit_UE::ResolveAllPending);
+
+#if WITH_ANGELSCRIPT_CK
+            FAngelscriptClassGenerator::OnPostReload.AddStatic(
+                &UCk_DeferredAssetInit_UE::OnAngelscriptPostReload);
+#endif
         }
     };
 
@@ -42,34 +45,42 @@ namespace
 namespace
 {
     // ----------------------------------------------------------------------------------------------------------------
-    // Phase 2 instance reset
+    // Phase 2 instance reset — copy CDO defaults over the cached instance before re-running
+    // __Init_, so `_Arr.Add(...)` style body statements don't double-apply.
     //
-    // Before re-running a literal-asset __Init_ body on an already-initialized instance, we copy
-    // the CDO's defaults over so that side-effectful statements (`default _Arr.Add(X);`,
-    // `_Struct.Inner.Add(...)`) don't double-apply on top of first-pass state.
-    //
-    // Skipped flags:
-    //   - Transient / DuplicateTransient / NonPIEDuplicateTransient: not persistent state.
-    //   - InstancedReference / ContainsInstancedReference / PersistentInstance / ExportObject:
-    //     subobjects (DefaultComponent etc.) — orphaning them would break any
-    //     `default MyComp.Foo = ...;` statements that follow.
-    //
-    // Note: we intentionally do NOT pre-reset the CDO in Phase 1. Scalar/object-ref default
-    // assignments like `default Config = bb::Asset_X;` are idempotent on re-run, and clearing
-    // class-owned properties before the re-run risks abandoning state (e.g. when a later
-    // statement in DefaultsFunction aborts and leaves a zeroed property in its place).
+    // Skip-list nuance: bare Instanced object refs (`UPROPERTY(Instanced) UMyComp*`) must be
+    // preserved — orphaning the subobject would break any `default _Comp.Foo = ...;` writes.
+    // But Instanced *containers* (`UPROPERTY(Instanced) TArray<TObjectPtr<UFoo>>`) MUST reset:
+    // asset bodies recreate their contents via NewObject, so without the reset the array
+    // accumulates new subobjects every reload. Orphans from prior runs are GC'd.
     // ----------------------------------------------------------------------------------------------------------------
 
-    constexpr EPropertyFlags GResetSkipPropertyFlags =
-        CPF_Transient |
-        CPF_DuplicateTransient |
-        CPF_NonPIEDuplicateTransient |
-        CPF_InstancedReference |
-        CPF_ContainsInstancedReference |
-        CPF_PersistentInstance |
-        CPF_ExportObject;
-
     constexpr auto ShouldCreateCDO = false;
+
+    auto ShouldSkipReset(const FProperty* InProp) -> bool
+    {
+        constexpr auto TransientFlags =
+            CPF_Transient |
+            CPF_DuplicateTransient |
+            CPF_NonPIEDuplicateTransient;
+
+        if (InProp->HasAnyPropertyFlags(TransientFlags))
+        { return true; }
+
+        constexpr auto InstancedFlags =
+            CPF_InstancedReference |
+            CPF_ContainsInstancedReference |
+            CPF_PersistentInstance |
+            CPF_ExportObject;
+
+        if (NOT InProp->HasAnyPropertyFlags(InstancedFlags))
+        { return false; }
+
+        const auto IsContainer = InProp->IsA<FArrayProperty>()
+                              || InProp->IsA<FSetProperty>()
+                              || InProp->IsA<FMapProperty>();
+        return NOT IsContainer;
+    }
 
     auto ResetInstanceFromCDO(UObject* InInstance) -> void
     {
@@ -81,7 +92,7 @@ namespace
         for (TFieldIterator<FProperty> PropIt(Class, EFieldIteratorFlags::IncludeSuper); PropIt; ++PropIt)
         {
             auto* Prop = *PropIt;
-            if (Prop->HasAnyPropertyFlags(GResetSkipPropertyFlags))
+            if (ShouldSkipReset(Prop))
             { continue; }
 
             Prop->CopyCompleteValue_InContainer(InInstance, CDO);
@@ -356,6 +367,44 @@ auto
 #else
         ck::core::Verbose(TEXT("[DeferredAssetInit] Phase 2: re-initialized {}/{} literal asset(s)"),
                           LiteralAssetStats.Succeeded, LiteralAssetStats.Declared);
+#endif
+    }
+
+#endif // WITH_ANGELSCRIPT_CK
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_DeferredAssetInit_UE::
+    OnAngelscriptPostReload(
+        bool InFullReload)
+    -> void
+{
+#if WITH_ANGELSCRIPT_CK
+
+#if WITH_EDITOR
+    ck::core::Display(TEXT("[DeferredAssetInit] Angelscript post-reload (FullReload=[{}]) — re-running literal asset inits"),
+                      InFullReload);
+#else
+    ck::core::Verbose(TEXT("[DeferredAssetInit] Angelscript post-reload (FullReload=[{}]) — re-running literal asset inits"),
+                      InFullReload);
+#endif
+
+    const auto Stats = ReRunAllLiteralAssetInits();
+    if (Stats.Succeeded < Stats.Declared)
+    {
+        ck::core::Warning(TEXT("[DeferredAssetInit] Post-reload: re-initialized {}/{} literal asset(s) — missing entries indicate AS preprocessor drift"),
+                          Stats.Succeeded, Stats.Declared);
+    }
+    else
+    {
+#if WITH_EDITOR
+        ck::core::Display(TEXT("[DeferredAssetInit] Post-reload: re-initialized {}/{} literal asset(s)"),
+                          Stats.Succeeded, Stats.Declared);
+#else
+        ck::core::Verbose(TEXT("[DeferredAssetInit] Post-reload: re-initialized {}/{} literal asset(s)"),
+                          Stats.Succeeded, Stats.Declared);
 #endif
     }
 

--- a/Source/CkCore/Public/CkCore/IO/CkDeferredAssetInit_AngelScript.h
+++ b/Source/CkCore/Public/CkCore/IO/CkDeferredAssetInit_AngelScript.h
@@ -9,23 +9,16 @@
 // --------------------------------------------------------------------------------------------------------------------
 // Deferred Asset Init
 //
-// Solves the problem of assets::load:: returning nullptr when called during Angelscript
-// __InitDefaults / literal-asset init (engine init isn't yet safe for blocking loads).
+// Fixes assets::load:: returning nullptr when called during AS __InitDefaults / literal-asset
+// init (engine init isn't yet safe for blocking loads), and the matching hot-reload case where
+// the AS plugin re-runs __Init_<Name> on the same cached instance — `_Arr.Add(...)` in the
+// body would otherwise double on every reload.
 //
-// On FCoreDelegates::OnFEngineLoopInitComplete we:
-//   - Force the blocking-load safety flag true (order-independent across cross-TU statics).
-//   - Short-circuit if no caller ever queried IsEngineSafeForBlockingLoads() while unsafe —
-//     nothing was deferred, no work to do.
-//   - Phase 1: walk AS classes via FAngelscriptManager modules and re-run their DefaultsFunction
-//     chain on each CDO. Scalar/object-ref assignments are idempotent so no pre-reset is done
-//     (pre-resetting class-owned properties risked clobbering state when a mid-chain statement
-//     aborted before the reassignment).
-//   - Phase 2: iterate each module's DeclaredLiteralAssets, reset the cached instance from its
-//     CDO (so .Add()-style statements in the body don't double), and call __Init_<AssetName>
-//     directly — bypassing the getter's first-call cache.
-//
-// The AS plugin's own hot-reload path already recreates CDOs/literal assets with working
-// blocking-loads, so we don't bind a separate hook for that.
+//   Phase 1 (boot only) — re-run each AS class's DefaultsFunction chain on its CDO. No
+//     pre-reset: scalar/object-ref defaults are idempotent, and clearing first risks
+//     abandoning state if a mid-chain statement aborts.
+//   Phase 2 (boot + hot-reload) — for each literal asset, reset the cached instance from its
+//     CDO then call __Init_<Name> directly (bypassing the getter's first-call cache).
 // --------------------------------------------------------------------------------------------------------------------
 
 UCLASS()
@@ -36,9 +29,12 @@ class CKCORE_API UCk_DeferredAssetInit_UE : public UBlueprintFunctionLibrary
 public:
     CK_GENERATED_BODY(UCk_DeferredAssetInit_UE);
 
-    // Called on OnFEngineLoopInitComplete. Re-runs Phase 1 (CDO defaults) and Phase 2
-    // (literal asset __Init_ functions) with blocking-loads now safe.
+    // OnFEngineLoopInitComplete — runs Phase 1 + Phase 2 with blocking-loads now safe.
     static void ResolveAllPending();
+
+    // FAngelscriptClassGenerator::OnPostReload — runs Phase 2 only. Phase 1 is skipped because
+    // the AS plugin updates CDOs in place during reload.
+    static void OnAngelscriptPostReload(bool InFullReload);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkInventory/Public/CkInventory/Item/CkItem_Definition.cpp
+++ b/Source/CkInventory/Public/CkInventory/Item/CkItem_Definition.cpp
@@ -20,10 +20,22 @@ auto
 {
     InHandle.Add<ck::FFragment_InventoryItem>(TWeakObjectPtr(this));
 
+    auto SeenTraitClasses = TSet<const UClass*>{};
     for (const auto& ItemTrait : _ItemTraits)
     {
         CK_ENSURE_IF_NOT(ck::IsValid(ItemTrait),
             TEXT("DoConstruct: Invalid ItemTrait on Definition [{}]."), this->GetFName())
+        { continue; }
+
+        // One-trait-per-class is invariant — Get_ItemTrait<T> returns the first match and
+        // PostEditChangeProperty rejects designer-authored duplicates. Catch runtime breaches
+        // (e.g. AS asset-init bug) here instead of letting them cascade into RecordEntry /
+        // Fragment-already-exists ensures downstream.
+        bool AlreadySeen = false;
+        SeenTraitClasses.Add(ItemTrait->GetClass(), &AlreadySeen);
+        CK_ENSURE_IF_NOT(NOT AlreadySeen,
+            TEXT("DoConstruct: Duplicate trait class [{}] on Definition [{}]."),
+            ItemTrait->GetClass(), this->GetFName())
         { continue; }
 
         Request_Construct_Instanced(InHandle, ItemTrait.Get());


### PR DESCRIPTION
## Summary

Fixes the root cause behind the inventory AutoTest failures that PR #646 papered over with a `DoConstruct` dedupe. The bug surfaces concretely as `Cannot Connect RecordEntry [...StackCount]` + `Fragment [FFragment_TagSet] already exists in Entity` ensures on every spawned item that uses an AS-declared `UCk_InventoryItem_Definition`, but the actual fault is general: **any** AS `asset Name of UClass { ... }` whose initializer body mutates a `TArray`/`TSet`/`TMap` UPROPERTY accumulates entries on each AS hot-reload.

### Root cause

Two gaps in `CkDeferredAssetInit_AngelScript`:

1. **`ResolveAllPending` was bound only to `OnFEngineLoopInitComplete`** — the AS plugin re-runs `__Init_<Name>` on the same cached literal-asset instance after every hot-reload without resetting it first, but this file's reset pass never fired on that path. The original comment claimed the AS plugin recreates literal assets on hot-reload; verified against `AngelscriptClassGenerator.cpp:2367/2446` — it does not, it just re-executes `__Init_` against the existing pointer.
2. **`ResetInstanceFromCDO` over-broadly skipped `CPF_InstancedReference`.** That skip was correct for bare-object Instanced subobjects (the `default _Comp.Foo = ...;` pattern), but it also bypassed Instanced *containers* (`UPROPERTY(Instanced) TArray<TObjectPtr<UFoo>>`) — exactly the case asset bodies hit when calling `_Arr.Add(NewObject(this, X))`.

### Changes

- **CkCore** — bind `OnAngelscriptPostReload` static to `FAngelscriptClassGenerator::OnPostReload` (re-runs Phase 2 only); replace the inline skip-flag check with a `ShouldSkipReset` helper that resets Instanced containers while still preserving the bare-Instanced-ref subobject pattern.
- **CkInventory** — add a `CK_ENSURE_IF_NOT` in `DoConstruct_Implementation` that names the duplicate-trait-class invariant directly. `Get_ItemTrait<T>` and `PostEditChangeProperty` already enforce one-trait-per-class; this gives runtime parity so a future regression fails loud with a diagnostic message instead of cascading into the `Cannot Connect RecordEntry` / `Fragment already exists` symptoms.

### Closes / supersedes

- Closes the underlying issue addressed by #646. PR #646 should be **closed without merge** — `dev` was never in a band-aid state, and the new ensure on this branch is strictly better than the silent skip the band-aid added.

## Test plan

- [x] All 5 `Inventory_DataOnly_*` AutoTests pass (the set that originally failed).
- [x] Verified across multiple AS recompile cycles via `OnPostReload` — duplication ensures stay absent.
- [x] `Inventory_TagsTrait_*` AutoTests still pass.
- [ ] `Inventory_StackableTrait_*` failures remain — pre-existing count-semantic bug, out of scope for this PR.
- [ ] Smoke check on AS class default `Instanced` bare-object subobject pattern (`default _Comp.Foo = ...;`) — should still survive hot-reload (the new helper skip-resets it).
- [ ] Headless CI: `<Editor>.exe BusterBlock.uproject -ExecCmds="Automation RunTests Project.Functional Tests; Quit" -unattended -nosplash -nullrhi`.