### PR TITLE
Actor↔Entity linkup DevEx: one-call spawn helper, EntityScript component, unified EcsReady promise

### DIFF
--- a/Script/CLAUDE.md
+++ b/Script/CLAUDE.md
@@ -483,6 +483,48 @@ auto Spawned = utils_entity_script::Request_SpawnEntity(
     FInstancedStruct::Make(Params));
 
 //============================================================================
+// 10.1 ACTOR ↔ ENTITY LINKUP (EntityScript_WithActor)
+//============================================================================
+//
+// To give an Actor an ECS Entity, use the one-call helper — do NOT hand-roll
+// the spawn-params + TransientEntity + HasAuthority boilerplate:
+
+class AMyActor : AActor
+{
+    default bReplicates = true;
+
+    UFUNCTION(BlueprintOverride)
+    void BeginPlay()
+    {
+        // Authority-gated internally: on clients this returns an INVALID pending
+        // handle and the Entity arrives via the EntityScript replication pipeline.
+        auto PendingEntity = utils_entity_script_with_actor::Request_SpawnEntityScript_OnActor(
+            this, UMyEntityScript);
+    }
+}
+
+// Editor/designer path: add the "Ck Entity Script (With Actor)" component
+// (UCk_EntityScript_WithActor_ActorComponent_UE) to the Actor and pick the
+// EntityScript class — zero code, same pipeline.
+//
+// To know when the Actor is ECS ready ON EVERY WORLD (server, client, late
+// join), bind the actor-side promise — works whether or not this world did
+// the spawning:
+//
+//   utils_owning_actor::Promise_OnActorEcsReady(
+//       this, FCk_Delegate_OwningActor_OnEcsReady(this, n"OnEcsReady"));
+//
+//   UFUNCTION()
+//   private void OnEcsReady(AActor InActor, FCk_Handle InEntity)
+//   { /* Entity linked; replicated values applied (default policy) */ }
+//
+// Policies (3rd param, optional): ValuesReplicated (default — safe to read
+// replicated attributes/team/SM state) | LinkEstablished (earlier; replicated
+// values may not be applied yet on clients).
+// Fires immediately if the Actor is already ready; auto-discards if the Actor
+// is destroyed before ever becoming ready.
+
+//============================================================================
 // 11. TIMERS / TICK PATTERN
 //============================================================================
 

--- a/Source/CkActorRelay/Public/CkActorRelay/CkActorRelay_Actor.cpp
+++ b/Source/CkActorRelay/Public/CkActorRelay/CkActorRelay_Actor.cpp
@@ -4,11 +4,9 @@
 
 #include "CkActorRelay/CkActorRelay_Log.h"
 
-#include "CkEcs/EntityScript/CkEntityScript_Utils.h"
 #include "CkEcs/OwningActor/CkOwningActor_Utils.h"
-#include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
 #include "CkEcsExt/EntityScript/CkEntityScript_WithActor.h"
-#include "CkEcsExt/EntityScript/CkEntityScript_WithActor_Data.h"
+#include "CkEcsExt/EntityScript/CkEntityScript_WithActor_Utils.h"
 
 #include <Net/UnrealNetwork.h>
 #include <Net/Core/PushModel/PushModel.h>
@@ -32,12 +30,7 @@ auto
 {
     Super::BeginPlay();
 
-    if (HasAuthority())
-    {
-        auto TransientEntity = UCk_Utils_EcsWorld_Subsystem_UE::Get_TransientEntity(GetWorld());
-        auto SpawnParams = FInstancedStruct::Make<FCk_EntityScript_WithActor_SpawnParams>(this);
-        UCk_Utils_EntityScript_UE::Request_SpawnEntity(TransientEntity, UCk_EntityScript_WithActor_UE::StaticClass(), SpawnParams);
-    }
+    UCk_Utils_EntityScript_WithActor_UE::Request_SpawnEntityScript_OnActor(this, UCk_EntityScript_WithActor_UE::StaticClass());
 
     OnRep_GroupSubsystemClass();
 }

--- a/Source/CkEcs/Claude.md
+++ b/Source/CkEcs/Claude.md
@@ -299,6 +299,25 @@ Registration lives in the feature's `_Fragment.cpp` via `RegisterLazy` (per-type
 
 Pinned by `Ck.Attribute.Net.Values_AppliedBefore_OnReplicationComplete`, `Float_InitialBakedValue_Replicates`, and `Float_PreComposition_StashedValue_Applies` in CkTests.
 
+### Actor-side unified promise
+
+For actor-linked entities (`EntityScript_WithActor`), consumers should not juggle the two signals
+directly. `UCk_Utils_OwningActor_UE::Promise_OnActorEcsReady(Actor, Delegate, Policy)` is the one
+actor-side hook that works on every world:
+
+- `ECk_ActorEcsReady_Policy::ValuesReplicated` (default) — fires once the Actor↔Entity link exists
+  AND `OnReplicationComplete` has fired for the linked entity. Collapses to link-time on authority
+  and for non-replicated entities. Replicated values are readable inside the callback.
+- `ECk_ActorEcsReady_Policy::LinkEstablished` — fires at link time (OnConstructed-equivalent on
+  clients; replicated values may not be applied yet).
+
+The promise fires immediately when bound after the actor is already ready, queues on the
+(non-replicated, auto-added) `UCk_EntityOwningActor_ActorComponent_UE` otherwise, and is discarded
+if the actor is destroyed before ever becoming ready. To spawn the actor-linked entity in the first
+place, use `UCk_Utils_EntityScript_WithActor_UE::Request_SpawnEntityScript_OnActor` (CkEcsExt) or
+add the `Ck Entity Script (With Actor)` component in the editor — both are authority-gated and
+replication-correct.
+
 ---
 
 ## Anti-patterns

--- a/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Fragment_Data.cpp
+++ b/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Fragment_Data.cpp
@@ -1,6 +1,7 @@
 #include "CkOwningActor_Fragment_Data.h"
 
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
+#include "CkEcs/OwningActor/CkOwningActor_Utils.h"
 #include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
 
 #include "Net/UnrealNetwork.h"
@@ -23,6 +24,15 @@ auto
     Super::EndPlay(InEndPlayReason);
 
     UCk_Utils_EntityLifetime_UE::Request_DestroyEntity(_EntityHandle);
+}
+
+auto
+    UCk_EntityOwningActor_ActorComponent_UE::
+    DoHandle_LinkedEntityReplicationComplete(
+        FCk_Handle InEntity)
+    -> void
+{
+    UCk_Utils_OwningActor_UE::DoFlush_PendingEcsReady_ValuesReplicated(this, GetOwner(), InEntity);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Fragment_Data.h
+++ b/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Fragment_Data.h
@@ -54,6 +54,23 @@ DECLARE_DYNAMIC_DELEGATE_TwoParams(
 
 // --------------------------------------------------------------------------------------------------------------------
 
+// Controls when Promise_OnActorEcsReady fires.
+UENUM(BlueprintType)
+enum class ECk_ActorEcsReady_Policy : uint8
+{
+    // Fire once the Entity is linked AND its replicated values have been applied
+    // (OnReplicationComplete). On authority and for non-replicated Entities this collapses to
+    // link-time. The multiplayer-safe default — replicated values (attributes, team, state
+    // machine state, etc.) are readable inside the callback on every world.
+    ValuesReplicated,
+
+    // Fire as soon as the Actor↔Entity link is established. On clients this is OnConstructed-time:
+    // the Entity is composed but replicated values may NOT be applied yet.
+    LinkEstablished,
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 UCLASS(NotBlueprintType, NotBlueprintable)
 class CKECS_API UCk_EntityOwningActor_ActorComponent_UE
     : public UCk_ActorComponent_UE
@@ -76,13 +93,25 @@ public:
     friend class UCk_Fragment_EntityReplicationDriver_Rep;
 
 private:
+    UFUNCTION()
+    void
+    DoHandle_LinkedEntityReplicationComplete(
+        FCk_Handle InEntity);
+
+private:
     FCk_Handle _EntityHandle;
 
-    // Promises queued by Promise_OnActorEcsReady while the Actor was not yet ECS ready. Flushed (and
-    // emptied) the moment the OwningActor link is established. These live with the component, so they
-    // are discarded automatically if the Actor is destroyed before ever becoming ECS ready.
-    TArray<FCk_Delegate_OwningActor_OnEcsReady> _PendingEcsReadyDelegates;
-    TArray<TFunction<void(AActor*, FCk_Handle)>> _PendingEcsReadyCallbacks;
+    // Promises queued by Promise_OnActorEcsReady while the Actor was not yet ECS ready (and, for the
+    // ValuesReplicated policy, while the linked Entity's replication was still pending). These live
+    // with the component, so they are discarded automatically if the Actor is destroyed before ever
+    // becoming ready. LinkEstablished queues flush the moment the OwningActor link is established;
+    // ValuesReplicated queues flush once the linked Entity's OnReplicationComplete fires (immediately
+    // at link-time when the Entity does not replicate).
+    TArray<FCk_Delegate_OwningActor_OnEcsReady> _PendingEcsReadyDelegates_LinkEstablished;
+    TArray<TFunction<void(AActor*, FCk_Handle)>> _PendingEcsReadyCallbacks_LinkEstablished;
+    TArray<FCk_Delegate_OwningActor_OnEcsReady> _PendingEcsReadyDelegates_ValuesReplicated;
+    TArray<TFunction<void(AActor*, FCk_Handle)>> _PendingEcsReadyCallbacks_ValuesReplicated;
+    bool _OnReplicationCompleteTrampolineBound = false;
 
 public:
     CK_PROPERTY_GET(_EntityHandle);

--- a/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Utils.cpp
@@ -232,7 +232,8 @@ auto
     UCk_Utils_OwningActor_UE::
     Promise_OnActorEcsReady(
         AActor* InActor,
-        const FCk_Delegate_OwningActor_OnEcsReady& InDelegate)
+        const FCk_Delegate_OwningActor_OnEcsReady& InDelegate,
+        ECk_ActorEcsReady_Policy InPolicy)
     -> void
 {
     CK_ENSURE_IF_NOT(ck::IsValid(InActor),
@@ -243,25 +244,44 @@ auto
         TEXT("Promise_OnActorEcsReady called with an unbound delegate for Actor [{}]"), InActor)
     { return; }
 
-    if (Get_IsActorEcsReady(InActor))
-    {
-        InDelegate.ExecuteIfBound(InActor, Get_ActorEntityHandle(InActor));
-        return;
-    }
-
     auto EntityOwningActorComp = DoGetOrAdd_EntityOwningActorComponent(InActor);
 
     if (ck::Is_NOT_Valid(EntityOwningActorComp))
     { return; }
 
-    EntityOwningActorComp->_PendingEcsReadyDelegates.Add(InDelegate);
+    if (Get_IsActorEcsReady(InActor))
+    {
+        const auto Entity = Get_ActorEntityHandle(InActor);
+
+        if (InPolicy == ECk_ActorEcsReady_Policy::LinkEstablished ||
+            NOT DoGet_ShouldDeferUntilReplicationComplete(Entity))
+        {
+            InDelegate.ExecuteIfBound(InActor, Entity);
+            return;
+        }
+
+        EntityOwningActorComp->_PendingEcsReadyDelegates_ValuesReplicated.Add(InDelegate);
+        DoBind_ReplicationCompleteTrampoline(EntityOwningActorComp, Entity);
+        return;
+    }
+
+    switch (InPolicy)
+    {
+        case ECk_ActorEcsReady_Policy::LinkEstablished:
+            EntityOwningActorComp->_PendingEcsReadyDelegates_LinkEstablished.Add(InDelegate);
+            break;
+        case ECk_ActorEcsReady_Policy::ValuesReplicated:
+            EntityOwningActorComp->_PendingEcsReadyDelegates_ValuesReplicated.Add(InDelegate);
+            break;
+    }
 }
 
 auto
     UCk_Utils_OwningActor_UE::
     Promise_OnActorEcsReady(
         AActor* InActor,
-        TFunction<void(AActor*, FCk_Handle)> InCallback)
+        TFunction<void(AActor*, FCk_Handle)> InCallback,
+        ECk_ActorEcsReady_Policy InPolicy)
     -> void
 {
     CK_ENSURE_IF_NOT(ck::IsValid(InActor),
@@ -272,18 +292,36 @@ auto
         TEXT("Promise_OnActorEcsReady called with an empty callback for Actor [{}]"), InActor)
     { return; }
 
-    if (Get_IsActorEcsReady(InActor))
-    {
-        InCallback(InActor, Get_ActorEntityHandle(InActor));
-        return;
-    }
-
     auto EntityOwningActorComp = DoGetOrAdd_EntityOwningActorComponent(InActor);
 
     if (ck::Is_NOT_Valid(EntityOwningActorComp))
     { return; }
 
-    EntityOwningActorComp->_PendingEcsReadyCallbacks.Add(MoveTemp(InCallback));
+    if (Get_IsActorEcsReady(InActor))
+    {
+        const auto Entity = Get_ActorEntityHandle(InActor);
+
+        if (InPolicy == ECk_ActorEcsReady_Policy::LinkEstablished ||
+            NOT DoGet_ShouldDeferUntilReplicationComplete(Entity))
+        {
+            InCallback(InActor, Entity);
+            return;
+        }
+
+        EntityOwningActorComp->_PendingEcsReadyCallbacks_ValuesReplicated.Add(MoveTemp(InCallback));
+        DoBind_ReplicationCompleteTrampoline(EntityOwningActorComp, Entity);
+        return;
+    }
+
+    switch (InPolicy)
+    {
+        case ECk_ActorEcsReady_Policy::LinkEstablished:
+            EntityOwningActorComp->_PendingEcsReadyCallbacks_LinkEstablished.Add(MoveTemp(InCallback));
+            break;
+        case ECk_ActorEcsReady_Policy::ValuesReplicated:
+            EntityOwningActorComp->_PendingEcsReadyCallbacks_ValuesReplicated.Add(MoveTemp(InCallback));
+            break;
+    }
 }
 
 auto
@@ -345,13 +383,39 @@ auto
     if (ck::Is_NOT_Valid(InComp))
     { return; }
 
+    DoFlush_PendingEcsReady_LinkEstablished(InComp, InActor, InEntity);
+
+    if (InComp->_PendingEcsReadyDelegates_ValuesReplicated.IsEmpty() &&
+        InComp->_PendingEcsReadyCallbacks_ValuesReplicated.IsEmpty())
+    { return; }
+
+    if (DoGet_ShouldDeferUntilReplicationComplete(InEntity))
+    {
+        DoBind_ReplicationCompleteTrampoline(InComp, InEntity);
+        return;
+    }
+
+    DoFlush_PendingEcsReady_ValuesReplicated(InComp, InActor, InEntity);
+}
+
+auto
+    UCk_Utils_OwningActor_UE::
+    DoFlush_PendingEcsReady_LinkEstablished(
+        UCk_EntityOwningActor_ActorComponent_UE* InComp,
+        AActor* InActor,
+        const FCk_Handle& InEntity)
+    -> void
+{
+    if (ck::Is_NOT_Valid(InComp))
+    { return; }
+
     // Move out before executing so a promise that queues another promise during its own callback
     // does not mutate the container we are iterating (and is itself fired immediately since the
     // Actor is already ECS ready by this point).
-    const auto PendingDelegates = MoveTemp(InComp->_PendingEcsReadyDelegates);
-    const auto PendingCallbacks = MoveTemp(InComp->_PendingEcsReadyCallbacks);
-    InComp->_PendingEcsReadyDelegates.Reset();
-    InComp->_PendingEcsReadyCallbacks.Reset();
+    const auto PendingDelegates = MoveTemp(InComp->_PendingEcsReadyDelegates_LinkEstablished);
+    const auto PendingCallbacks = MoveTemp(InComp->_PendingEcsReadyCallbacks_LinkEstablished);
+    InComp->_PendingEcsReadyDelegates_LinkEstablished.Reset();
+    InComp->_PendingEcsReadyCallbacks_LinkEstablished.Reset();
 
     for (const auto& Delegate : PendingDelegates)
     {
@@ -363,6 +427,69 @@ auto
         if (Callback)
         { Callback(InActor, InEntity); }
     }
+}
+
+auto
+    UCk_Utils_OwningActor_UE::
+    DoFlush_PendingEcsReady_ValuesReplicated(
+        UCk_EntityOwningActor_ActorComponent_UE* InComp,
+        AActor* InActor,
+        const FCk_Handle& InEntity)
+    -> void
+{
+    if (ck::Is_NOT_Valid(InComp))
+    { return; }
+
+    const auto PendingDelegates = MoveTemp(InComp->_PendingEcsReadyDelegates_ValuesReplicated);
+    const auto PendingCallbacks = MoveTemp(InComp->_PendingEcsReadyCallbacks_ValuesReplicated);
+    InComp->_PendingEcsReadyDelegates_ValuesReplicated.Reset();
+    InComp->_PendingEcsReadyCallbacks_ValuesReplicated.Reset();
+
+    for (const auto& Delegate : PendingDelegates)
+    {
+        Delegate.ExecuteIfBound(InActor, InEntity);
+    }
+
+    for (const auto& Callback : PendingCallbacks)
+    {
+        if (Callback)
+        { Callback(InActor, InEntity); }
+    }
+}
+
+auto
+    UCk_Utils_OwningActor_UE::
+    DoGet_ShouldDeferUntilReplicationComplete(
+        const FCk_Handle& InEntity)
+    -> bool
+{
+    if (UCk_Utils_EntityReplicationDriver_UE::Has(InEntity))
+    { return NOT UCk_Utils_EntityReplicationDriver_UE::Get_IsReplicationComplete(InEntity); }
+
+    // The link is established mid-Construct, BEFORE OwningActor::Add adds the ReplicationDriver —
+    // fall back to the Entity's replication setting (populated by the spawn processor pre-Construct)
+    // to decide whether OnReplicationComplete will eventually fire for this Entity.
+    return UCk_Utils_Net_UE::Has(InEntity) &&
+        UCk_Utils_Net_UE::Get_Replication(InEntity) == ECk_Replication::Replicates;
+}
+
+auto
+    UCk_Utils_OwningActor_UE::
+    DoBind_ReplicationCompleteTrampoline(
+        UCk_EntityOwningActor_ActorComponent_UE* InComp,
+        const FCk_Handle& InEntity)
+    -> void
+{
+    if (InComp->_OnReplicationCompleteTrampolineBound)
+    { return; }
+
+    auto Delegate = FCk_Delegate_EntityReplicationDriver_OnReplicationComplete{};
+    Delegate.BindDynamic(InComp, &UCk_EntityOwningActor_ActorComponent_UE::DoHandle_LinkedEntityReplicationComplete);
+
+    auto Entity = InEntity;
+    UCk_Utils_EntityReplicationDriver_UE::Promise_OnReplicationComplete(Entity, Delegate);
+
+    InComp->_OnReplicationCompleteTrampolineBound = true;
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Utils.h
+++ b/Source/CkEcs/Public/CkEcs/OwningActor/CkOwningActor_Utils.h
@@ -121,16 +121,18 @@ public:
     UFUNCTION(BlueprintCallable,
               DisplayName = "[Ck][OwningActor] Promise/Future On Actor Ecs Ready",
               Category = "Ck|Utils|OwningActor",
-              meta = (DefaultToSelf = "InActor", Keywords = "bind, wait, when, ready, ecs, future"))
+              meta = (DefaultToSelf = "InActor", Keywords = "bind, wait, when, ready, ecs, future, replicated"))
     static void
     Promise_OnActorEcsReady(
         AActor* InActor,
-        const FCk_Delegate_OwningActor_OnEcsReady& InDelegate);
+        const FCk_Delegate_OwningActor_OnEcsReady& InDelegate,
+        ECk_ActorEcsReady_Policy InPolicy = ECk_ActorEcsReady_Policy::ValuesReplicated);
 
     static void
     Promise_OnActorEcsReady(
         AActor* InActor,
-        TFunction<void(AActor*, FCk_Handle)> InCallback);
+        TFunction<void(AActor*, FCk_Handle)> InCallback,
+        ECk_ActorEcsReady_Policy InPolicy = ECk_ActorEcsReady_Policy::ValuesReplicated);
 
     UFUNCTION(BlueprintPure,
               DisplayName = "[Ck][OwningActor] OwningActorBasicDetails == OwningActorBasicDetails",
@@ -160,6 +162,8 @@ private:
         const AActor* InActor);
 
 private:
+    friend class UCk_EntityOwningActor_ActorComponent_UE;
+
     static auto
     DoGetOrAdd_EntityOwningActorComponent(
         AActor* InActor) -> UCk_EntityOwningActor_ActorComponent_UE*;
@@ -168,6 +172,27 @@ private:
     DoFlush_PendingEcsReady(
         UCk_EntityOwningActor_ActorComponent_UE* InComp,
         AActor* InActor,
+        const FCk_Handle& InEntity) -> void;
+
+    static auto
+    DoFlush_PendingEcsReady_LinkEstablished(
+        UCk_EntityOwningActor_ActorComponent_UE* InComp,
+        AActor* InActor,
+        const FCk_Handle& InEntity) -> void;
+
+    static auto
+    DoFlush_PendingEcsReady_ValuesReplicated(
+        UCk_EntityOwningActor_ActorComponent_UE* InComp,
+        AActor* InActor,
+        const FCk_Handle& InEntity) -> void;
+
+    static auto
+    DoGet_ShouldDeferUntilReplicationComplete(
+        const FCk_Handle& InEntity) -> bool;
+
+    static auto
+    DoBind_ReplicationCompleteTrampoline(
+        UCk_EntityOwningActor_ActorComponent_UE* InComp,
         const FCk_Handle& InEntity) -> void;
 };
 

--- a/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_ActorComponent.cpp
+++ b/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_ActorComponent.cpp
@@ -1,0 +1,25 @@
+#include "CkEntityScript_WithActor_ActorComponent.h"
+
+#include "CkEntityScript_WithActor.h"
+#include "CkEntityScript_WithActor_Utils.h"
+
+#include "CkCore/Validation/CkIsValid.h"
+
+#include <GameFramework/Actor.h>
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_EntityScript_WithActor_ActorComponent_UE::
+    BeginPlay()
+    -> void
+{
+    Super::BeginPlay();
+
+    if (ck::Is_NOT_Valid(_EntityScript))
+    { return; }
+
+    UCk_Utils_EntityScript_WithActor_UE::Request_SpawnEntityScript_OnActor(GetOwner(), _EntityScript);
+}
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_ActorComponent.h
+++ b/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_ActorComponent.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "CkCore/Macros/CkMacros.h"
+
+#include "CkEcs/OwningActor/CkOwningActor_Fragment_Data.h"
+
+#include "CkEntityScript_WithActor_ActorComponent.generated.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+class UCk_EntityScript_WithActor_UE;
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// Add this component to any Actor to make it ECS-ready without writing spawn code: pick an
+// EntityScript class and the component requests the WithActor spawn on BeginPlay (authority-gated;
+// clients receive the Entity through the EntityScript replication pipeline and link up in
+// Construct). With no class set it is just the passive link holder the runtime auto-adds at link
+// time. Non-replicated — the Entity itself carries all replication. Do NOT pair this with a manual
+// Request_SpawnEntityScript_OnActor call on the same Actor; that would link two Entities to one Actor.
+UCLASS(BlueprintType, ClassGroup = "Ck",
+       meta = (BlueprintSpawnableComponent, DisplayName = "Ck Entity Script (With Actor)"))
+class CKECSEXT_API UCk_EntityScript_WithActor_ActorComponent_UE
+    : public UCk_EntityOwningActor_ActorComponent_UE
+{
+    GENERATED_BODY()
+
+public:
+    CK_GENERATED_BODY(UCk_EntityScript_WithActor_ActorComponent_UE);
+
+protected:
+    auto
+    BeginPlay() -> void override;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite,
+              Category = "Ck",
+              meta = (AllowPrivateAccess = true))
+    TSubclassOf<UCk_EntityScript_WithActor_UE> _EntityScript;
+
+public:
+    CK_PROPERTY(_EntityScript);
+};
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_Utils.cpp
+++ b/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_Utils.cpp
@@ -1,0 +1,41 @@
+#include "CkEntityScript_WithActor_Utils.h"
+
+#include "CkEntityScript_WithActor.h"
+#include "CkEntityScript_WithActor_Data.h"
+
+#include "CkCore/Ensure/CkEnsure.h"
+#include "CkCore/Validation/CkIsValid.h"
+
+#include "CkEcs/EntityScript/CkEntityScript_Utils.h"
+#include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
+
+#include <GameFramework/Actor.h>
+#include <StructUtils/InstancedStruct.h>
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_EntityScript_WithActor_UE::
+    Request_SpawnEntityScript_OnActor(
+        AActor* InActor,
+        TSubclassOf<UCk_EntityScript_WithActor_UE> InEntityScriptClass)
+    -> FCk_Handle_PendingEntityScript
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InActor),
+        TEXT("Request_SpawnEntityScript_OnActor called with an invalid Actor"))
+    { return {}; }
+
+    CK_ENSURE_IF_NOT(ck::IsValid(InEntityScriptClass),
+        TEXT("Request_SpawnEntityScript_OnActor called with an invalid EntityScript class for Actor [{}]"), InActor)
+    { return {}; }
+
+    if (NOT InActor->HasAuthority())
+    { return {}; }
+
+    auto TransientEntity = UCk_Utils_EcsWorld_Subsystem_UE::Get_TransientEntity(InActor->GetWorld());
+    const auto SpawnParams = FInstancedStruct::Make<FCk_EntityScript_WithActor_SpawnParams>(InActor);
+
+    return UCk_Utils_EntityScript_UE::Request_SpawnEntity(TransientEntity, InEntityScriptClass, SpawnParams);
+}
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_Utils.h
+++ b/Source/CkEcsExt/Public/CkEcsExt/EntityScript/CkEntityScript_WithActor_Utils.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CkCore/Macros/CkMacros.h"
+
+#include "CkEcs/EntityScript/CkEntityScript_Fragment_Data.h"
+
+#include <Kismet/BlueprintFunctionLibrary.h>
+
+#include "CkEntityScript_WithActor_Utils.generated.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+class UCk_EntityScript_WithActor_UE;
+
+// --------------------------------------------------------------------------------------------------------------------
+
+UCLASS(NotBlueprintable, Meta = (ScriptMixin = "AActor"))
+class CKECSEXT_API UCk_Utils_EntityScript_WithActor_UE : public UBlueprintFunctionLibrary
+{
+    GENERATED_BODY()
+
+public:
+    CK_GENERATED_BODY(UCk_Utils_EntityScript_WithActor_UE);
+
+public:
+    // The one-call replacement for the hand-rolled WithActor spawn boilerplate. Spawns only on
+    // authority — on clients the Entity arrives through the EntityScript replication pipeline and
+    // links up in Construct, so the returned handle is invalid there. The actor-side hook that
+    // works on every world is UCk_Utils_OwningActor_UE::Promise_OnActorEcsReady.
+    UFUNCTION(BlueprintCallable,
+              Category = "Ck|Utils|EntityScript",
+              DisplayName = "[Ck][EntityScript] Request Spawn EntityScript On Actor",
+              meta = (DefaultToSelf = "InActor", Keywords = "spawn, link, actor, entity, ecs, ready, bridge"))
+    static FCk_Handle_PendingEntityScript
+    Request_SpawnEntityScript_OnActor(
+        AActor* InActor,
+        TSubclassOf<UCk_EntityScript_WithActor_UE> InEntityScriptClass);
+};
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkIsmRenderer/Public/CkIsmRenderer/CkIsmSubsystem.cpp
+++ b/Source/CkIsmRenderer/Public/CkIsmRenderer/CkIsmSubsystem.cpp
@@ -4,9 +4,8 @@
 #include "CkCore/Object/CkObject_Utils.h"
 #include "CkCore/Validation/CkIsValid.h"
 
-#include "CkEcs/EntityScript/CkEntityScript_Utils.h"
 #include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
-#include "CkEcsExt/EntityScript/CkEntityScript_WithActor_Data.h"
+#include "CkEcsExt/EntityScript/CkEntityScript_WithActor_Utils.h"
 
 #include "CkIsmRenderer/CkIsmRenderer_EntityScript.h"
 #include "CkIsmRenderer/Renderer/CkIsmRenderer_TransientFactory.h"
@@ -42,13 +41,13 @@ auto
     if (ck::Is_NOT_Valid(World))
     { return; }
 
+    // The registry may not be ready yet — keep _Initialized false so DoInitialize retries later.
     auto TransientEntity = UCk_Utils_EcsWorld_Subsystem_UE::Get_TransientEntity(World);
     if (ck::Is_NOT_Valid(TransientEntity))
     { return; }
 
-    auto SpawnParams = FInstancedStruct::Make<FCk_EntityScript_WithActor_SpawnParams>(this);
-    UCk_Utils_EntityScript_UE::Request_SpawnEntity(
-        TransientEntity, UCk_EntityScript_IsmRenderer_UE::StaticClass(), SpawnParams);
+    UCk_Utils_EntityScript_WithActor_UE::Request_SpawnEntityScript_OnActor(
+        this, UCk_EntityScript_IsmRenderer_UE::StaticClass());
 
     _Initialized = true;
 }


### PR DESCRIPTION
## Summary

Restores the EntityBridge-era developer experience for actor-linked entities — without replicated objects, new pipeline stages, or any concept beyond EntityScript. Design doc: \`docs/ActorEntityLinkup_DevEx_Proposal.md\` in CkPlugins.

- **\`Request_SpawnEntityScript_OnActor(Actor, ScriptClass)\`** (CkEcsExt) — one-call replacement for the hand-rolled spawn-params + TransientEntity + HasAuthority boilerplate. Authority-gated and replication-correct in one place; BP-callable + \`ScriptMixin\` on AActor (AS: \`utils_entity_script_with_actor::...\` or \`Actor.Request_SpawnEntityScript_OnActor(...)\`).
- **"Ck Entity Script (With Actor)" component** — editor-addable, **non-replicated** thin subclass of the existing link component (one link holder either way): add component, pick an EntityScript class, done. \`None\` = passive link holder.
- **\`Promise_OnActorEcsReady\` policy param** — \`ValuesReplicated\` (new default: fires once linked AND OnReplicationComplete has fired, via a trampoline on the link component) / \`LinkEstablished\` (previous link-time behavior). Collapses to link-time on authority / non-replicated entities. Kills the OnConstructed-vs-OnReplicationComplete two-promise footgun for actor consumers.
- ActorRelay + IsmRenderer migrated to the helper; CLAUDE.md docs updated (Script + CkEcs).

## Verification

- Editor builds clean (Win64 Development).
- AngelScript compiles clean; generated wrapper \`utils_entity_script_with_actor.as\` confirmed.
- New multi-client PIE spec **Ck.OwningActor.Net.EcsReady_PromisePolicies** (companion CkTests PR): server queue-then-flush, client bind-before-arrival with values applied at fire, LinkEstablished with valid entity, synchronous bind-after-ready, one-shot semantics — **passing**.
- Existing **Ck.Attribute.Net.Values_AppliedBefore_OnReplicationComplete** still passing through the migrated harness.

Companion PR: chainkemists/CkTests \`feature/actor-ecs-ready-devex\` (specs + gym migrations). Merge this one first — the CkTests branch compiles against the new helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)