### PR TITLE
fix(CkAngelscriptGenerator): self-heal bootstrap for headless commandlets (CI cooks)

### DIFF
--- a/Source/CkAngelscriptGenerator/CkAngelscriptGenerator_Module.cpp
+++ b/Source/CkAngelscriptGenerator/CkAngelscriptGenerator_Module.cpp
@@ -90,6 +90,26 @@ namespace
 
                 for (const auto& File : Files)
                 {
+                    // A stub is only a STALE SURVIVOR when its canonical file
+                    // exists to supersede it. With gitignored canonicals
+                    // (*_EntitySpawnParams.as), the stub IS the bootstrap for
+                    // the upcoming AS compile — in commandlets this module
+                    // loads BEFORE Hazelight's initial compile, so deleting it
+                    // here re-wedges the cook retry that synthesized it
+                    // (pinned by the 2026-06-10 two-pass cook verification).
+                    // Once the compile succeeds, the canonical regenerates
+                    // and the very next sweep (PostCompile or next startup)
+                    // deletes the stub as before.
+                    const auto CanonicalPath = FPaths::GetPath(File) /
+                        FPaths::GetCleanFilename(File).Replace(TEXT("_StubRecovery_"), TEXT(""));
+                    if (NOT IFileManager::Get().FileExists(*CanonicalPath))
+                    {
+                        ck::angelscriptgenerator::Log(
+                            TEXT("[Module] Retaining self-heal stub (its canonical is absent — the stub is ")
+                            TEXT("the bootstrap for the next AS compile): {}"), File);
+                        continue;
+                    }
+
                     if (IFileManager::Get().Delete(*File, /*RequireExists=*/false, /*EvenReadOnly=*/false, /*Quiet=*/true))
                     {
                         ck::angelscriptgenerator::Log(

--- a/Source/CkAngelscriptGenerator/SelfHeal/CkAngelscriptGenerator_Dispatcher.cpp
+++ b/Source/CkAngelscriptGenerator/SelfHeal/CkAngelscriptGenerator_Dispatcher.cpp
@@ -995,6 +995,53 @@ namespace ck::angelscriptgenerator::self_heal
             sModalTicksWaited = 0;
         }
 
+        // Headless (commandlet / unattended) bootstrap drain. No Slate modal
+        // will ever pump here, and for commandlets Hazelight hard-exits the
+        // process right after the OnReloadHadErrors broadcast returns
+        // ("Cannot run when angelscript has failed to compile" —
+        // AngelscriptManager.cpp's IsRunningCommandlet() guard). There is no
+        // hot-reload watcher thread in that flow either, so the mtime-baseline
+        // hazard the modal-tick deferral exists for does not apply — applying
+        // strategies SYNCHRONOUSLY inside the broadcast is safe and is the
+        // only window we get. The stubs land on disk before the exit: the
+        // next invocation of the same commandlet (e.g. a CI cook step with
+        // automatic retry) compiles against them, regenerates the canonicals
+        // post-compile, and proceeds. Pinned by the 2026-06-10 CI cook
+        // failure on the first gitignored-EntitySpawnParams fresh clone.
+        auto Drain_PendingActions_Headless() -> void
+        {
+            Log(TEXT("[SelfHeal] Headless bootstrap — applying {} recovery action(s) synchronously ")
+                TEXT("(no modal pump in commandlet/unattended mode)."),
+                sPendingActions.Num());
+
+            auto AppliedActions = TArray<FCk_RecoveryAction>{};
+            for (const auto& Action : sPendingActions)
+            {
+                if (NOT Try_ReserveSynthesis(Action))
+                { continue; }
+                if (Apply_Strategy(Action.Strategy, Action.Error))
+                { AppliedActions.Add(Action); }
+            }
+            const auto QueuedCount = sPendingActions.Num();
+            sPendingActions.Reset();
+
+            if (AppliedActions.Num() > 0)
+            {
+                ++sCyclesRun;
+                Log(TEXT("[SelfHeal] Cycle {} applied {} strategy/strategies synchronously. ")
+                    TEXT("If this process exits with 'Cannot run when angelscript has failed to ")
+                    TEXT("compile', RE-RUN THE SAME COMMAND — the next run compiles against the ")
+                    TEXT("synthesized recovery stubs and regenerates the canonical files."),
+                    sCyclesRun, AppliedActions.Num());
+
+                Log_AppliedActions_ToMessageLog(AppliedActions);
+            }
+            else
+            {
+                Log_TerminalBanner_AllUnactionable(QueuedCount);
+            }
+        }
+
         auto Ensure_ModalTickSubscribed() -> void
         {
             if (sModalTickHandle.IsValid())
@@ -1002,8 +1049,7 @@ namespace ck::angelscriptgenerator::self_heal
 
             if (NOT FSlateApplication::IsInitialized())
             {
-                Warning(TEXT("[SelfHeal] FSlateApplication not initialized — cannot subscribe to ")
-                        TEXT("modal-tick pump. Recovery deferral will not fire. (Is this a -nullrhi run?)"));
+                Drain_PendingActions_Headless();
                 return;
             }
 

--- a/Source/CkAngelscriptGenerator/SelfHeal/CkAngelscriptGenerator_StubSynthesizer.cpp
+++ b/Source/CkAngelscriptGenerator/SelfHeal/CkAngelscriptGenerator_StubSynthesizer.cpp
@@ -147,6 +147,16 @@ namespace ck::angelscriptgenerator::self_heal
             return Out;
         }
 
+        // Classes whose source-derived FULL SHAPE was synthesized by THIS
+        // process. Distinguishes "signature error in the same bulk drain that
+        // wrote the full shape" (never compile-tested — wait for the next
+        // compile) from "signature error after a compile that already
+        // included the full shape" (genuine divergence — per-signature
+        // fallback). Session-static on purpose: mirrors the dispatcher's
+        // convergence trackers; a new process starts clean, which is exactly
+        // the headless cook-retry boundary.
+        TSet<FString> sFullShapeClassesThisSession;
+
         // ---- File IO helpers -------------------------------------------------------
 
         // Read full file contents as text. Returns empty string + false if not found.
@@ -791,11 +801,38 @@ namespace ck::angelscriptgenerator::self_heal
         auto ExistingStub = FString{};
         const auto StubFileExists = Try_ReadFile(StubPath, ExistingStub);
 
-        // Re-fire for a class whose full shape already landed: no-op success.
+        // Re-fire for a class whose full shape already landed:
+        //  - struct-shaped errors (missing type / bare ctor): the struct
+        //    exists in the sibling — satisfied, no-op success.
+        //  - signature errors (NoMatchingSignatures) where the full shape was
+        //    written THIS SESSION (typically the same bulk drain): the
+        //    signature has never been compile-tested against the fresh full
+        //    shape — no-op success and let the next compile decide. Deferring
+        //    here appended junk per-signature overloads for calls the full
+        //    shape would have satisfied (and a `nullptr`-passing call then
+        //    coexists ambiguously with the full-shape overload).
+        //  - signature errors where the full shape came from a PREVIOUS
+        //    session/process (marker on disk, not in the session set — the
+        //    headless cook-retry flow): that compile already ran against the
+        //    full shape and still missed, so the caller genuinely diverges
+        //    (arg-order drift, base-vs-typed-handle slot). Return failure so
+        //    the dispatcher falls back to the per-signature error-text append
+        //    ALONGSIDE the full shape. Returning success unconditionally
+        //    swallowed that fallback and wedged the headless cook retry on
+        //    BB_CorridorGym.as's stale 25-arg StoreDriver call (2026-06-10).
         if (StubFileExists && ExistingStub.Contains(Get_FullShapeMarkerLine(InClassName)))
         {
-            Result.Success        = true;
-            Result.TargetFilePath = StubPath;
+            if (InError.Kind != ECk_AsParsedError_Kind::NoMatchingSignatures
+                || sFullShapeClassesThisSession.Contains(InClassName))
+            {
+                Result.Success        = true;
+                Result.TargetFilePath = StubPath;
+                return Result;
+            }
+
+            Result.ErrorMessage = FString::Printf(
+                TEXT("Full shape for '%s' already in the sibling (from a prior compile) but this Params overload is still unmatched — defer to the per-signature path."),
+                *InClassName);
             return Result;
         }
 
@@ -833,10 +870,22 @@ namespace ck::angelscriptgenerator::self_heal
             return Result;
         }
 
+        sFullShapeClassesThisSession.Add(InClassName);
+
         Result.Success        = true;
         Result.TargetFilePath = StubPath;
         Result.InjectedBlock  = StubBlock;
         return Result;
+    }
+
+    // ----------------------------------------------------------------------------------------------------------------
+
+    auto
+        FCkAsStubSynthesizer::
+        Reset_SessionState_ForTests()
+        -> void
+    {
+        sFullShapeClassesThisSession.Reset();
     }
 }
 

--- a/Source/CkAngelscriptGenerator/SelfHeal/CkAngelscriptGenerator_StubSynthesizer.h
+++ b/Source/CkAngelscriptGenerator/SelfHeal/CkAngelscriptGenerator_StubSynthesizer.h
@@ -132,6 +132,12 @@ namespace ck::angelscriptgenerator::self_heal
         // class-level dedup marker for source-derived stubs.
         static auto Get_FullShapeMarkerLine(const FString& InClassName) -> FString;
 
+        // Clears the session-static "full shapes written this process" set —
+        // lets tests simulate the next-process boundary (headless cook
+        // retry) where a signature miss against an on-disk full shape defers
+        // to the per-signature path instead of no-op'ing.
+        static auto Reset_SessionState_ForTests() -> void;
+
         static auto Get_MarkerComment    () -> FString;
         static auto Get_StubFileHeader   () -> FString;
         static auto Derive_StubSiblingPath(const FString& InCanonicalFilePath) -> FString;

--- a/Source/CkAngelscriptGenerator/Tests/Test_StubSynthesizer.cpp
+++ b/Source/CkAngelscriptGenerator/Tests/Test_StubSynthesizer.cpp
@@ -1227,10 +1227,39 @@ bool FCkTest_StubSynthesizer_Inject_SourceDerived_EndToEnd::RunTest(const FStrin
     TestTrue(TEXT("positional ctor assigns"), Stub.Contains(TEXT("        Phase = InPhase;")));
     TestTrue(TEXT("namespace block"), Stub.Contains(TEXT("namespace UTestSynth_DamageReceiver")));
 
-    // Re-fire: no-op success, struct still defined exactly once.
+    // Re-fire with a struct-shaped error: no-op success, struct still
+    // defined exactly once.
     const auto ResultB = FCkAsStubSynthesizer::Inject_EntityScriptParamsStub_SourceDerived(
         TEXT("UTestSynth_DamageReceiver"), Error, {}, {ScriptRoot});
-    TestTrue(TEXT("re-fire reports success (no-op)"), ResultB.Success);
+    TestTrue(TEXT("struct-shaped re-fire reports success (no-op)"), ResultB.Success);
+
+    // Re-fire with a SIGNATURE error in the SAME session that wrote the full
+    // shape: never compile-tested against it yet — must no-op success and
+    // let the next compile decide (deferring here appended junk overloads
+    // for calls the full shape satisfies).
+    auto DivergentSignature = FCk_AsParsedError{};
+    DivergentSignature.Kind            = ECk_AsParsedError_Kind::NoMatchingSignatures;
+    DivergentSignature.TargetNamespace = TEXT("UTestSynth_DamageReceiver");
+    DivergentSignature.FunctionName    = TEXT("Params");
+    DivergentSignature.ArgsList        = TEXT("FGameplayTag, const int");
+    DivergentSignature.FilePath        = *ClassFile;
+    const auto ResultSameSession = FCkAsStubSynthesizer::Inject_EntityScriptParamsStub_SourceDerived(
+        TEXT("UTestSynth_DamageReceiver"), DivergentSignature, {}, {ScriptRoot});
+    TestTrue(TEXT("same-session signature re-fire no-ops (Success = true)"), ResultSameSession.Success);
+
+    // Same signature error from the NEXT process (headless cook retry — the
+    // full shape is on disk from the prior run and the compile that just
+    // failed already included it): the caller genuinely diverges — must
+    // DEFER so the dispatcher's error-text fallback appends the
+    // per-signature overload alongside the full shape. Returning success
+    // here swallowed the fallback and wedged the headless cook retry
+    // (BB_CorridorGym's stale 25-arg StoreDriver call, 2026-06-10).
+    FCkAsStubSynthesizer::Reset_SessionState_ForTests();
+    const auto ResultNextSession = FCkAsStubSynthesizer::Inject_EntityScriptParamsStub_SourceDerived(
+        TEXT("UTestSynth_DamageReceiver"), DivergentSignature, {}, {ScriptRoot});
+    TestFalse(TEXT("next-session signature miss against on-disk full shape DEFERS (Success = false)"), ResultNextSession.Success);
+    TestTrue(TEXT("deferral reason mentions per-signature path"),
+        ResultNextSession.ErrorMessage.Contains(TEXT("per-signature")));
 
     // Cross-path dedup: an error-text inject for the same class's Params()
     // must no-op against the full-shape block's end-marker. No candidates


### PR DESCRIPTION
## Why

BusterBlock's CI cook failed on chainkemists/BusterBlock#2048 (the EntitySpawnParams gitignore rollout): a cook on a fresh checkout hard-exits at the failed AS compile (`Cannot run when angelscript has failed to compile`) **before any deferred self-heal can run** — a commandlet has no Slate modal pump and no hot-reload watcher thread, so the modal-tick deferral never fires. Reproduced locally with both ESPs deleted + `-run=cook`.

## What (four coordinated fixes)

- **Dispatcher — synchronous headless drain:** when Slate is uninitialized, apply the queued recovery actions immediately inside `OnReloadHadErrors`. The mtime-baseline hazard the deferral exists for needs a watcher thread; there isn't one here, and this broadcast is the only window before the engine exits. The stubs land on disk; the *retried* command compiles against them.
- **Module sweep — canonical-aware:** the startup "force-quit survivor" sweep now only deletes a `_StubRecovery_` sibling when its canonical exists. With gitignored canonicals the stub IS the next compile's bootstrap, and in commandlets this module loads *before* Hazelight compiles — the unconditional sweep was eating the stubs the previous run just wrote.
- **`Normalize_TypeToken` — `<null handle>` → `UObject`:** a caller passing a `nullptr` literal is reported with `<null handle>` as the arg type; emitting that verbatim made the entire stub file unparseable, voiding every stub it carried.
- **Source-derived re-fire — session-aware deferral:** a signature miss against a full shape written by a *prior process* defers to the per-signature error-text append (the caller genuinely diverges — e.g. a stale call site after an ExposeOnSpawn shape change). Same-session re-fires still no-op, since the fresh full shape hasn't been compile-tested yet.

## Verification

- Local two-pass cook with both ESPs deleted: **pass 1** synthesizes 74 stubs synchronously and exits as the engine dictates; **pass 2** retains the stubs, compiles green, regenerates both canonicals byte-stable, deletes the stubs, and proceeds into the cook. Exactly one retry needed.
- **70/70** `CkAngelscriptGenerator.UnitTests.*` (new regression coverage: null-handle normalization, same-session vs next-session re-fire behavior).

Pairs with the BusterBlock-side Buildkite change (automatic retry on the cook step) riding chainkemists/BusterBlock#2048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)