### PR TITLE
fix(ecseditor): gate scheduler tick during PIE

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsEditor_Subsystem.cpp
+++ b/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsEditor_Subsystem.cpp
@@ -18,6 +18,10 @@
 
 #include <Engine/World.h>
 
+#if WITH_EDITOR
+#include <Editor.h>
+#endif
+
 // --------------------------------------------------------------------------------------------------------------------
 
 auto
@@ -118,6 +122,22 @@ auto
     -> void
 {
     Super::Tick(DeltaTime);
+
+#if WITH_EDITOR
+    // Skip scheduler work while PIE is active. Editor-world entities are authoring-time only
+    // (FTag_EditorOnlyEntity) and dynamic-fragment iteration here can dereference handles whose
+    // registry was destroyed by a previous PIE teardown — converted to a hard crash inside EnTT.
+    // The redraw request below is still serviced so editor viewports refresh normally.
+    if (ck::IsValid(GEditor, ck::IsValid_Policy_NullptrOnly{}) && ck::IsValid(GEditor->PlayWorld))
+    {
+        if (_PendingRedraw)
+        {
+            UCk_Utils_EditorOnly_UE::Request_RedrawLevelEditingViewports();
+            _PendingRedraw = false;
+        }
+        return;
+    }
+#endif
 
     const auto DeltaT = FCk_Time{DeltaTime};
 


### PR DESCRIPTION
## Summary

Early-out from `UCk_EditorEcsWorld_Subsystem_UE::Tick` while PIE is active. The editor ECS subsystem was ticking its schedulers every frame even during PIE, which:

- **Crashed** when dynamic-fragment iteration dereferenced handles whose registry had been destroyed by an earlier PIE teardown (EnTT `sparse_set` deref hard crash).
- **Burned ~20-70 ms/frame** in `PostTickComponentUpdate → Recreate` on the game thread, scaling linearly with the number of EntitySpawner-based actors placed in the level. Each editor-preview entity's components were getting render-state-dirty-marked every tick by transform/scene-node/render processors that had no real work to do.

Pending viewport redraws are still serviced before the early-return so the level editor still refreshes if anything else dirties it.

## Why F11 "fixed" it before

Immersive PIE hides the level editor viewport, which causes Unreal to stop ticking the editor world entirely. That happened to mask both the crash and the slowdown without addressing either. This PR is the direct, narrow equivalent — pause the editor subsystem's scheduler tick during PIE regardless of viewport visibility.

## Repro / measurement

`stat game` in PIE on a populated gym (Store_Gym_BB_MAP) shows the `Post Tick Component Update` / `Recreate` line collapsing from ~70 ms/frame to ~0 ms after the patch. TestGyms_BB_MAP was unaffected before the fix because it spawns entities at runtime rather than through editor-time EntitySpawner placement — so it never created editor-preview entities for the schedulers to act on.

### Before (windowed PIE, Store_Gym_BB_MAP, `stat game`)

https://github.com/user-attachments/assets/d467c135-ab91-45aa-a0c8-ca54cebd53a8

### After (same scene, same commands)

https://github.com/user-attachments/assets/68817863-c843-4c43-9235-aa559f9ce32b

## Test plan

- [ ] Open Store_Gym_BB_MAP, PIE windowed, run `stat game`, verify `Post Tick Component Update` is near zero
- [ ] Compare F11 immersive vs windowed PIE — game-thread cost should match
- [ ] Stop PIE, drag an EntitySpawner around in the editor viewport, verify the preview entity still updates its transform (PostEditMove path is unaffected)
- [ ] Verify level editor viewport still refreshes when an EntitySpawner is added/removed in pure-editor (non-PIE) sessions (`_PendingRedraw` is still serviced)
- [ ] No regression on the EnTT crash this commit originally targeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)