### PR TITLE
feat(entity-tag): counted Add/Remove + gameplay-tag hierarchy + presence-flip signals

### DIFF
--- a/Source/CkAnimation/Public/CkAnimation/AnimNotify/CkAnimNotifyState_EcsReady.cpp
+++ b/Source/CkAnimation/Public/CkAnimation/AnimNotify/CkAnimNotifyState_EcsReady.cpp
@@ -11,9 +11,8 @@ auto
         UAnimSequenceBase* InAnimation,
         const FAnimNotifyEventReference& InEventReference,
         FCk_Time InTotalDuration) const
-    -> bool
+    -> void
 {
-    return false;
 }
 
 auto
@@ -25,10 +24,8 @@ auto
         UAnimSequenceBase* InAnimation,
         const FAnimNotifyEventReference& InEventReference,
         FCk_Time InFrameDeltaT) const
-    -> bool
-
+    -> void
 {
-    return false;
 }
 
 auto
@@ -39,10 +36,8 @@ auto
         USkeletalMeshComponent* InMeshComp,
         UAnimSequenceBase* InAnimation,
         const FAnimNotifyEventReference& InEventReference) const
-    -> bool
-
+    -> void
 {
-    return false;
 }
 
 auto

--- a/Source/CkAnimation/Public/CkAnimation/AnimNotify/CkAnimNotifyState_EcsReady.h
+++ b/Source/CkAnimation/Public/CkAnimation/AnimNotify/CkAnimNotifyState_EcsReady.h
@@ -16,7 +16,7 @@ public:
     UFUNCTION(BlueprintNativeEvent,
         Category = "Ck|Animation",
         DisplayName="[Ck] Received Notify Begin (Override)")
-	bool
+	void
     Do_ReceivedNotifyBegin(
         AActor* InActorOwner,
         UPARAM(ref) FCk_Handle& InOwnerEntity,
@@ -28,7 +28,7 @@ public:
     UFUNCTION(BlueprintNativeEvent,
         Category = "Ck|Animation",
         DisplayName="[Ck] Received Notify Tick (Override)")
-	bool
+	void
     Do_ReceivedNotifyTick(
         AActor* InActorOwner,
         UPARAM(ref) FCk_Handle& InOwnerEntity,
@@ -40,7 +40,7 @@ public:
     UFUNCTION(BlueprintNativeEvent,
         Category = "Ck|Animation",
         DisplayName="[Ck] Received Notify End (Override)")
-	bool
+	void
     Do_ReceivedNotifyEnd(
         AActor* InActorOwner,
         UPARAM(ref) FCk_Handle& InOwnerEntity,

--- a/Source/CkEntityTag/Claude.md
+++ b/Source/CkEntityTag/Claude.md
@@ -10,10 +10,12 @@
 ## Key API
 
 - `UCk_Utils_EntityTag_UE::Add(InHandle, FName)` — add a named tag. `NAME_None` is rejected at the boundary (Display log, no-op) to prevent default-initialised names from polluting `ForEach_Entity(NAME_None)` queries.
-- `Add_UsingGameplayTag(InHandle, FGameplayTag)` — same as Add via `Tag.GetTagName()`; an empty `FGameplayTag` reduces to NAME_None and is rejected by the same boundary.
-- Standard Has, Remove, query operations.
+- `Add_UsingGameplayTag(InHandle, FGameplayTag)` — adds the gameplay tag plus its full parent chain as FName entries (e.g., `A.B.C` registers `A.B.C`, `A.B`, `A`), so `ForEach_Entity("A.B")` finds entities tagged with any `A.B.*` descendant.
+- `Has` / `Has_UsingGameplayTag`, `Get_AllTags`, `Get_AllTagsAsContainer` (explicit gameplay tags only — does not include parent-flattened ancestors).
+- `Request_TryRemove` / `Request_TryRemove_UsingGameplayTag` (rejects partial matches via `HasTagExact` guard).
+- `BindTo_OnTagUpdated` / `BindTo_OnGameplayTagUpdated` signals — fire on the 0↔1 presence flip only (not on intermediate count changes). The gameplay-tag binding supports a `RelevantTags` filter container.
 
-> **Single-slot per entity.** `Add` and `Add_UsingGameplayTag` share one storage slot. A second Add (either flavor) on an entity that already has an EntityTag will hit entt's per-fragment uniqueness assertion (surfaces as a CK_ENSURE). Either gate calls on `Has(...)` or design entities so the tag is set once at construction.
+> **Counted Add/Remove.** A tag added N times needs N removes to disappear. `Has` reports presence (count ≥ 1); signals fire only on the 0→1 (Added) and 1→0 (Removed) transitions. Parent FNames added via a gameplay-tag Add are reference-counted across all gameplay-tag children that share the ancestor, so removing one child does not strip parent FNames still held by siblings.
 
 ---
 

--- a/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Fragment.h
+++ b/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Fragment.h
@@ -18,9 +18,77 @@ namespace ck
 {
     // --------------------------------------------------------------------------------------------------------------------
 
-    using FFragment_EntityTag_Params = FCk_Fragment_EntityTag_ParamsData;
+    // Per-tag storage marker placed in the hashed EnTT storage view used by ForEach_Entity.
+    // The presence (or absence) of this storage entry mirrors whether the entity currently
+    // "Has" the tag — the count itself lives in FFragment_EntityTag_Current._Tags.
+    using FFragment_EntityTag_StorageParams = FCk_Fragment_EntityTag_ParamsData;
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    struct FEntityTagCount
+    {
+        FName _Name;
+        int32 _Count = 0;
+
+        FEntityTagCount() = default;
+        FEntityTagCount(FName InName, int32 InCount)
+            : _Name(InName)
+            , _Count(InCount)
+        {}
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    struct FEntityGameplayTagCount
+    {
+        FGameplayTag _Tag;
+        int32 _Count = 0;
+
+        FEntityGameplayTagCount() = default;
+        FEntityGameplayTagCount(FGameplayTag InTag, int32 InCount)
+            : _Tag(InTag)
+            , _Count(InCount)
+        {}
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    struct CKENTITYTAG_API FFragment_EntityTag_Current
+    {
+    public:
+        CK_GENERATED_BODY(FFragment_EntityTag_Current);
+
+        friend class ::UCk_Utils_EntityTag_UE;
+
+    private:
+        TArray<FEntityTagCount>          _Tags;
+        TArray<FEntityGameplayTagCount>  _GameplayTagCounts;
+
+    public:
+        CK_PROPERTY_GET(_Tags);
+        CK_PROPERTY_GET(_GameplayTagCounts);
+
+    public:
+        FFragment_EntityTag_Current() = default;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    CK_DEFINE_SIGNAL_AND_UTILS_WITH_DELEGATE(
+        CKENTITYTAG_API,
+        EntityTag_OnTagUpdated,
+        FCk_Delegate_EntityTag_OnTagUpdated,
+        FCk_Handle,
+        FName,
+        ECk_EntityTagUpdate);
+
+    CK_DEFINE_SIGNAL_AND_UTILS_WITH_DELEGATE(
+        CKENTITYTAG_API,
+        EntityTag_OnGameplayTagUpdated,
+        FCk_Delegate_EntityTag_OnGameplayTagUpdated,
+        FCk_Handle,
+        FGameplayTag,
+        ECk_EntityTagUpdate);
 
     // --------------------------------------------------------------------------------------------------------------------
 }
-
-// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Fragment_Data.h
+++ b/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Fragment_Data.h
@@ -11,10 +11,14 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
-// Not yet useful for this feature
-//USTRUCT(BlueprintType, meta=(HasNativeMake, HasNativeBreak))
-//struct CKENTITYTAG_API FCk_Handle_EntityTag : public FCk_Handle_TypeSafe { GENERATED_BODY() CK_GENERATED_BODY_HANDLE_TYPESAFE(FCk_Handle_EntityTag); };
-//CK_DEFINE_CUSTOM_ISVALID_AND_FORMATTER_HANDLE_TYPESAFE(FCk_Handle_EntityTag);
+UENUM(BlueprintType)
+enum class ECk_EntityTagUpdate : uint8
+{
+    Added,
+    Removed,
+};
+
+CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_EntityTagUpdate);
 
 //--------------------------------------------------------------------------------------------------------------------
 
@@ -36,5 +40,19 @@ public:
 
     CK_DEFINE_CONSTRUCTORS(FCk_Fragment_EntityTag_ParamsData, _Tag);
 };
+
+// --------------------------------------------------------------------------------------------------------------------
+
+DECLARE_DYNAMIC_DELEGATE_ThreeParams(
+    FCk_Delegate_EntityTag_OnTagUpdated,
+    FCk_Handle, InOwner,
+    FName, InTagName,
+    ECk_EntityTagUpdate, InUpdateType);
+
+DECLARE_DYNAMIC_DELEGATE_ThreeParams(
+    FCk_Delegate_EntityTag_OnGameplayTagUpdated,
+    FCk_Handle, InOwner,
+    FGameplayTag, InTag,
+    ECk_EntityTagUpdate, InUpdateType);
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Utils.cpp
+++ b/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Utils.cpp
@@ -3,6 +3,40 @@
 #include "CkEntityTag/CkEntityTag_Fragment.h"
 #include "CkEntityTag/CkEntityTag_Log.h"
 
+#include "CkCore/Algorithms/CkAlgorithms.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_EntityTag_UE::
+    Set_StoragePresence(
+        FCk_Handle& InHandle,
+        FName InTag,
+        bool InPresent)
+    -> void
+{
+    auto&& Storage = InHandle.Get_RegistryView().Storage<ck::FFragment_EntityTag_StorageParams>(
+        entt::id_type{GetTypeHash(InTag)});
+    const auto Entity = InHandle.Get_Entity().Get_ID();
+
+    if (InPresent)
+    {
+        if (NOT Storage.contains(Entity))
+        {
+            Storage.emplace<ck::FFragment_EntityTag_StorageParams>(
+                Entity,
+                ck::FFragment_EntityTag_StorageParams{InTag});
+        }
+    }
+    else
+    {
+        if (Storage.contains(Entity))
+        {
+            Storage.remove(Entity);
+        }
+    }
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 auto
@@ -23,11 +57,31 @@ auto
         return InHandle;
     }
 
-    auto Params = ck::FFragment_EntityTag_Params{InTag};
-    InHandle.Add<ck::FFragment_EntityTag_Params>(Params);
+    auto& Current = InHandle.AddOrGet<ck::FFragment_EntityTag_Current>();
 
-    auto&& Storage = InHandle.Get_RegistryView().Storage<ck::FFragment_EntityTag_Params>(entt::id_type{GetTypeHash(InTag)});
-    Storage.emplace<ck::FFragment_EntityTag_Params>(InHandle.Get_Entity().Get_ID(), std::move(Params));
+    const auto TagIndex = ck::algo::FindIndex(Current._Tags, [InTag](const ck::FEntityTagCount& InPair)
+    {
+        return InPair._Name == InTag;
+    });
+
+    const auto AddNew = TagIndex == INDEX_NONE;
+    if (AddNew)
+    {
+        Current._Tags.Emplace(InTag, 1);
+    }
+    else
+    {
+        Current._Tags[TagIndex]._Count++;
+    }
+
+    Set_StoragePresence(InHandle, InTag, true);
+
+    if (AddNew)
+    {
+        ck::UUtils_Signal_EntityTag_OnTagUpdated::Broadcast(
+            InHandle,
+            ck::MakePayload(InHandle, InTag, ECk_EntityTagUpdate::Added));
+    }
 
     return InHandle;
 }
@@ -39,57 +93,49 @@ auto
         FGameplayTag InTag)
     -> FCk_Handle
 {
-    const auto Name = InTag.GetTagName();
-    return Add(InHandle, Name);
+    CK_ENSURE_IF_NOT(ck::IsValid(InHandle),
+        TEXT("Unable to add EntityTag [{}] to Handle [{}] that is INVALID"), InTag, InHandle)
+    { return {}; }
+
+    if (NOT InTag.IsValid())
+    { return InHandle; }
+
+    auto& Current = InHandle.AddOrGet<ck::FFragment_EntityTag_Current>();
+
+    const auto GameplayTagIndex = ck::algo::FindIndex(Current._GameplayTagCounts,
+        [InTag](const ck::FEntityGameplayTagCount& InPair)
+    {
+        return InPair._Tag == InTag;
+    });
+
+    const auto AddNewGameplayTag = GameplayTagIndex == INDEX_NONE;
+    if (AddNewGameplayTag)
+    {
+        Current._GameplayTagCounts.Emplace(InTag, 1);
+    }
+    else
+    {
+        Current._GameplayTagCounts[GameplayTagIndex]._Count++;
+    }
+
+    // GetGameplayTagParents() returns self + every ancestor (A.B.C -> {A.B.C, A.B, A}).
+    // Adding each as an FName entry lets ForEach_Entity("A.B") find entities tagged "A.B.C".
+    for (const auto& TagInChain : InTag.GetGameplayTagParents())
+    {
+        Add(InHandle, TagInChain.GetTagName());
+    }
+
+    if (AddNewGameplayTag)
+    {
+        ck::UUtils_Signal_EntityTag_OnGameplayTagUpdated::Broadcast(
+            InHandle,
+            ck::MakePayload(InHandle, InTag, ECk_EntityTagUpdate::Added));
+    }
+
+    return InHandle;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
-
-auto
-    UCk_Utils_EntityTag_UE::
-    Request_TryRemove(
-        FCk_Handle& InHandle,
-        FName InTag)
-    -> ECk_SucceededFailed
-{
-    CK_ENSURE_IF_NOT(ck::IsValid(InHandle), TEXT("Invalid Handle passed. Unable to remove Tag [{}] from Entity"), InTag)
-    { return ECk_SucceededFailed::Failed; }
-
-    auto&& Storage = InHandle.Get_RegistryView().Storage<ck::FFragment_EntityTag_Params>(entt::id_type{GetTypeHash(InTag)});
-    InHandle.Try_Remove<ck::FFragment_EntityTag_Params>();
-
-    const auto Entity = InHandle.Get_Entity().Get_ID();
-
-    if(NOT Storage.contains(Entity))
-    { return ECk_SucceededFailed::Failed; }
-
-    Storage.remove(Entity);
-    return ECk_SucceededFailed::Succeeded;
-}
-
-auto
-    UCk_Utils_EntityTag_UE::
-    Request_TryRemove_UsingGameplayTag(
-        FCk_Handle& InHandle,
-        FGameplayTag InTag)
-    -> ECk_SucceededFailed
-{
-    return Request_TryRemove(InHandle, InTag.GetTagName());
-}
-
-auto
-    UCk_Utils_EntityTag_UE::
-    TryGet_Tag(
-        const FCk_Handle& InHandle)
-    -> FName
-{
-    if (InHandle.Has<ck::FFragment_EntityTag_Params>())
-    {
-        return *InHandle.Get<ck::FFragment_EntityTag_Params>().Get_Tag().ToString();
-    }
-
-    return {};
-}
 
 auto
     UCk_Utils_EntityTag_UE::
@@ -101,9 +147,15 @@ auto
     if (ck::Is_NOT_Valid(InHandle))
     { return false; }
 
-    auto Handle = InHandle;
-    auto& Storage = Handle.Get_RegistryView().Storage<ck::FFragment_EntityTag_Params>(entt::id_type{GetTypeHash(InTag)});
-    return Storage.contains(Handle.Get_Entity().Get_ID());
+    if (NOT InHandle.Has<ck::FFragment_EntityTag_Current>())
+    { return false; }
+
+    const auto& Current = InHandle.Get<ck::FFragment_EntityTag_Current>();
+
+    return ck::algo::AnyOf(Current._Tags, [InTag](const ck::FEntityTagCount& InPair)
+    {
+        return InPair._Name == InTag;
+    });
 }
 
 auto
@@ -118,28 +170,170 @@ auto
 
 auto
     UCk_Utils_EntityTag_UE::
-    ForEach_Entity_UsingGameplayTag(
-        const FCk_Handle& InAnyHandle,
-        FGameplayTag InTag)
-    -> TArray<FCk_Handle>
+    Get_AllTagsAsContainer(
+        const FCk_Handle& InHandle)
+    -> FGameplayTagContainer
 {
-    return ForEach_Entity(InAnyHandle, InTag.GetTagName());
+    CK_ENSURE_IF_NOT(ck::IsValid(InHandle),
+        TEXT("Unable to get entity tags on Handle [{}] that is INVALID"), InHandle)
+    { return {}; }
+
+    if (NOT InHandle.Has<ck::FFragment_EntityTag_Current>())
+    { return {}; }
+
+    const auto& Current = InHandle.Get<ck::FFragment_EntityTag_Current>();
+
+    auto Container = FGameplayTagContainer{};
+    for (const auto& GameplayTagCount : Current._GameplayTagCounts)
+    {
+        Container.AddTag(GameplayTagCount._Tag);
+    }
+    return Container;
 }
+
+auto
+    UCk_Utils_EntityTag_UE::
+    Get_AllTags(
+        const FCk_Handle& InHandle)
+    -> TArray<FName>
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InHandle),
+        TEXT("Unable to get entity tags on Handle [{}] that is INVALID"), InHandle)
+    { return {}; }
+
+    if (NOT InHandle.Has<ck::FFragment_EntityTag_Current>())
+    { return {}; }
+
+    const auto& Current = InHandle.Get<ck::FFragment_EntityTag_Current>();
+    return ck::algo::Transform<TArray<FName>>(Current._Tags, [](const ck::FEntityTagCount& InPair)
+    {
+        return InPair._Name;
+    });
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_EntityTag_UE::
+    Request_TryRemove(
+        FCk_Handle& InHandle,
+        FName InTag)
+    -> ECk_SucceededFailed
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InHandle), TEXT("Invalid Handle passed. Unable to remove Tag [{}] from Entity"), InTag)
+    { return ECk_SucceededFailed::Failed; }
+
+    if (NOT InHandle.Has<ck::FFragment_EntityTag_Current>())
+    { return ECk_SucceededFailed::Failed; }
+
+    auto& Current = InHandle.Get<ck::FFragment_EntityTag_Current>();
+
+    const auto TagIndex = ck::algo::FindIndex(Current._Tags, [InTag](const ck::FEntityTagCount& InPair)
+    {
+        return InPair._Name == InTag;
+    });
+
+    if (TagIndex == INDEX_NONE)
+    { return ECk_SucceededFailed::Failed; }
+
+    Current._Tags[TagIndex]._Count--;
+
+    const auto WasRemoved = Current._Tags[TagIndex]._Count <= 0;
+
+    if (WasRemoved)
+    {
+        Current._Tags.RemoveAtSwap(TagIndex);
+        Set_StoragePresence(InHandle, InTag, false);
+    }
+
+    const auto NowEmpty =
+        Current._Tags.IsEmpty() &&
+        Current._GameplayTagCounts.IsEmpty();
+
+    if (NowEmpty)
+    {
+        InHandle.Try_Remove<ck::FFragment_EntityTag_Current>();
+    }
+
+    if (WasRemoved)
+    {
+        ck::UUtils_Signal_EntityTag_OnTagUpdated::Broadcast(
+            InHandle,
+            ck::MakePayload(InHandle, InTag, ECk_EntityTagUpdate::Removed));
+    }
+
+    return ECk_SucceededFailed::Succeeded;
+}
+
+auto
+    UCk_Utils_EntityTag_UE::
+    Request_TryRemove_UsingGameplayTag(
+        FCk_Handle& InHandle,
+        FGameplayTag InTag)
+    -> ECk_SucceededFailed
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InHandle),
+        TEXT("Invalid Handle passed. Unable to remove Tag [{}] from Entity"), InTag)
+    { return ECk_SucceededFailed::Failed; }
+
+    if (NOT InHandle.Has<ck::FFragment_EntityTag_Current>())
+    { return ECk_SucceededFailed::Failed; }
+
+    auto& Current = InHandle.Get<ck::FFragment_EntityTag_Current>();
+
+    // Reject partial matches: removing `A.B` from an entity that only has `A.B.C` is not allowed.
+    // Only tags added explicitly via Add_UsingGameplayTag appear in _GameplayTagCounts (parents do
+    // not), so an absent entry is exactly the partial-match case we want to reject.
+    const auto GameplayTagIndex = ck::algo::FindIndex(Current._GameplayTagCounts,
+        [InTag](const ck::FEntityGameplayTagCount& InPair)
+    {
+        return InPair._Tag == InTag;
+    });
+
+    if (GameplayTagIndex == INDEX_NONE)
+    { return ECk_SucceededFailed::Failed; }
+
+    Current._GameplayTagCounts[GameplayTagIndex]._Count--;
+    const auto WasRemoved = Current._GameplayTagCounts[GameplayTagIndex]._Count <= 0;
+
+    if (WasRemoved)
+    {
+        Current._GameplayTagCounts.RemoveAtSwap(GameplayTagIndex);
+    }
+
+    // Mirror-remove the self + parent FName chain we added on Add_UsingGameplayTag.
+    for (const auto& TagInChain : InTag.GetGameplayTagParents())
+    {
+        const auto RemoveResult = Request_TryRemove(InHandle, TagInChain.GetTagName());
+        CK_ENSURE_IF_NOT(RemoveResult == ECk_SucceededFailed::Succeeded,
+            TEXT("Failed to remove FName mirror Tag [{}] (in chain for [{}]) on Entity [{}]. EntityTag state is corrupted."), TagInChain, InTag, InHandle)
+        { return ECk_SucceededFailed::Failed; }
+    }
+
+    if (WasRemoved)
+    {
+        ck::UUtils_Signal_EntityTag_OnGameplayTagUpdated::Broadcast(
+            InHandle,
+            ck::MakePayload(InHandle, InTag, ECk_EntityTagUpdate::Removed));
+    }
+
+    return ECk_SucceededFailed::Succeeded;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
 
 auto
     UCk_Utils_EntityTag_UE::
     ForEach_Entity(
         const FCk_Handle& InAnyHandle,
         FName InTag)
-        -> TArray<FCk_Handle>
+    -> TArray<FCk_Handle>
 {
     auto EntityTags = TArray<FCk_Handle>{};
-
     ForEach_Entity(InAnyHandle, InTag, [&](FCk_Handle InEntity)
     {
         EntityTags.Emplace(InEntity);
     });
-
     return EntityTags;
 }
 
@@ -155,17 +349,101 @@ auto
     { return; }
 
     auto Handle = InAnyHandle;
-    auto& Storage = Handle.Get_RegistryView().Storage<ck::FFragment_EntityTag_Params>(entt::id_type{GetTypeHash(InTag)});
+    auto& Storage = Handle.Get_RegistryView().Storage<ck::FFragment_EntityTag_StorageParams>(
+        entt::id_type{GetTypeHash(InTag)});
 
     const auto View = entt::basic_view{Storage};
-    View.each([&](const auto InEntity, const ck::FFragment_EntityTag_Params& InParams)
+    View.each([&](const auto InEntity, const ck::FFragment_EntityTag_StorageParams& /*InParams*/)
     {
         if (NOT InAnyHandle.Get_RegistryView().IsValid(InEntity))
         { return; }
 
-        auto Handle = InAnyHandle.Get_ValidHandle(InEntity);
-        InFunc(Handle);
+        auto HandleFromEntity = InAnyHandle.Get_ValidHandle(InEntity);
+        InFunc(HandleFromEntity);
     });
+}
+
+auto
+    UCk_Utils_EntityTag_UE::
+    ForEach_Entity_UsingGameplayTag(
+        const FCk_Handle& InAnyHandle,
+        FGameplayTag InTag)
+    -> TArray<FCk_Handle>
+{
+    return ForEach_Entity(InAnyHandle, InTag.GetTagName());
+}
+
+auto
+    UCk_Utils_EntityTag_UE::
+    ForEach_Entity_UsingGameplayTag(
+        const FCk_Handle& InAnyHandle,
+        FGameplayTag InTag,
+        const TFunction<void(FCk_Handle)>& InFunc)
+    -> void
+{
+    ForEach_Entity(InAnyHandle, InTag.GetTagName(), InFunc);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_EntityTag_UE::
+    BindTo_OnTagUpdated(
+        FCk_Handle& InHandle,
+        ECk_Signal_BindingPolicy InBindingPolicy,
+        ECk_Signal_PostFireBehavior InPostFireBehavior,
+        const FCk_Delegate_EntityTag_OnTagUpdated& InDelegate)
+    -> FCk_Handle
+{
+    CK_SIGNAL_BIND(ck::UUtils_Signal_EntityTag_OnTagUpdated, InHandle, InDelegate, InBindingPolicy, InPostFireBehavior);
+    return InHandle;
+}
+
+auto
+    UCk_Utils_EntityTag_UE::
+    UnbindFrom_OnTagUpdated(
+        FCk_Handle& InHandle,
+        const FCk_Delegate_EntityTag_OnTagUpdated& InDelegate)
+    -> FCk_Handle
+{
+    CK_SIGNAL_UNBIND(ck::UUtils_Signal_EntityTag_OnTagUpdated, InHandle, InDelegate);
+    return InHandle;
+}
+
+auto
+    UCk_Utils_EntityTag_UE::
+    BindTo_OnGameplayTagUpdated(
+        FCk_Handle& InHandle,
+        FGameplayTagContainer InRelevantTags,
+        ECk_Signal_BindingPolicy InBindingPolicy,
+        ECk_Signal_PostFireBehavior InPostFireBehavior,
+        const FCk_Delegate_EntityTag_OnGameplayTagUpdated& InDelegate)
+    -> FCk_Handle
+{
+    if (InRelevantTags.IsEmpty())
+    {
+        CK_SIGNAL_BIND(ck::UUtils_Signal_EntityTag_OnGameplayTagUpdated, InHandle, InDelegate, InBindingPolicy, InPostFireBehavior);
+    }
+    else
+    {
+        CK_SIGNAL_BIND_WITH_CONDITION(ck::UUtils_Signal_EntityTag_OnGameplayTagUpdated, InHandle, InDelegate, InBindingPolicy, InPostFireBehavior,
+            [InRelevantTags](FCk_Handle /*InOwner*/, FGameplayTag InTag, ECk_EntityTagUpdate /*InUpdateType*/)
+            {
+                return InRelevantTags.HasTag(InTag);
+            });
+    }
+    return InHandle;
+}
+
+auto
+    UCk_Utils_EntityTag_UE::
+    UnbindFrom_OnGameplayTagUpdated(
+        FCk_Handle& InHandle,
+        const FCk_Delegate_EntityTag_OnGameplayTagUpdated& InDelegate)
+    -> FCk_Handle
+{
+    CK_SIGNAL_UNBIND(ck::UUtils_Signal_EntityTag_OnGameplayTagUpdated, InHandle, InDelegate);
+    return InHandle;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Utils.h
+++ b/Source/CkEntityTag/Public/CkEntityTag/CkEntityTag_Utils.h
@@ -21,7 +21,7 @@ public:
 public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|EntityTag",
-              DisplayName="[Ck][EntityTag] Add Feature (Using FName)")
+              DisplayName="[Ck][EntityTag] Add Tag (Using FName)")
     static FCk_Handle
     Add(
         UPARAM(ref) FCk_Handle& InHandle,
@@ -29,20 +29,54 @@ public:
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|EntityTag",
-              DisplayName="[Ck][EntityTag] Add Feature (Using GameplayTag)")
+              DisplayName="[Ck][EntityTag] Add Tag (Using GameplayTag)")
     static FCk_Handle
     Add_UsingGameplayTag(
         UPARAM(ref) FCk_Handle& InHandle,
         UPARAM(meta = (Categories = "EntityTag")) FGameplayTag InTag);
 
 public:
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|EntityTag",
+              DisplayName="[Ck][EntityTag] Has Tag (Using FName)",
+              meta=(KeyWords = "has,tag"))
+    static bool
+    Has(
+        const FCk_Handle& InHandle,
+        FName InTag);
+
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|EntityTag",
+              DisplayName="[Ck][EntityTag] Has Tag (Using GameplayTag)",
+              meta=(KeyWords = "has,tag"))
+    static bool
+    Has_UsingGameplayTag(
+        const FCk_Handle& InHandle,
+        UPARAM(meta = (Categories = "EntityTag")) FGameplayTag InTag);
+
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|EntityTag",
-              DisplayName="[Ck][EntityTag] Request Remove")
+              DisplayName="[Ck][EntityTag] Get Tags as GameplayTagContainer")
+    static FGameplayTagContainer
+    Get_AllTagsAsContainer(
+        const FCk_Handle& InHandle);
+
+    UFUNCTION(BlueprintCallable,
+              Category = "Ck|Utils|EntityTag",
+              DisplayName="[Ck][EntityTag] Get All Tags (Debug Only)",
+              meta = (DevelopmentOnly))
+    static TArray<FName>
+    Get_AllTags(
+        const FCk_Handle& InHandle);
+
+public:
+    UFUNCTION(BlueprintCallable,
+              Category = "Ck|Utils|EntityTag",
+              DisplayName="[Ck][EntityTag] Request Remove (Using FName)")
     static ECk_SucceededFailed
     Request_TryRemove(
         UPARAM(ref) FCk_Handle& InHandle,
-        FName InTag);
+        UPARAM(meta = (Categories = "EntityTag")) FName InTag);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|EntityTag",
@@ -52,33 +86,21 @@ public:
         UPARAM(ref) FCk_Handle& InHandle,
         UPARAM(meta = (Categories = "EntityTag")) FGameplayTag InTag);
 
-    UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|EntityTag",
-              DisplayName="[Ck][EntityTag] Try Get Tag")
-    static FName
-    TryGet_Tag(
-        const FCk_Handle& InHandle);
-
 public:
-    UFUNCTION(BlueprintPure,
+    UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|EntityTag",
-              DisplayName="[Ck][EntityTag] Has",
-              meta=(KeyWords = "has,tag"))
-    static bool
-    Has(
-        const FCk_Handle& InHandle,
-        FName InTag);
+              DisplayName="[Ck][EntityTag] For Each (Using FName)",
+              meta=(KeyWords = "get,all,tags"))
+    static TArray<FCk_Handle>
+    ForEach_Entity(
+        const FCk_Handle& InAnyHandle,
+        UPARAM(meta = (Categories = "EntityTag")) FName InTag);
+    static auto
+    ForEach_Entity(
+        const FCk_Handle& InAnyHandle,
+        UPARAM(meta = (Categories = "EntityTag")) FName InTag,
+        const TFunction<void(FCk_Handle)>& InFunc) -> void;
 
-    UFUNCTION(BlueprintPure,
-              Category = "Ck|Utils|EntityTag",
-              DisplayName="[Ck][EntityTag] Has (Using GameplayTag)",
-              meta=(KeyWords = "has,tag"))
-    static bool
-    Has_UsingGameplayTag(
-        const FCk_Handle& InHandle,
-        UPARAM(meta = (Categories = "EntityTag")) FGameplayTag InTag);
-
-public:
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|EntityTag",
               DisplayName="[Ck][EntityTag] For Each (Using GameplayTag)",
@@ -87,20 +109,58 @@ public:
     ForEach_Entity_UsingGameplayTag(
         const FCk_Handle& InAnyHandle,
         UPARAM(meta = (Categories = "EntityTag")) FGameplayTag InTag);
+    static auto
+    ForEach_Entity_UsingGameplayTag(
+        const FCk_Handle& InAnyHandle,
+        UPARAM(meta = (Categories = "EntityTag")) FGameplayTag InTag,
+        const TFunction<void(FCk_Handle)>& InFunc) -> void;
+
+public:
+    UFUNCTION(BlueprintCallable,
+              Category = "Ck|Utils|EntityTag",
+              DisplayName = "[Ck][EntityTag] Bind To OnTagUpdated")
+    static FCk_Handle
+    BindTo_OnTagUpdated(
+        UPARAM(ref) FCk_Handle& InHandle,
+        ECk_Signal_BindingPolicy InBindingPolicy,
+        ECk_Signal_PostFireBehavior InPostFireBehavior,
+        const FCk_Delegate_EntityTag_OnTagUpdated& InDelegate);
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|EntityTag",
-              DisplayName="[Ck][EntityTag] For Each",
-              meta=(KeyWords = "get,all,tags"))
-    static TArray<FCk_Handle>
-    ForEach_Entity(
-        const FCk_Handle& InAnyHandle,
-        FName InTag);
+              DisplayName = "[Ck][EntityTag] Unbind From OnTagUpdated")
+    static FCk_Handle
+    UnbindFrom_OnTagUpdated(
+        UPARAM(ref) FCk_Handle& InHandle,
+        const FCk_Delegate_EntityTag_OnTagUpdated& InDelegate);
+
+    UFUNCTION(BlueprintCallable,
+              Category = "Ck|Utils|EntityTag",
+              DisplayName = "[Ck][EntityTag] Bind To OnGameplayTagUpdated")
+    static FCk_Handle
+    BindTo_OnGameplayTagUpdated(
+        UPARAM(ref) FCk_Handle& InHandle,
+        FGameplayTagContainer InRelevantTags,
+        ECk_Signal_BindingPolicy InBindingPolicy,
+        ECk_Signal_PostFireBehavior InPostFireBehavior,
+        const FCk_Delegate_EntityTag_OnGameplayTagUpdated& InDelegate);
+
+    UFUNCTION(BlueprintCallable,
+              Category = "Ck|Utils|EntityTag",
+              DisplayName = "[Ck][EntityTag] Unbind From OnGameplayTagUpdated")
+    static FCk_Handle
+    UnbindFrom_OnGameplayTagUpdated(
+        UPARAM(ref) FCk_Handle& InHandle,
+        const FCk_Delegate_EntityTag_OnGameplayTagUpdated& InDelegate);
+
+private:
+    // Set/clear the per-tag EnTT storage marker used by ForEach_Entity. Lives in this
+    // class so its friend access to FCk_Registry::Storage<T> resolves.
     static auto
-    ForEach_Entity(
-        const FCk_Handle& InAnyHandle,
+    Set_StoragePresence(
+        FCk_Handle& InHandle,
         FName InTag,
-        const TFunction<void(FCk_Handle)>& InFunc) -> void;
+        bool InPresent) -> void;
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Re-implementation of the original intent of [#629](https://github.com/chainkemists/CkFoundation/pull/629) (Sep 2025, never merged), layered on top of current `dev`. Brings counted Add/Remove, gameplay-tag parent flattening, and presence-flip signals to `CkEntityTag`. Bundles a small `CkAnimation` cleanup that was part of the original PR.

## Behavior changes

- **Counted Add/Remove.** Adding the same tag N times requires N Removes to drop presence. `Has` reports presence (count >= 1); the EnTT storage marker mirrors `Has`. Signals fire only on the 0↔1 transitions.
- **Gameplay-tag parent flatten.** `Add_UsingGameplayTag(A.B.C)` registers `A.B.C`, `A.B`, `A` as FName entries — `ForEach_Entity("A.B")` finds entities tagged with any `A.B.*` descendant. Parents are reference-counted across siblings.
- **`Request_TryRemove_UsingGameplayTag` rejects partial matches.** Removing `A.B` from an entity that only has `A.B.C` explicitly returns `Failed`.
- **New signals.** `OnTagUpdated` (FName) and `OnGameplayTagUpdated` (FGameplayTag) with payload `(Handle, Tag, ECk_EntityTagUpdate{Added|Removed})`. `BindTo_OnGameplayTagUpdated` accepts a `RelevantTags` filter container.
- **New queries.** `Get_AllTagsAsContainer` (explicit gameplay tags only, built on demand), `Get_AllTags` (`DevelopmentOnly` FName list).
- **`TryGet_Tag` removed** — never made sense for multi-tag entities.

## Implementation notes

- `FFragment_EntityTag_Current` holds `TArray<FEntityTagCount>` + `TArray<FEntityGameplayTagCount>`. Fragment self-removes when both arrays empty.
- Per-tag EnTT storage type renamed `FFragment_EntityTag_Params` → `FFragment_EntityTag_StorageParams` to clarify its role (storage marker, not the count source).
- **No new module dependencies.** Counts live in local arrays rather than `FGameplayTagCountContainer`, so `GameplayAbilities` is not pulled in.
- `Add(NAME_None)` rejection from [84806a1](https://github.com/chainkemists/CkFoundation/commit/84806a1ce6) preserved (with its Display log).

## Companion PR

Tests live in CkTests: **\[CkTests link to be added once that PR is up].** All 16 EntityTag AutoTests (6 pre-existing + 10 new) pass.

## CkAnimation cleanup

`Do_ReceivedNotifyBegin / Tick / End` on `UCk_AnimNotifyState_EcsReady_UE` were declared as `BlueprintNativeEvent` returning `bool`, but the return value was never read by any caller. Changed to `void`. No behavior change.

## Test plan

- [x] BusterBlockEditor builds clean (`Result: Succeeded`, full target build verified).
- [x] AS hot-reload clean — `utils_entity_tag.as` regen with 14 exposed functions, no AS compile errors.
- [x] All 16 `CkAutoTest_EntityTag_*` pass (verified across two full test runs, including post-cleanup verification).
- [x] No regressions in unrelated test families (CkAggro, CkRelationship, etc.) — those pre-existing failures on `dev` were upstream-fixed before this branch was based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)