### PR TITLE
fix(CkEcs): root replicated-driver objects via TStrongObjectPtr in their fragment

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Processor.cpp
@@ -110,7 +110,7 @@ namespace ck
         if (InHandle.Has<FTag_Replicated>())
         {
             ck::algo::ForEachIsValid(UCk_Utils_ReplicatedObjects_UE::Get_ReplicatedObjects(InHandle).Get_ReplicatedObjects(),
-                [&](const TWeakObjectPtr<UCk_ReplicatedObject_UE>& InRO)
+                [&](const TStrongObjectPtr<UCk_ReplicatedObject_UE>& InRO)
                 {
                     const auto EcsRO = Cast<UCk_Ecs_ReplicatedObject_UE>(InRO.Get());
 

--- a/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityLifetime/CkEntityLifetime_Utils.cpp
@@ -11,6 +11,7 @@
 #include "CkEcs/Net/CkNet_Fragment.h"
 #include "CkEcs/Subsystem/CkEcsEditor_Subsystem.h"
 #include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
+#include "CkEcs/Tag/CkTag_EditorOnly.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Fragment_Params.cpp
+++ b/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Fragment_Params.cpp
@@ -126,9 +126,9 @@ auto
     DoRequest_LinkAssociatedEntity(FCk_Handle InEntity)
     -> void
 {
-    for (const auto RO : _ReplicatedObjects)
+    for (const auto& RO : _ReplicatedObjects)
     {
-        const auto EcsReplicatedObject = Cast<UCk_Ecs_ReplicatedObject_UE>(RO);
+        const auto EcsReplicatedObject = Cast<UCk_Ecs_ReplicatedObject_UE>(RO.Get());
 
         CK_ENSURE_IF_NOT(ck::IsValid(EcsReplicatedObject), TEXT("ReplicatedObject is not valid. Unable to Link with Entity [{}]"),
             InEntity)
@@ -137,6 +137,38 @@ auto
         EcsReplicatedObject->_AssociatedEntity = InEntity;
         EcsReplicatedObject->OnLink();
     }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_ReplicatedObjects::
+    ToWeak(
+        const TArray<TStrongObjectPtr<UCk_ReplicatedObject_UE>>& InStrong)
+    -> TArray<TWeakObjectPtr<UCk_ReplicatedObject_UE>>
+{
+    auto Weak = TArray<TWeakObjectPtr<UCk_ReplicatedObject_UE>>{};
+    Weak.Reserve(InStrong.Num());
+    for (const auto& Strong : InStrong)
+    {
+        Weak.Emplace(Strong.Get());
+    }
+    return Weak;
+}
+
+auto
+    FCk_ReplicatedObjects::
+    ToStrong(
+        const TArray<TWeakObjectPtr<UCk_ReplicatedObject_UE>>& InWeak)
+    -> TArray<TStrongObjectPtr<UCk_ReplicatedObject_UE>>
+{
+    auto Strong = TArray<TStrongObjectPtr<UCk_ReplicatedObject_UE>>{};
+    Strong.Reserve(InWeak.Num());
+    for (const auto& Weak : InWeak)
+    {
+        Strong.Emplace(Weak.Get());
+    }
+    return Strong;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Fragment_Params.h
+++ b/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Fragment_Params.h
@@ -7,6 +7,8 @@
 
 #include "CkCore/Macros/CkMacros.h"
 
+#include <UObject/StrongObjectPtr.h>
+
 #include "CkReplicatedObjects_Fragment_Params.generated.h"
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -124,14 +126,30 @@ public:
     // TODO: clean up the struct
 
 private:
-    UPROPERTY()
-    TArray<TWeakObjectPtr<UCk_ReplicatedObject_UE>> _ReplicatedObjects;
+    // STRONG ownership: this fragment is the GC anchor for its replicated objects, mirroring how
+    // FFragment_EntityScript_Current owns its UCk_EntityScript_UE via TStrongObjectPtr. The actor's
+    // FSubObjectRegistry holds them weakly (UE_NET_SUBOBJECTLIST_WEAKPTR) and the entity-fragment
+    // back-ref is GC-untraced, so without this strong ref GC reclaims the object whenever there is no
+    // active netdriver+channels (standalone / -nullrhi), cascading Request_DestroyEntity into actor
+    // teardown. Not a UPROPERTY because TStrongObjectPtr is not UHT-reflectable; the wire format
+    // (FCk_EntityReplicationDriver_ReplicateObjects_Data::_Objects) stays weak and we convert at the
+    // boundary via ToWeak/ToStrong.
+    TArray<TStrongObjectPtr<UCk_ReplicatedObject_UE>> _ReplicatedObjects;
 
 protected:
     auto DoRequest_LinkAssociatedEntity(FCk_Handle InEntity) -> void;
 
 public:
     CK_PROPERTY(_ReplicatedObjects);
+
+    // Convert between the fragment's strong storage and the weak wire format used by replication.
+    static auto
+    ToWeak(
+        const TArray<TStrongObjectPtr<UCk_ReplicatedObject_UE>>& InStrong) -> TArray<TWeakObjectPtr<UCk_ReplicatedObject_UE>>;
+
+    static auto
+    ToStrong(
+        const TArray<TWeakObjectPtr<UCk_ReplicatedObject_UE>>& InWeak) -> TArray<TStrongObjectPtr<UCk_ReplicatedObject_UE>>;
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Utils.cpp
@@ -53,9 +53,9 @@ auto
     InHandle.AddOrGet<ck::FFragment_ReplicatedObjects_Params>()
     .Update_ReplicatedObjects([&](FCk_ReplicatedObjects& InReplicatedObjects)
     {
-        InReplicatedObjects.Update_ReplicatedObjects([&](TArray<TWeakObjectPtr<UCk_ReplicatedObject_UE>>& InArray)
+        InReplicatedObjects.Update_ReplicatedObjects([&](TArray<TStrongObjectPtr<UCk_ReplicatedObject_UE>>& InArray)
         {
-            InArray.Add(InReplicatedObject);
+            InArray.AddUnique(TStrongObjectPtr<UCk_ReplicatedObject_UE>{InReplicatedObject});
         });
     });
 }
@@ -71,9 +71,9 @@ auto
 
     auto RoleToReturn = ENetRole::ROLE_None;
 
-    OnFirstValidReplicatedObject(InHandle, ECk_PendingKill_Policy::IncludePendingKill, [&](const TWeakObjectPtr<UCk_ReplicatedObject_UE>& InRO)
+    OnFirstValidReplicatedObject(InHandle, ECk_PendingKill_Policy::IncludePendingKill, [&](const TStrongObjectPtr<UCk_ReplicatedObject_UE>& InRO)
     {
-        const auto& ReplicatedObjectAsActor = Cast<AActor>(InRO.Get(true)->GetOuter());
+        const auto& ReplicatedObjectAsActor = Cast<AActor>(InRO.Get()->GetOuter());
 
         CK_ENSURE_IF_NOT(ck::IsValid(ReplicatedObjectAsActor, ck::IsValid_Policy_NullptrOnly{}),
             TEXT("Outer of Replicated Object [{}] for Entity [{}] is NOT an Actor when expected it to be"), InRO, InHandle)
@@ -90,7 +90,7 @@ auto
     OnFirstValidReplicatedObject(
         const FCk_Handle& InHandle,
         ECk_PendingKill_Policy InPendingKillPolicy,
-        const std::function<void(const TWeakObjectPtr<UCk_ReplicatedObject_UE>& InRO)>& InFunc)
+        const std::function<void(const TStrongObjectPtr<UCk_ReplicatedObject_UE>& InRO)>& InFunc)
     -> void
 {
     if (NOT Ensure(InHandle))
@@ -98,12 +98,14 @@ auto
 
     const auto ReplicatedObjects = Get_ReplicatedObjects(InHandle).Get_ReplicatedObjects();
 
-    const auto& ReplicatedObjectToUse = ReplicatedObjects.FindByPredicate([&](const TWeakObjectPtr<UCk_ReplicatedObject_UE>& InRO) -> bool
+    const auto& ReplicatedObjectToUse = ReplicatedObjects.FindByPredicate([&](const TStrongObjectPtr<UCk_ReplicatedObject_UE>& InRO) -> bool
     {
         switch (InPendingKillPolicy)
         {
+            // TStrongObjectPtr has no IncludePendingKill validity policy; it keeps the object reachable, so the
+            // only failure mode is the pointee being pending-kill. Route that policy through the raw pointer.
             case ECk_PendingKill_Policy::ExcludePendingKill: return ck::IsValid(InRO);
-            case ECk_PendingKill_Policy::IncludePendingKill: return ck::IsValid(InRO, ck::IsValid_Policy_IncludePendingKill{});
+            case ECk_PendingKill_Policy::IncludePendingKill: return ck::IsValid(InRO.Get(), ck::IsValid_Policy_IncludePendingKill{});
             default: return {};
         }
     });

--- a/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Utils.h
+++ b/Source/CkEcs/Public/CkEcs/Fragments/ReplicatedObjects/CkReplicatedObjects_Utils.h
@@ -47,7 +47,7 @@ public:
     OnFirstValidReplicatedObject(
         const FCk_Handle& InHandle,
         ECk_PendingKill_Policy InPendingKillPolicy,
-        const std::function<void(const TWeakObjectPtr<UCk_ReplicatedObject_UE>& InRO)>& InFunc) -> void;
+        const std::function<void(const TStrongObjectPtr<UCk_ReplicatedObject_UE>& InRO)>& InFunc) -> void;
 
 public:
     static auto

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle.cpp
@@ -780,7 +780,7 @@ namespace UE::Net
         {
             // TODO: This is a temporary fix. We need to find a better way to handle the fact that sometimes the Handle does NOT have a replicated object
             UCk_Utils_ReplicatedObjects_UE::OnFirstValidReplicatedObject(Source, ECk_PendingKill_Policy::IncludePendingKill,
-            [&](const TWeakObjectPtr<UCk_ReplicatedObject_UE>& InRO)
+            [&](const TStrongObjectPtr<UCk_ReplicatedObject_UE>& InRO)
             {
                 auto EcsRO = Cast<UCk_Ecs_ReplicatedObject_UE>(InRO.Get());
                 if (ck::IsValid(EcsRO) && ck::IsValid(EcsRO->Get_AssociatedEntity()))

--- a/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
+++ b/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
@@ -177,7 +177,7 @@ auto
     }
 
     UCk_Utils_ReplicatedObjects_UE::Add(_AssociatedEntity, FCk_ReplicatedObjects{}.
-        Set_ReplicatedObjects(_ReplicationData.Get_ReplicatedObjectsData().Get_Objects()));
+        Set_ReplicatedObjects(FCk_ReplicatedObjects::ToStrong(_ReplicationData.Get_ReplicatedObjectsData().Get_Objects())));
 
     // --------------------------------------------------------------------------------------------------------------------
 
@@ -235,7 +235,7 @@ auto
         { return; }
 
         UCk_Utils_ReplicatedObjects_UE::Add(ThisAsWeakPtr->_AssociatedEntity, FCk_ReplicatedObjects{}.
-            Set_ReplicatedObjects(ThisAsWeakPtr->_ReplicationData_EntityScript.Get_ReplicatedObjectsData().Get_Objects()));
+            Set_ReplicatedObjects(FCk_ReplicatedObjects::ToStrong(ThisAsWeakPtr->_ReplicationData_EntityScript.Get_ReplicatedObjectsData().Get_Objects())));
 
         // --------------------------------------------------------------------------------------------------------------------
         // Make sure to call this on "self" since the # of dependent rep driver include "self" as well
@@ -316,7 +316,7 @@ auto
     _AssociatedEntity.Add<FCk_EntityReplicationDriver_AbilityData>(_ReplicationData_Ability);
 
     UCk_Utils_ReplicatedObjects_UE::Add(_AssociatedEntity, FCk_ReplicatedObjects{}.
-        Set_ReplicatedObjects(_ReplicationData_Ability.Get_ReplicatedObjectsData().Get_Objects()));
+        Set_ReplicatedObjects(FCk_ReplicatedObjects::ToStrong(_ReplicationData_Ability.Get_ReplicatedObjectsData().Get_Objects())));
 
     // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
@@ -168,7 +168,7 @@ auto
                 FCk_EntityReplicationDriver_ReplicationData
                 {
                     InConstructionInfos,
-                    FCk_EntityReplicationDriver_ReplicateObjects_Data{ReplicatedObjects.Get_ReplicatedObjects()}
+                    FCk_EntityReplicationDriver_ReplicateObjects_Data{FCk_ReplicatedObjects::ToWeak(ReplicatedObjects.Get_ReplicatedObjects())}
                 }
                 .Set_OwningEntityDriver(InHandle.Get<TObjectPtr<UCk_Fragment_EntityReplicationDriver_Rep>>())
                 .Set_IsOwningEntityDriverDependentOnThis(IsOwningEntityDriverDependentOnThis)
@@ -241,7 +241,7 @@ auto
                     InEntityScript,
                     InSpawnParams,
                     InReplicatedOwner.Get<TObjectPtr<UCk_Fragment_EntityReplicationDriver_Rep>>(),
-                    FCk_EntityReplicationDriver_ReplicateObjects_Data{ReplicatedObjects.Get_ReplicatedObjects()}
+                    FCk_EntityReplicationDriver_ReplicateObjects_Data{FCk_ReplicatedObjects::ToWeak(ReplicatedObjects.Get_ReplicatedObjects())}
                 }
                 .Set_IsOwningEntityDriverDependentOnThis(IsOwningEntityDriverDependentOnThis)
             );


### PR DESCRIPTION
## Summary

The per-entity replication-driver object (`UCk_Fragment_EntityReplicationDriver_Rep : UCk_Ecs_ReplicatedObject_UE`) had **no strong GC root**. Every reference to it was weak or GC-untraced:

- `FCk_ReplicatedObjects::_ReplicatedObjects` → `TArray<TWeakObjectPtr<…>>` (weak)
- the `OnLink` entity-fragment back-ref → `TObjectPtr` inside an EnTT USTRUCT (UE GC does **not** trace UPROPERTY refs inside ECS fragments)
- the actor's `ReplicatedSubObjects` → `FSubObjectRegistry` of `FWeakObjectPtr` (weak; and not visited by `AActor::AddReferencedObjects`, which only collects `OwnedComponents`)

In a **live netdriver session** the object is incidentally kept alive by the `UNetConnection → UActorChannel → FObjectReplicator::ObjectPtr` chain. But with **no active netdriver + channels** — standalone PIE, `-game -nullrhi -unattended` (Gauntlet) — nothing roots it. GC reclaims it on the first sweep, and `UCk_Ecs_ReplicatedObject_UE::BeginDestroy` cascades `Request_DestroyEntity` → `FProcessor_OwningActor_Destroy`, destroying the owning actor (in the repro, the PlayerController, ~1.2s after possession).

## Fix

Give the replicated-driver object the **same ownership the entity script already has** (`TStrongObjectPtr<UCk_EntityScript_UE> _Script`): make `_ReplicatedObjects` a `TArray<TStrongObjectPtr<…>>` so the fragment owns its objects and releases them only when the entity is destroyed and the fragment is dropped.

Constraint handled: `_ReplicatedObjects` doubles as the replication marshaling source/sink, and `TStrongObjectPtr` cannot be a `UPROPERTY`. So the wire struct (`FCk_EntityReplicationDriver_ReplicateObjects_Data::_Objects`) stays `TWeakObjectPtr`, and we convert at the boundary via new `FCk_ReplicatedObjects::ToWeak` / `ToStrong` helpers (2 server-build sites → `ToWeak`, 3 client-set sites → `ToStrong`).

No reference cycle: the fragment is ECS data (not a UObject) and `_AssociatedEntity` is a lightweight handle. `BeginDestroy`'s cascade is unchanged and now fires only on genuine teardown (a no-op, since the entity is already destroying).

Also adds an explicit `CkTag_EditorOnly.h` include in `CkEntityLifetime_Utils.cpp`: the sibling `Processor.cpp` edit shifts the unity-build group and re-exposes a latent transitive-include dependency on `ck::FTag_EditorOnlyEntity`.

## Why this supersedes #653

#653 anchored the objects on `UCk_EcsWorld_Subsystem_UE` via a `UPROPERTY` array. After the review discussion there about how UE actually roots replicated subobjects (the `FSubObjectRegistry` is weak; the real anchor is the netdriver/channel chain), this approach is cleaner: it mirrors the existing, proven entity-script ownership model and co-locates the lifetime with the entity instead of a global subsystem list. The root-cause analysis and mechanism discussion live in #653.

## Test plan

- [x] Headless `-game -nullrhi -unattended`: BusterBlock `PlayerMovesOnInput` Gauntlet test — pawn translates >50cm (delta≈143cm), exit 0, **no** `OnPlayerLogout` mid-test (the GC repro that previously failed).
- [x] `PlayerImcBoundAtBoot` — still exit 0 (no regression on `OnAsInit`-only flows).
- [x] Real-world PIE, both **listen server** and **singleplayer/standalone**, with `gc.CollectGarbageEveryFrame 1`: replicated entities/actors are no longer destroyed; gameplay stable.
- [x] Multiplayer: client-side replicated entities still spawn/replicate/clean up when the server destroys them (`PreDestroyFromReplication` → `Request_DestroyEntity` → fragment dropped → strong ref released → GC reclaims).