### PR TITLE
Foundation hardening pass: validity guards, lifetime leaks, dedup, conventions

### DIFF
--- a/Source/CkActorRelay/Public/CkActorRelay/CkActorRelay_GroupSubsystem.cpp
+++ b/Source/CkActorRelay/Public/CkActorRelay/CkActorRelay_GroupSubsystem.cpp
@@ -686,6 +686,17 @@ auto
         }
     }
 
+    // The loop above can only remove entries via a still-valid PC — a PC destroyed
+    // before this point leaves its PlayerState entry behind forever (the subsystem
+    // outlives worlds). Prune any entry whose PlayerState is dead or foreign.
+    for (auto It = _PlayerChannels.CreateIterator(); It; ++It)
+    {
+        const auto PlayerState = It.Key().Get();
+
+        if (ck::Is_NOT_Valid(PlayerState) || PlayerState->GetWorld() != InWorld)
+        { It.RemoveCurrent(); }
+    }
+
     _ServerChannels = ck::algo::Filter(_ServerChannels, [&](const ACk_ActorRelay_UE* InChannel)
     {
         return ck::IsValid(InChannel) && InChannel->GetWorld() == InWorld;

--- a/Source/CkAggro/Public/CkAggro/CkAggroOwner_Processor.cpp
+++ b/Source/CkAggro/Public/CkAggro/CkAggroOwner_Processor.cpp
@@ -69,10 +69,22 @@ namespace ck
         -> void
     {
         // assuming that the record is already sorted
-        // assuming that the incoming handle has an Actor (TODO: remove this assumption)
+        // TODO: support actor-less AggroOwners (line-of-sight needs a UWorld which we currently reach via the Actor)
 
         const auto OwningActorEntity = UCk_Utils_OwningActor_UE::TryGet_Entity_OwningActor_InOwnershipChain(InHandle);
+
+        CK_ENSURE_IF_NOT(ck::IsValid(OwningActorEntity),
+            TEXT("AggroOwner [{}] has no OwningActor in its ownership chain — cannot line-of-sight score its Aggros"),
+            InHandle)
+        { return; }
+
         const auto Actor = UCk_Utils_OwningActor_UE::Get_EntityOwningActor(OwningActorEntity);
+
+        CK_ENSURE_IF_NOT(ck::IsValid(Actor),
+            TEXT("AggroOwner [{}] OwningActor entity [{}] does NOT have a valid Actor — cannot line-of-sight score its Aggros"),
+            InHandle, OwningActorEntity)
+        { return; }
+
         const auto OwnerLocation = UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentLocation(InHandle);
 
         ck::FUtils_RecordOfAggros::ForEach_ValidEntry(InHandle, [&](FCk_Handle_Aggro InAggro)
@@ -91,8 +103,7 @@ namespace ck
             CollisionParams.AddIgnoredActor(OtherActor);
 
             auto Response = FCollisionResponseParams{};
-            auto HitResult = FHitResult{}; // TODO: for debugging only, to remove
-            auto Hit = Actor->GetWorld()->LineTraceSingleByChannel(HitResult, OwnerLocation, TargetLocation, ECC_Visibility, CollisionParams, Response);
+            const auto Hit = Actor->GetWorld()->LineTraceTestByChannel(OwnerLocation, TargetLocation, ECC_Visibility, CollisionParams, Response);
 
             if (Hit)
             { return ECk_Record_ForEachIterationResult::Continue; }

--- a/Source/CkAnimation/Public/CkAnimation/CkAnimation_Utils.h
+++ b/Source/CkAnimation/Public/CkAnimation/CkAnimation_Utils.h
@@ -42,8 +42,8 @@ public:
     FCk_Animation_MontageSection_LengthInfo(
         FCk_Time&& _StartTime,
         FCk_Time&& _EndTime)
-        : _StartTime(std::move(_StartTime))
-        , _EndTime(std::move(_EndTime))
+        : _StartTime(MoveTemp(_StartTime))
+        , _EndTime(MoveTemp(_EndTime))
         , _Length(this->_EndTime - this->_StartTime)
     {};
 };
@@ -81,8 +81,8 @@ public:
     FCk_Animation_MontageNotify_TimeInfo(
         FCk_Time&& _StartTime,
         FCk_Time&& _EndTime)
-        : _StartTime(std::move(_StartTime))
-        , _EndTime(std::move(_EndTime))
+        : _StartTime(MoveTemp(_StartTime))
+        , _EndTime(MoveTemp(_EndTime))
         , _Length(this->_EndTime - this->_StartTime)
     {};
 };

--- a/Source/CkCore/Public/CkCore/Math/Vector/CkVector_Utils.cpp
+++ b/Source/CkCore/Public/CkCore/Math/Vector/CkVector_Utils.cpp
@@ -308,9 +308,7 @@ auto
         ECk_Plane_Axis InAxis)
     -> FVector
 {
-    auto V = Get_Flattened(InVector, InAxis);
-    V.Normalize();
-    return V;
+    return Get_Flattened(InVector, InAxis).GetSafeNormal();
 }
 
 auto

--- a/Source/CkCue/Public/CkCue/CkCueExecutor_Subsystem.cpp
+++ b/Source/CkCue/Public/CkCue/CkCueExecutor_Subsystem.cpp
@@ -239,6 +239,11 @@ auto
             [OwnerEntity = InOwnerEntity, CueName = InCueName, SpawnParams = InSpawnParams, IsReliable, InMulticastPolicy]
             (ACk_CueRelay_UE* CueRelay)
             {
+                // The relay can come up well after the cue was queued — the owner
+                // may have been destroyed in the interim. Don't ship a dead handle.
+                if (ck::Is_NOT_Valid(OwnerEntity))
+                { return; }
+
                 switch (InMulticastPolicy)
                 {
                     case ECk_Cue_MulticastPolicy::ServerOnly:
@@ -291,6 +296,11 @@ auto
             {
                 auto CueRelay = Cast<ACk_CueRelay_UE>(InResult.Get_ChannelActor().Get());
                 if (ck::Is_NOT_Valid(CueRelay))
+                { return; }
+
+                // Same as the client path — the owner may have been destroyed while
+                // waiting for a channel. Don't multicast a dead handle.
+                if (ck::Is_NOT_Valid(OwnerEntity))
                 { return; }
 
                 auto OriginatingPlayerState = static_cast<APlayerState*>(nullptr);

--- a/Source/CkDynamic/Public/CkDynamic/CkDynamic_Utils.cpp
+++ b/Source/CkDynamic/Public/CkDynamic/CkDynamic_Utils.cpp
@@ -17,44 +17,41 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace
+static auto PassesDestroyFilter(const FCk_Handle& InHandle, ECk_DestroyFilter InFilter) -> bool
 {
-    auto PassesDestroyFilter(const FCk_Handle& InHandle, ECk_DestroyFilter InFilter) -> bool
+    switch (InFilter)
     {
-        switch (InFilter)
+        case ECk_DestroyFilter::None:
         {
-            case ECk_DestroyFilter::None:
-            {
-                return true;
-            }
-            case ECk_DestroyFilter::IgnorePendingKill:
-            {
-                return NOT (UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::BeginDestroy) ||
-                            UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::Teardown) ||
-                            UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::Destroyed));
-            }
-            case ECk_DestroyFilter::Teardown:
-            {
-                return UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::Teardown);
-            }
-            default:
-            {
-                CK_INVALID_ENUM(InFilter);
-                return false;
-            }
+            return true;
+        }
+        case ECk_DestroyFilter::IgnorePendingKill:
+        {
+            return NOT (UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::BeginDestroy) ||
+                        UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::Teardown) ||
+                        UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::Destroyed));
+        }
+        case ECk_DestroyFilter::Teardown:
+        {
+            return UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InHandle, ECk_EntityLifetime_DestructionPhase::Teardown);
+        }
+        default:
+        {
+            CK_INVALID_ENUM(InFilter);
+            return false;
         }
     }
+}
 
-    auto Get_InvalidSentinel_FragmentData(const UScriptStruct* InStructType) -> FInstancedStruct&
+static auto Get_InvalidSentinel_FragmentData(const UScriptStruct* InStructType) -> FInstancedStruct&
+{
+    static TMap<const UScriptStruct*, FInstancedStruct> Sentinels;
+    auto& Instance = Sentinels.FindOrAdd(InStructType);
+    if (NOT Instance.IsValid() || Instance.GetScriptStruct() != InStructType)
     {
-        static TMap<const UScriptStruct*, FInstancedStruct> Sentinels;
-        auto& Instance = Sentinels.FindOrAdd(InStructType);
-        if (NOT Instance.IsValid() || Instance.GetScriptStruct() != InStructType)
-        {
-            Instance.InitializeAs(InStructType);
-        }
-        return Instance;
+        Instance.InitializeAs(InStructType);
     }
+    return Instance;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -85,11 +82,13 @@ auto
         InFragmentData.GetScriptStruct(), InHandle)
     { return InHandle; }
 
-    Storage.emplace(Entity, std::move(Fragment));
+    Storage.emplace(Entity, MoveTemp(Fragment));
 
+    // The default-storage fragment is only a presence marker (Has<>/removal) —
+    // the real data lives in the named storage. Keep it default-constructed.
     if (NOT InHandle.Has<ck::FFragment_DynamicFragment_Data>())
     {
-        InHandle.Add<ck::FFragment_DynamicFragment_Data>(Fragment);
+        InHandle.Add<ck::FFragment_DynamicFragment_Data>(ck::FFragment_DynamicFragment_Data{});
     }
 
     if (InReplication == ECk_Replication::Replicates)

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Marker/CkMarker_Processor.cpp
@@ -321,7 +321,6 @@ namespace ck
             const FFragment_Marker_Params&  InParamsComp) const
         -> void
     {
-        // TODO: Extract this in a common function to avoid code duplication between similar system for Sensor
         const auto& MarkerAttachedEntityAndActor = InCurrentComp.Get_AttachedEntityAndActor();
         const auto& MarkerAttachedActor          = MarkerAttachedEntityAndActor.Get_Actor();
 
@@ -334,38 +333,8 @@ namespace ck
         CK_ENSURE_IF_NOT(ck::IsValid(Marker), TEXT("Invalid Marker Actor Component stored for Marker Entity [{}]"), InMarkerEntity)
         { return; }
 
-        const auto& BoneTransform = [&]() -> TOptional<FTransform>
-        {
-            const auto& Params           = InParamsComp.Get_Params();
-            const auto& AttachmentParams = Params.Get_AttachmentParams();
-            const auto& BoneName         = AttachmentParams.Get_BoneName();
-
-            CK_ENSURE_IF_NOT(UCk_Utils_Actor_UE::Get_DoesBoneExistInSkeletalMesh(MarkerAttachedActor.Get(), BoneName),
-                TEXT("Marker Entity [{}] cannot update its Transform according to Bone [{}] because its Attached Actor [{}] does NOT have it in its Skeletal Mesh"),
-                InMarkerEntity,
-                BoneName,
-                MarkerAttachedEntityAndActor)
-            { return {}; }
-
-            const auto& AttachedActorSkeletalMeshComponent = MarkerAttachedActor->FindComponentByClass<USkeletalMeshComponent>();
-            const auto& SocketBoneName                     = AttachedActorSkeletalMeshComponent->GetSocketBoneName(BoneName);
-            const auto& BoneIndex                          = AttachedActorSkeletalMeshComponent->GetBoneIndex(SocketBoneName);
-            const auto& AttachedActorTransform             = MarkerAttachedActor->GetTransform();
-            const auto& AttachmentPolicy                   = AttachmentParams.Get_AttachmentPolicy();
-            auto SkeletonTransform                         = AttachedActorSkeletalMeshComponent->GetBoneTransform(BoneIndex);
-
-            if (NOT EnumHasAnyFlags(AttachmentPolicy, ECk_Marker_AttachmentPolicy::UseBoneRotation))
-            {
-                SkeletonTransform.CopyRotation(AttachedActorTransform);
-            }
-
-            if (NOT EnumHasAnyFlags(AttachmentPolicy, ECk_Marker_AttachmentPolicy::UseBonePosition))
-            {
-                SkeletonTransform.CopyTranslation(AttachedActorTransform);
-            }
-
-            return SkeletonTransform;
-        }();
+        const auto& BoneTransform = UCk_Utils_MarkerAndSensor_UE::Get_MarkerOrSensor_BoneFollowTransform(
+            InMarkerEntity, MarkerAttachedEntityAndActor, InParamsComp.Get_Params().Get_AttachmentParams());
 
         if (ck::Is_NOT_Valid(BoneTransform))
         { return; }

--- a/Source/CkOverlapBody/Public/CkOverlapBody/MarkerAndSensor/CkMarkerAndSensor_Utils.h
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/MarkerAndSensor/CkMarkerAndSensor_Utils.h
@@ -17,6 +17,7 @@
 #include "CkPhysics/CkPhysics_Common.h"
 #include "CkPhysics/CkPhysics_Utils.h"
 
+#include <Components/SkeletalMeshComponent.h>
 #include <CoreMinimal.h>
 
 #include "CkMarkerAndSensor_Utils.generated.h"
@@ -74,6 +75,16 @@ public:
         T_MarkerOrSensorCompType* InMarkerOrSensorComp,
         T_MarkerOrSensorPhysicsParams InMarkerOrSensorPhysicsParams,
         ECk_EnableDisable InEnableGenerateOverlapEvents) -> void;
+
+    // Shared by the Marker and Sensor UpdateTransform processors — computes the
+    // bone-following world transform per the attachment params' policy flags.
+    // Returns an unset optional if the bone does not exist on the attached actor.
+    template <typename T_HandleType, typename T_AttachmentParams>
+    static auto
+    Get_MarkerOrSensor_BoneFollowTransform(
+        const T_HandleType& InMarkerOrSensorEntity,
+        const FCk_EntityOwningActor_BasicDetails& InAttachedEntityAndActor,
+        const T_AttachmentParams& InAttachmentParams) -> TOptional<FTransform>;
 
 private:
     template <typename T_MarkerOrSensorCurrent, typename T_MarkerOrSensorParams>
@@ -616,6 +627,47 @@ auto
     UCk_Utils_Physics_UE::Request_SetOverlapBehavior(InMarkerOrSensorComp, OverlapBehavior);
     UCk_Utils_Physics_UE::Request_SetGenerateOverlapEvents(InMarkerOrSensorComp, InEnableGenerateOverlapEvents);
     UCk_Utils_Physics_UE::Request_SetCollisionEnabled(InMarkerOrSensorComp, CollisionEnabled);
+}
+
+template <typename T_HandleType, typename T_AttachmentParams>
+auto
+    UCk_Utils_MarkerAndSensor_UE::
+    Get_MarkerOrSensor_BoneFollowTransform(
+        const T_HandleType& InMarkerOrSensorEntity,
+        const FCk_EntityOwningActor_BasicDetails& InAttachedEntityAndActor,
+        const T_AttachmentParams& InAttachmentParams)
+    -> TOptional<FTransform>
+{
+    const auto& AttachedActor = InAttachedEntityAndActor.Get_Actor();
+    const auto& BoneName      = InAttachmentParams.Get_BoneName();
+
+    CK_ENSURE_IF_NOT(UCk_Utils_Actor_UE::Get_DoesBoneExistInSkeletalMesh(AttachedActor.Get(), BoneName),
+        TEXT("Marker/Sensor Entity [{}] cannot update its Transform according to Bone [{}] because its Attached Actor [{}] does NOT have it in its Skeletal Mesh"),
+        InMarkerOrSensorEntity,
+        BoneName,
+        InAttachedEntityAndActor)
+    { return {}; }
+
+    using AttachmentPolicyType = std::decay_t<decltype(InAttachmentParams.Get_AttachmentPolicy())>;
+
+    const auto& AttachedActorSkeletalMeshComponent = AttachedActor->FindComponentByClass<USkeletalMeshComponent>();
+    const auto& SocketBoneName                     = AttachedActorSkeletalMeshComponent->GetSocketBoneName(BoneName);
+    const auto& BoneIndex                          = AttachedActorSkeletalMeshComponent->GetBoneIndex(SocketBoneName);
+    const auto& AttachedActorTransform             = AttachedActor->GetTransform();
+    const auto& AttachmentPolicy                   = InAttachmentParams.Get_AttachmentPolicy();
+    auto SkeletonTransform                         = AttachedActorSkeletalMeshComponent->GetBoneTransform(BoneIndex);
+
+    if (NOT EnumHasAnyFlags(AttachmentPolicy, AttachmentPolicyType::UseBoneRotation))
+    {
+        SkeletonTransform.CopyRotation(AttachedActorTransform);
+    }
+
+    if (NOT EnumHasAnyFlags(AttachmentPolicy, AttachmentPolicyType::UseBonePosition))
+    {
+        SkeletonTransform.CopyTranslation(AttachedActorTransform);
+    }
+
+    return SkeletonTransform;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
+++ b/Source/CkOverlapBody/Public/CkOverlapBody/Sensor/CkSensor_Processor.cpp
@@ -24,6 +24,39 @@ CK_REGISTER_PROCESSOR(ck::FProcessor_Sensor_EndPlay);
 
 namespace ck
 {
+    // Shared by EnableDisable request handling and Teardown — fires an
+    // EndOverlap signal for every Marker overlap the Sensor currently tracks.
+    template <typename T_SensorHandle>
+    static auto
+    DoManuallyTriggerAllEndOverlaps(
+        const T_SensorHandle& InSensorEntity,
+        const FFragment_Sensor_Current& InCurrentComp,
+        const FCk_Sensor_BasicDetails& InSensorBasicDetails) -> void
+    {
+        for (const auto& OverlapKvp : InCurrentComp.Get_CurrentMarkerOverlaps().Get_Overlaps())
+        {
+            const auto& MarkerDetails = OverlapKvp.Key;
+            const auto& OverlapDetails = OverlapKvp.Value.Get_OverlapDetails();
+
+            const auto& OnEndOverlapPayload = FCk_Sensor_Payload_OnEndOverlap
+            {
+                InSensorBasicDetails,
+                MarkerDetails,
+                FCk_Sensor_EndOverlap_UnrealDetails
+                {
+                    OverlapDetails.Get_OverlappedComponent().Get(),
+                    OverlapDetails.Get_OtherActor().Get(),
+                    OverlapDetails.Get_OtherComp().Get()
+                }
+            };
+
+            UUtils_Signal_OnSensorEndOverlap::Broadcast(InSensorEntity, MakePayload(
+                InCurrentComp.Get_AttachedEntityAndActor().Get_Handle(), OnEndOverlapPayload));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     auto
         FProcessor_Sensor_Setup::
         DoTick(
@@ -192,31 +225,6 @@ namespace ck
             InCurrentComp.Get_AttachedEntityAndActor()
         };
 
-        // TODO: this is repeated in this file, consolidate
-        const auto& DoManuallyTriggerAllEndOverlaps = [&]() -> void
-        {
-            for (const auto& OverlapKvp : InCurrentComp.Get_CurrentMarkerOverlaps().Get_Overlaps())
-            {
-                const auto& MarkerDetails = OverlapKvp.Key;
-                const auto& OverlapDetails = OverlapKvp.Value.Get_OverlapDetails();
-
-                const auto& OnEndOverlapPayload = FCk_Sensor_Payload_OnEndOverlap
-                {
-                    SensorBasicDetails,
-                    MarkerDetails,
-                    FCk_Sensor_EndOverlap_UnrealDetails
-                    {
-                        OverlapDetails.Get_OverlappedComponent().Get(),
-                        OverlapDetails.Get_OtherActor().Get(),
-                        OverlapDetails.Get_OtherComp().Get()
-                    }
-                };
-
-                UUtils_Signal_OnSensorEndOverlap::Broadcast(InSensorEntity, MakePayload(
-                    InCurrentComp.Get_AttachedEntityAndActor().Get_Handle(), OnEndOverlapPayload));
-            }
-        };
-
         const auto& CurrentEnableDisable = InCurrentComp.Get_EnableDisable();
         const auto& NewEnableDisable     = InRequest.Get_EnableDisable();
 
@@ -234,7 +242,7 @@ namespace ck
 
         if (NewEnableDisable == ECk_EnableDisable::Disable)
         {
-            DoManuallyTriggerAllEndOverlaps();
+            DoManuallyTriggerAllEndOverlaps(InSensorEntity, InCurrentComp, SensorBasicDetails);
             InCurrentComp._CurrentMarkerOverlaps = {};
         }
 
@@ -530,7 +538,6 @@ namespace ck
             const FFragment_Sensor_Params&  InParamsComp)
             -> void
     {
-        // TODO: Extract this in a common function to avoid code duplication between similar system for Marker
         const auto& SensorAttachedEntityAndActor = InCurrentComp.Get_AttachedEntityAndActor();
         const auto& SensorAttachedActor          = SensorAttachedEntityAndActor.Get_Actor();
 
@@ -543,38 +550,8 @@ namespace ck
         CK_ENSURE_IF_NOT(ck::IsValid(Sensor), TEXT("Invalid Sensor Actor Component stored for Sensor Entity [{}]"), InSensorEntity)
         { return; }
 
-        const auto& BoneTransform = [&]() -> TOptional<FTransform>
-        {
-            const auto& Params           = InParamsComp.Get_Params();
-            const auto& AttachmentParams = Params.Get_AttachmentParams();
-            const auto& BoneName         = AttachmentParams.Get_BoneName();
-
-            CK_ENSURE_IF_NOT(UCk_Utils_Actor_UE::Get_DoesBoneExistInSkeletalMesh(SensorAttachedActor.Get(), BoneName),
-                TEXT("Sensor Entity [{}] cannot update its Transform according to Bone [{}] because its Attached Actor [{}] does NOT have it in its Skeletal Mesh"),
-                InSensorEntity,
-                BoneName,
-                SensorAttachedEntityAndActor)
-            { return {}; }
-
-            const auto& AttachedActorSkeletalMeshComponent = SensorAttachedActor->FindComponentByClass<USkeletalMeshComponent>();
-            const auto& AttachedActorTransform             = SensorAttachedActor->GetTransform();
-            const auto& AttachmentPolicy                   = AttachmentParams.Get_AttachmentPolicy();
-            const auto& SocketBoneName                     = AttachedActorSkeletalMeshComponent->GetSocketBoneName(BoneName);
-            const auto& BoneIndex                          = AttachedActorSkeletalMeshComponent->GetBoneIndex(SocketBoneName);
-            auto SkeletonTransform                         = AttachedActorSkeletalMeshComponent->GetBoneTransform(BoneIndex);
-
-            if (NOT EnumHasAnyFlags(AttachmentPolicy, ECk_Sensor_AttachmentPolicy::UseBoneRotation))
-            {
-                SkeletonTransform.CopyRotation(AttachedActorTransform);
-            }
-
-            if (NOT EnumHasAnyFlags(AttachmentPolicy, ECk_Sensor_AttachmentPolicy::UseBonePosition))
-            {
-                SkeletonTransform.CopyTranslation(AttachedActorTransform);
-            }
-
-            return SkeletonTransform;
-        }();
+        const auto& BoneTransform = UCk_Utils_MarkerAndSensor_UE::Get_MarkerOrSensor_BoneFollowTransform(
+            InSensorEntity, SensorAttachedEntityAndActor, InParamsComp.Get_Params().Get_AttachmentParams());
 
         if (ck::Is_NOT_Valid(BoneTransform))
         { return; }
@@ -622,30 +599,7 @@ namespace ck
             InCurrentComp.Get_AttachedEntityAndActor()
         };
 
-        const auto& DoManuallyTriggerAllEndOverlaps = [&]() -> void
-        {
-            for (const auto& OverlapKvp : InCurrentComp.Get_CurrentMarkerOverlaps().Get_Overlaps())
-            {
-                const auto& MarkerDetails = OverlapKvp.Key;
-                const auto& OverlapDetails = OverlapKvp.Value.Get_OverlapDetails();
-
-                const auto& OnEndOverlapPayload = FCk_Sensor_Payload_OnEndOverlap
-                {
-                    SensorBasicDetails,
-                    MarkerDetails,
-                    FCk_Sensor_EndOverlap_UnrealDetails
-                    {
-                        OverlapDetails.Get_OverlappedComponent().Get(),
-                        OverlapDetails.Get_OtherActor().Get(),
-                        OverlapDetails.Get_OtherComp().Get()
-                    }
-                };
-
-                UUtils_Signal_OnSensorEndOverlap::Broadcast(InSensorEntity, MakePayload(
-                    InCurrentComp.Get_AttachedEntityAndActor().Get_Handle(), OnEndOverlapPayload));
-            }
-        };
-        DoManuallyTriggerAllEndOverlaps();
+        DoManuallyTriggerAllEndOverlaps(InSensorEntity, InCurrentComp, SensorBasicDetails);
     }
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkRelationship/Public/CkRelationship/Player/CkPlayer_Utils.cpp
+++ b/Source/CkRelationship/Public/CkRelationship/Player/CkPlayer_Utils.cpp
@@ -60,14 +60,14 @@ auto
         ECk_Replication InReplicates)
     -> FCk_Handle_Player
 {
-    const auto OldID = Get_ID(Cast(InHandle));
+    auto PlayerHandle = Cast(InHandle);
+    const auto OldID = ck::IsValid(PlayerHandle) ? Get_ID(PlayerHandle) : ECk_Player_ID::Unassigned;
 
     if (OldID == InPlayerID)
-    { return Cast(InHandle); } // TODO: performing the cast twice (on in Get_ID above), can we fix this?
+    { return PlayerHandle; }
 
-    if (Has(InHandle))
+    if (ck::IsValid(PlayerHandle))
     {
-        auto PlayerHandle = Cast(InHandle);
         DoRemoveExistingPlayer(PlayerHandle);
     }
 

--- a/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Utils.cpp
+++ b/Source/CkRelationship/Public/CkRelationship/Team/CkTeam_Utils.cpp
@@ -65,14 +65,14 @@ auto
         ECk_Team_ID InTeamID)
     -> FCk_Handle_Team
 {
-    const auto OldID = Has(InHandle) ? Get_ID(Cast(InHandle)) : ECk_Team_ID::Unassigned;
+    auto TeamHandle = Cast(InHandle);
+    const auto OldID = ck::IsValid(TeamHandle) ? Get_ID(TeamHandle) : ECk_Team_ID::Unassigned;
 
     if (OldID == InTeamID)
-    { return Cast(InHandle); } // TODO: performing the cast twice (on in Get_ID above), can we fix this?
+    { return TeamHandle; }
 
-    if (Has(InHandle))
+    if (ck::IsValid(TeamHandle))
     {
-        auto TeamHandle = Cast(InHandle);
         DoRemoveExistingTeam(TeamHandle);
     }
 

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Processor.cpp
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Processor.cpp
@@ -212,6 +212,13 @@ namespace ck
 
         const auto& FoundPendingObject = AllPendingObjects[FoundPendingObjectIndex];
         const auto& StreamingHandle    = FoundPendingObject.Get_StreamableHandle();
+
+        CK_ENSURE_IF_NOT(ck::IsValid(StreamingHandle),
+            TEXT("Streamable Handle for Streamed Object [{}] is INVALID — the async load likely completed "
+                 "synchronously before the handle was stored on the pending entry."),
+            InObjectStreamed)
+        { return; }
+
         const auto& LoadedAsset        = StreamingHandle->GetLoadedAsset();
         const auto ObjectToLoadHardRef = FCk_ResourceLoader_ObjectReference_Hard{LoadedAsset};
         const auto LoadedObject        = FCk_ResourceLoader_LoadedObject{InObjectStreamed, ObjectToLoadHardRef}.Set_StreamableHandle(StreamingHandle);
@@ -236,6 +243,11 @@ namespace ck
 
         const auto& FoundPendingObjectBatch = AllPendingObjectBatches[FoundPendingObjectBatchIndex];
         const auto& StreamingHandle         = FoundPendingObjectBatch.Get_StreamableHandle();
+
+        CK_ENSURE_IF_NOT(ck::IsValid(StreamingHandle),
+            TEXT("Streamable Handle for Streamed Object Batch is INVALID — the async load likely completed "
+                 "synchronously before the handle was stored on the pending entry."))
+        { return; }
 
         auto LoadedAssets = TArray<UObject*>{};
         StreamingHandle->GetLoadedAssets(LoadedAssets);

--- a/Source/CkSpatialQuery/Public/CkSpatialQuery/Probe/CkProbeTrace_Processor.cpp
+++ b/Source/CkSpatialQuery/Public/CkSpatialQuery/Probe/CkProbeTrace_Processor.cpp
@@ -52,7 +52,9 @@ namespace ck
         if (InHandle.Has<FTag_ProbeTrace_Disabled>())
         { return; }
 
-        CK_ENSURE_IF_NOT(ck::IsValid(_PhysicsSystem),
+        const auto PhysicsSystem = _PhysicsSystem.Pin();
+
+        CK_ENSURE_IF_NOT(ck::IsValid(PhysicsSystem),
             TEXT("PhysicsSystem is NOT valid. Unable to start trace using Handle [{}]"), InHandle)
         {
             UCk_Utils_EntityLifetime_UE::Request_DestroyEntity(InHandle);
@@ -80,11 +82,11 @@ namespace ck
 
         const auto& Overlaps =
             InRequest.Get_TracePolicy() == ECk_ProbeTrace_Policy::Multi ?
-            UCk_Utils_ProbeTrace_UE::Request_MultiLineTrace(InHandle, RayCastSettings, FireOverlaps, TryDebugDraw, *_PhysicsSystem.Pin()) :
+            UCk_Utils_ProbeTrace_UE::Request_MultiLineTrace(InHandle, RayCastSettings, FireOverlaps, TryDebugDraw, *PhysicsSystem) :
             [&]
             {
                 auto Result = UCk_Utils_ProbeTrace_UE::Request_SingleLineTrace(InHandle, RayCastSettings, FireOverlaps,
-                    TryDebugDraw, *_PhysicsSystem.Pin());
+                    TryDebugDraw, *PhysicsSystem);
 
                 if (ck::Is_NOT_Valid(Result))
                 { return TArray<FCk_Probe_RayCast_Result>{}; }
@@ -179,7 +181,9 @@ namespace ck
         if (InHandle.Has<FTag_ProbeTrace_Disabled>())
         { return; }
 
-        CK_ENSURE_IF_NOT(ck::IsValid(_PhysicsSystem),
+        const auto PhysicsSystem = _PhysicsSystem.Pin();
+
+        CK_ENSURE_IF_NOT(ck::IsValid(PhysicsSystem),
             TEXT("PhysicsSystem is NOT valid. Unable to start shape trace using Handle [{}]"), InHandle)
         {
             UCk_Utils_EntityLifetime_UE::Request_DestroyEntity(InHandle);
@@ -207,11 +211,11 @@ namespace ck
 
         const auto& Overlaps =
             InRequest.Get_TracePolicy() == ECk_ProbeTrace_Policy::Multi ?
-            UCk_Utils_ProbeTrace_UE::Request_MultiShapeTrace(InHandle, ShapeCastSettings, FireOverlaps, TryDebugDraw, *_PhysicsSystem.Pin()) :
+            UCk_Utils_ProbeTrace_UE::Request_MultiShapeTrace(InHandle, ShapeCastSettings, FireOverlaps, TryDebugDraw, *PhysicsSystem) :
             [&]
             {
                 auto Result = UCk_Utils_ProbeTrace_UE::Request_SingleShapeTrace(InHandle, ShapeCastSettings, FireOverlaps,
-                    TryDebugDraw, *_PhysicsSystem.Pin());
+                    TryDebugDraw, *PhysicsSystem);
 
                 if (ck::Is_NOT_Valid(Result))
                 { return TArray<FCk_ShapeCast_Result>{}; }
@@ -303,7 +307,9 @@ namespace ck
             const FFragment_ProbeTrace_RayCast& InRequest) const
         -> void
     {
-        if (ck::Is_NOT_Valid(_PhysicsSystem) || ck::Is_NOT_Valid(InRequest.Get_StartPos()))
+        const auto PhysicsSystem = _PhysicsSystem.Pin();
+
+        if (ck::Is_NOT_Valid(PhysicsSystem) || ck::Is_NOT_Valid(InRequest.Get_StartPos()))
         { return; }
 
         const auto& Transform = UCk_Utils_Transform_UE::Get_EntityCurrentTransform(InRequest.Get_StartPos());
@@ -326,11 +332,11 @@ namespace ck
 
         if (InRequest.Get_TracePolicy() == ECk_ProbeTrace_Policy::Multi)
         {
-            UCk_Utils_ProbeTrace_UE::Request_MultiLineTrace(InHandle, RayCastSettings, FireOverlaps, TryDebugDraw, *_PhysicsSystem.Pin());
+            UCk_Utils_ProbeTrace_UE::Request_MultiLineTrace(InHandle, RayCastSettings, FireOverlaps, TryDebugDraw, *PhysicsSystem);
         }
         else
         {
-            UCk_Utils_ProbeTrace_UE::Request_SingleLineTrace(InHandle, RayCastSettings, FireOverlaps, TryDebugDraw, *_PhysicsSystem.Pin());
+            UCk_Utils_ProbeTrace_UE::Request_SingleLineTrace(InHandle, RayCastSettings, FireOverlaps, TryDebugDraw, *PhysicsSystem);
         }
     }
 
@@ -353,7 +359,9 @@ namespace ck
             const FFragment_ProbeTrace_ShapeCast& InRequest) const
         -> void
     {
-        if (ck::Is_NOT_Valid(_PhysicsSystem) || ck::Is_NOT_Valid(InRequest.Get_StartPos()))
+        const auto PhysicsSystem = _PhysicsSystem.Pin();
+
+        if (ck::Is_NOT_Valid(PhysicsSystem) || ck::Is_NOT_Valid(InRequest.Get_StartPos()))
         { return; }
 
         const auto& Transform = UCk_Utils_Transform_UE::Get_EntityCurrentTransform(InRequest.Get_StartPos());
@@ -376,11 +384,11 @@ namespace ck
 
         if (InRequest.Get_TracePolicy() == ECk_ProbeTrace_Policy::Multi)
         {
-            UCk_Utils_ProbeTrace_UE::Request_MultiShapeTrace(InHandle, ShapeCastSettings, FireOverlaps, TryDebugDraw, *_PhysicsSystem.Pin());
+            UCk_Utils_ProbeTrace_UE::Request_MultiShapeTrace(InHandle, ShapeCastSettings, FireOverlaps, TryDebugDraw, *PhysicsSystem);
         }
         else
         {
-            UCk_Utils_ProbeTrace_UE::Request_SingleShapeTrace(InHandle, ShapeCastSettings, FireOverlaps, TryDebugDraw, *_PhysicsSystem.Pin());
+            UCk_Utils_ProbeTrace_UE::Request_SingleShapeTrace(InHandle, ShapeCastSettings, FireOverlaps, TryDebugDraw, *PhysicsSystem);
         }
     }
 }

--- a/Source/CkSpatialQuery/Public/CkSpatialQuery/Probe/CkProbeTrace_Utils.cpp
+++ b/Source/CkSpatialQuery/Public/CkSpatialQuery/Probe/CkProbeTrace_Utils.cpp
@@ -47,6 +47,9 @@ namespace ck::details
 
             const auto OtherProbe = UCk_Utils_Probe_UE::Cast(_AnyHandle.Get_ValidHandle(Entity));
 
+            if (ck::Is_NOT_Valid(OtherProbe))
+            { return; }
+
             _Hits.Emplace(std::make_pair(OtherProbe, InResult.mFraction));
         }
 
@@ -81,6 +84,10 @@ namespace ck::details
             { return; }
 
             const auto OtherProbe = UCk_Utils_Probe_UE::Cast(_AnyHandle.Get_ValidHandle(Entity));
+
+            if (ck::Is_NOT_Valid(OtherProbe))
+            { return; }
+
             _Hits.Emplace(std::make_pair(OtherProbe, InResult.mFraction));
         }
 

--- a/Source/CkUnrealComponent/Public/CkUnrealComponent/CkUnrealComponent_Utils.cpp
+++ b/Source/CkUnrealComponent/Public/CkUnrealComponent/CkUnrealComponent_Utils.cpp
@@ -166,7 +166,8 @@ auto
     { return {}; }
 
     auto& Bridge = ck_actor_component_internal::Get_BridgeMap();
-    if (auto* Found = Bridge.Find(TWeakObjectPtr<UActorComponent>{InComponent}))
+    if (auto* Found = Bridge.Find(TWeakObjectPtr<UActorComponent>{InComponent});
+        Found != nullptr && ck::IsValid(*Found))
     { return *Found; }
 
     return {};
@@ -341,7 +342,18 @@ auto
     if (ck::Is_NOT_Valid(InComponent))
     { return; }
 
-    ck_actor_component_internal::Get_BridgeMap().Add(TWeakObjectPtr{InComponent}, InHandle);
+    auto& Bridge = ck_actor_component_internal::Get_BridgeMap();
+
+    // Opportunistically prune entries whose component died without going
+    // through DoUnregisterBridge (e.g. PIE teardown ordering) — the map is
+    // process-lifetime static and would otherwise grow unbounded.
+    for (auto It = Bridge.CreateIterator(); It; ++It)
+    {
+        if (ck::Is_NOT_Valid(It.Key()))
+        { It.RemoveCurrent(); }
+    }
+
+    Bridge.Add(TWeakObjectPtr{InComponent}, InHandle);
 }
 
 auto

--- a/Source/CkVariables/Public/CkVariables/CkUnrealVariables_Utils.cpp
+++ b/Source/CkVariables/Public/CkVariables/CkUnrealVariables_Utils.cpp
@@ -239,10 +239,7 @@ auto
     -> TMap<FName, UObject*>
 {
     if (NOT UtilsType::Has(InHandle))
-    {
-        static TMap<FName, UObject*> Invalid;
-        return Invalid;
-    }
+    { return {}; }
 
     const auto& Variables = InHandle.Get<FragmentType>().Get_Variables();
 


### PR DESCRIPTION
## Summary

Output of a full architecture / code-smell / hardening review of CkFoundation. Every fix below was verified by hand against the code before changing it; several review findings were **rejected** on verification and are documented (with rationale) in the accompanying `FOUNDATION_REVIEW.md` so they do not get re-raised.

### Hardening fixes

- **CkSpatialQuery / ProbeTrace** — all four processors dereferenced `*_PhysicsSystem.Pin()` inline after only validating the weak pointer (check-to-use gap); now pin once and validate the pinned pointer (the pattern `CkProbe_Processor` already uses). The Jolt cast collectors also emplaced `Cast` results into hit lists unguarded — bodies whose entity is no longer a valid probe are now skipped.
- **CkRelationship** — `Player::Assign` called `Get_ID(Cast(InHandle))` with no `Has` guard (invalid handle into `Get_ID` for entities without the fragment). Both `Assign`s restructured: cast once, guard, reuse (resolves the double-cast TODOs).
- **CkUnrealComponent** — the process-lifetime component→entity bridge map only shed entries via `DoUnregisterBridge`; stale weak keys now pruned opportunistically on register, and lookups no longer return dead handles.
- **CkActorRelay** — `OnPostLoadMapWithWorld` could only remove a player channel pool via a still-valid PlayerController; pools of PCs destroyed before map transition leaked for the subsystem lifetime. The map is now pruned of dead/foreign entries directly.
- **CkAggro** — line-of-sight scoring crashed at `Actor->GetWorld()` for actor-less owners (its own TODO admitted the assumption); now ensure-guarded. Also `LineTraceSingleByChannel` + throwaway `FHitResult` → `LineTraceTestByChannel`.
- **CkResourceLoader** — both load-completion callbacks dereferenced the streamable handle unguarded; `RequestAsyncLoad` fires the delegate synchronously for already-resident assets, before the handle is stored. Now guarded.
- **CkCue** — deferred relay lambdas (client + server) captured `OwnerEntity` and shipped it in RPCs whenever the channel finally came up; both now re-validate the owner first.
- **CkCore** — `Get_FlattenedAndNormalized` used `Normalize()` (leaves near-zero input unchanged → non-unit garbage); now `GetSafeNormal()`.

### Refactors / conventions

- **CkOverlapBody** — resolves three standing duplication TODOs: the identical end-overlap broadcast lambda (Sensor request handler + Teardown) is one templated helper; the bone-follow transform duplicated across Sensor/Marker `UpdateTransform` moved into `UCk_Utils_MarkerAndSensor_UE`.
- **CkDynamic** — use-after-move fix in `Add_Fragment` (marker fragment is presence-only and now explicitly default-constructed), anonymous namespace → `static`, `std::move` → `MoveTemp`.
- **CkAnimation / CkVariables** — `MoveTemp` conventions, dead static map removed.

### Architecture validation

A full `Build.cs` dependency audit against the documented tier table found **zero violations** — no tier inversions, no cycles, no runtime→editor deps. (Only doc drift: 4 editor modules missing from the editor-modules doc.)

## Test plan

- Full editor build (Development) green.
- **495/495** functional AutoTests pass headless (`Automation RunTests Project.Functional Tests`), including the Relationship, Probe, Cue, Dynamic, Variables, UnrealComponent, and OverlapBody suites that exercise the changed code.
- Two new regression AutoTests added in the companion CkTests PR (Vector3 safe-normalize, Team Assign same-ID no-op) — both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)