### PR TITLE
feat(CkEcs): GC-anchor replicated subobjects on EcsWorld subsystem

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -11,6 +11,7 @@
 #include "CkEcs/Net/CkNet_Fragment.h"
 #include "CkEcs/Subsystem/CkEcsEditor_Subsystem.h"
 #include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
+#include "CkEcs/Tag/CkTag_EditorOnly.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Fragment_Params.cpp
+++ b/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Fragment_Params.cpp
@@ -2,6 +2,7 @@
 
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Fragment.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
+#include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
 
 #include <Engine/World.h>
 
@@ -42,6 +43,16 @@ auto
 
     InTopmostOwningActor->AddReplicatedSubObject(Obj);
 
+    // GC anchor — neither the actor's FSubObjectRegistry (weak in PIE/editor builds via
+    // UE_NET_SUBOBJECTLIST_WEAKPTR) nor FCk_ReplicatedObjects (TWeakObjectPtr) roots the
+    // object. Without anchoring on a UPROPERTY-walked root, GC collects on the first
+    // pass and BeginDestroy cascades through Request_DestroyEntity into actor teardown.
+    if (auto* World = InTopmostOwningActor->GetWorld())
+    {
+        if (auto* EcsWorld = World->GetSubsystem<UCk_EcsWorld_Subsystem_UE>())
+        { EcsWorld->Anchor_ReplicatedObject(Obj); }
+    }
+
     return Obj;
 }
 
@@ -64,6 +75,13 @@ auto
     { return; }
 
     InRo->_ReplicatedActor->RemoveReplicatedSubObject(InRo);
+
+    // Drop the GC anchor so the object becomes weakly-held; the next GC pass reclaims it.
+    if (auto* World = InRo->_ReplicatedActor->GetWorld())
+    {
+        if (auto* EcsWorld = World->GetSubsystem<UCk_EcsWorld_Subsystem_UE>())
+        { EcsWorld->Unanchor_ReplicatedObject(InRo); }
+    }
 }
 
 auto

--- a/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsWorld_Subsystem.cpp
+++ b/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsWorld_Subsystem.cpp
@@ -170,6 +170,30 @@ auto
 
 auto
     UCk_EcsWorld_Subsystem_UE::
+    Anchor_ReplicatedObject(
+        UCk_ReplicatedObject_UE* InObj)
+    -> void
+{
+    if (ck::Is_NOT_Valid(InObj, ck::IsValid_Policy_NullptrOnly{}))
+    { return; }
+
+    _AnchoredReplicatedObjects.AddUnique(InObj);
+}
+
+auto
+    UCk_EcsWorld_Subsystem_UE::
+    Unanchor_ReplicatedObject(
+        UCk_ReplicatedObject_UE* InObj)
+    -> void
+{
+    if (ck::Is_NOT_Valid(InObj, ck::IsValid_Policy_NullptrOnly{}))
+    { return; }
+
+    _AnchoredReplicatedObjects.RemoveSingleSwap(InObj, EAllowShrinking::No);
+}
+
+auto
+    UCk_EcsWorld_Subsystem_UE::
     OnEndFrame_DoRebuild()
     -> void
 {

--- a/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsWorld_Subsystem.h
+++ b/Source/CkEcs/Public/CkEcs/Subsystem/CkEcsWorld_Subsystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CkCore/Macros/CkMacros.h"
+#include "CkCore/ObjectReplication/CkReplicatedObject.h"
 #include "CkCore/Subsystems/GameWorldSubsytem/CkGameWorldSubsystem.h"
 
 #include "CkEcs/Registry/CkRegistry.h"
@@ -120,6 +121,19 @@ public:
     auto
     Request_RebuildProcessorGraph() -> void;
 
+    // GC anchor for replicated subobjects created via UCk_Ecs_ReplicatedObject_UE::Create.
+    // Neither AActor's FSubObjectRegistry (TWeakObjectPtr in PIE/editor builds, see
+    // UE_NET_SUBOBJECTLIST_WEAKPTR) nor FCk_ReplicatedObjects (TWeakObjectPtr by design)
+    // roots these objects. Without a UPROPERTY-walked anchor, GC collects them on the
+    // first pass and their BeginDestroy cascades through Request_DestroyEntity into the
+    // OwningActor_Destroy processor, destroying the parent actor.
+    auto
+    Anchor_ReplicatedObject(
+        UCk_ReplicatedObject_UE* InObj) -> void;
+    auto
+    Unanchor_ReplicatedObject(
+        UCk_ReplicatedObject_UE* InObj) -> void;
+
 private:
     auto DoBuildGraphAndSpawnActors(
         UWorld& InWorld) -> void;
@@ -134,6 +148,10 @@ private:
 private:
     UPROPERTY(BlueprintReadOnly, Transient, meta = (AllowPrivateAccess = true))
     FCk_Handle _TransientEntity;
+
+    // See Anchor_ReplicatedObject above for the why.
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<UCk_ReplicatedObject_UE>> _AnchoredReplicatedObjects;
 
 private:
     TMap<TEnumAsByte<ETickingGroup>, TStrongObjectPtr<ACk_EcsWorld_Actor_UE>> _WorldActors;


### PR DESCRIPTION
## Summary

`UCk_Ecs_ReplicatedObject_UE` instances had no UPROPERTY root keeping them alive:

- `AActor::FSubObjectRegistry` stores subobjects as `FWeakObjectPtr` in PIE/editor builds (`UE_NET_SUBOBJECTLIST_WEAKPTR=1`) — by design, expecting game code to anchor.
- `FCk_ReplicatedObjects` holds them via `TWeakObjectPtr` — by design weak.
- The `NewObject` outer is just metadata; it doesn't keep the subobject reachable.

In PIE the editor's incidental anchors hid the bug. Under `-game -nullrhi -unattended` (e.g. Gauntlet smoke runs), those anchors don't exist, so GC collects the objects on the first sweep and `BeginDestroy` cascades `Request_DestroyEntity` through `OwningActor_Destroy` — destroying the parent actor (the `PlayerController` in our repro, ~1.2s after possession).

## Fix

- Add a `UPROPERTY() TArray<TObjectPtr<UCk_ReplicatedObject_UE>>` anchor on `UCk_EcsWorld_Subsystem_UE` (a real `UObject` whose UPROPERTY GC actually traces).
- Wire `UCk_Ecs_ReplicatedObject_UE::Create` to register and `Destroy` to unregister.
- `Destroy()` unanchors; GC reclaims on the next pass.
- Drive-by: add a defensive `CkTag_EditorOnly.h` include in `CkEntityLifetime_Utils.cpp` that was previously transitive via the unity-build composition — the new `CkEcsWorld_Subsystem.h` include from `CkReplicatedObjects_Fragment_Params.cpp` shifts the unity group and exposed a latent compile error there.

## Test plan

Verified via BusterBlock's `PlayerMovesOnInput` Gauntlet test in `-game -nullrhi -unattended`:

- [x] Without fix: `OnPlayerLogout` fires ~1.2s after possession; test fails with delta=0cm (PC destroyed mid-test by the cascade).
- [x] With fix: no `OnPlayerLogout` cascade; pawn moves >150cm in 1s; test exits 0.
- [x] `PlayerImcBoundAtBoot` (the simpler existing test) still passes — no regression on `OnAsInit`-only flows.