### PR TITLE
fix(CkInventory): split-off item inherits source tags before acceptance check

### DIFF
--- a/Source/CkInventory/Public/CkInventory/Inventory/CkInventory_Fragment_Data.h
+++ b/Source/CkInventory/Public/CkInventory/Inventory/CkInventory_Fragment_Data.h
@@ -638,6 +638,21 @@ DECLARE_DYNAMIC_DELEGATE_FourParams(
 
 // --------------------------------------------------------------------------------------------------------------------
 
+// Whether an AddItem request re-runs the inventory's acceptance check (Get_CanAcceptItem) before
+// placing the item. AlreadyValidated is an internal flag for a caller that already proved acceptance
+// against an equivalent item in the same synchronous pass: ExecuteTransfer's split branch validates
+// the SOURCE (whose runtime tags are committed) before minting the split-off copy, whose OnSplit tag
+// copy is a deferred request that has not drained when the add's check runs. It skips ONLY the
+// categorical acceptance recheck; placement / grid-space / dimensions checks still run.
+UENUM(BlueprintType)
+enum class ECk_AddAcceptance : uint8
+{
+    Validate,
+    AlreadyValidated
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 USTRUCT(BlueprintType)
 struct CKINVENTORY_API FCk_Request_Inventory_AddItem : public FCk_Request_Base
 {
@@ -652,8 +667,14 @@ private:
               meta = (AllowPrivateAccess = true))
     FCk_Handle_Item _ItemToAdd;
 
+    // Internal: AlreadyValidated lets ExecuteTransfer's split branch skip the redundant categorical
+    // acceptance recheck after it has validated the source item. Defaults to Validate; not editable.
+    UPROPERTY()
+    ECk_AddAcceptance _Acceptance = ECk_AddAcceptance::Validate;
+
 public:
     CK_PROPERTY_GET(_ItemToAdd);
+    CK_PROPERTY(_Acceptance);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Request_Inventory_AddItem, _ItemToAdd);

--- a/Source/CkInventory/Public/CkInventory/Inventory/CkInventory_RequestHandlers.cpp
+++ b/Source/CkInventory/Public/CkInventory/Inventory/CkInventory_RequestHandlers.cpp
@@ -78,16 +78,19 @@ namespace ck::inventory_handlers
         const auto Guard = ck::MakeRequestResultGuard<UUtils_Signal_Inventory_OnOperationResult_Add>(
             InRequest, [&]{ return MakePayload(Base, ItemHandle, R); });
 
-        R = UCk_Utils_Inventory_UE::Get_CanAcceptItem(Base, ItemHandle);
-        if (R != Result::Success)
+        if (InRequest.Get_Acceptance() == ECk_AddAcceptance::Validate)
         {
-            // Caller-attributable rejection (e.g. Failed_ItemAlreadyInInventory,
-            // Failed_RejectedByCustomAcceptanceLogic) — surface through the Result
-            // enum, log at Display so the AutoTest framework doesn't escalate the
-            // diagnostic to a test failure.
-            ck::inventory::Display(TEXT("AddItem: Failed [{}] for item [{}] in inventory [{}]"),
-                R, ItemHandle, InHandle);
-            return R;
+            R = UCk_Utils_Inventory_UE::Get_CanAcceptItem(Base, ItemHandle);
+            if (R != Result::Success)
+            {
+                // Caller-attributable rejection (e.g. Failed_ItemAlreadyInInventory,
+                // Failed_RejectedByCustomAcceptanceLogic) — surface through the Result
+                // enum, log at Display so the AutoTest framework doesn't escalate the
+                // diagnostic to a test failure.
+                ck::inventory::Display(TEXT("AddItem: Failed [{}] for item [{}] in inventory [{}]"),
+                    R, ItemHandle, InHandle);
+                return R;
+            }
         }
 
         UCk_Utils_Inventory_UE::RecordOfInventoryItems_Utils::Request_Connect(
@@ -520,10 +523,12 @@ namespace ck::inventory_handlers
                 InSource, FFragment_Inventory_Params{}, SourceRemoveEntry{Req});
         };
 
-        const auto DoAddToTarget = [&](FCk_Handle_Item ItemToAdd) -> ECk_Inventory_OperationResult_Add
+        const auto DoAddToTarget = [&](FCk_Handle_Item ItemToAdd,
+            ECk_AddAcceptance InAcceptance = ECk_AddAcceptance::Validate) -> ECk_Inventory_OperationResult_Add
         {
             using TargetAddEntry = typename TInventoryRequestTraits<TTargetHandle>::AddItem::Entry;
             FCk_Request_Inventory_AddItem Req{ItemToAdd};
+            Req.Set_Acceptance(InAcceptance);
             // Construct entry: with placement addon if Spatial, else default.
             if constexpr (std::is_same_v<typename TargetAddEntry::AddonType, FCk_SpatialPlacement>)
             {
@@ -614,6 +619,23 @@ namespace ck::inventory_handlers
         }
         else
         {
+            // The split copy below inherits the source's runtime tags via a DEFERRED OnSplit
+            // request, so the synchronous CATEGORICAL acceptance check (custom CanAcceptItem —
+            // tags / type / traits) would see the not-yet-copied tags and wrongly reject it. Decide
+            // that categorical question against the SOURCE (whose tags are committed) — the same
+            // Get_CanAcceptItem the Stock prompt runs on the held item — and skip only it on the
+            // copy. Abort ONLY on a categorical rejection: quantitative capacity is already clamped
+            // into TransferCount above (Get_AbsorbableUnits) and re-derived on the copy, so a NoSpace
+            // result must fall through to the normal partial-transfer path rather than abort it.
+            // Checked before touching the source stack so a rejection needs no rollback.
+            if (const auto SourceAccept = UCk_Utils_Inventory_UE::Get_CanAcceptItem(BaseTarget, InSourceItem);
+                SourceAccept == ECk_Inventory_OperationResult_Add::Failed_RejectedByCustomAcceptanceLogic)
+            {
+                ck::inventory::Display(TEXT("TransferItem: source [{}] categorically rejected by target [{}]; split skipped"),
+                    InSourceItem, InTarget);
+                return detail::MapAddResultToTransfer(SourceAccept);
+            }
+
             UCk_Utils_ItemTrait_Stackable_UE::Request_AdjustStackCount(InSourceItem, -MoveCount);
 
             auto TargetContextOwner = UCk_Utils_ContextOwner_UE::Get_ContextOwner(BaseTarget);
@@ -629,7 +651,9 @@ namespace ck::inventory_handlers
             Definition->OnSplit(InSourceItem, NewItem);
             UCk_Utils_ItemTrait_Stackable_UE::Request_OverrideStackCount(NewItem, MoveCount);
 
-            const auto AddResult = DoAddToTarget(NewItem);
+            // Acceptance already proven against the source above; skip the redundant categorical
+            // recheck on the not-yet-tag-copied split unit. Placement / grid-space checks still run.
+            const auto AddResult = DoAddToTarget(NewItem, ECk_AddAcceptance::AlreadyValidated);
 
             if (AddResult != ECk_Inventory_OperationResult_Add::Success)
             {

--- a/Source/CkInventory/Public/CkInventory/Inventory/Spatial/CkInventory_Spatial_RequestTraits.cpp
+++ b/Source/CkInventory/Public/CkInventory/Inventory/Spatial/CkInventory_Spatial_RequestTraits.cpp
@@ -45,16 +45,19 @@ namespace ck::inventory_handlers
         const auto Guard = ck::MakeRequestResultGuard<UUtils_Signal_Inventory_OnOperationResult_Add>(
             InRequest, [&]{ return MakePayload(Base, ItemHandle, R); });
 
-        R = UCk_Utils_Inventory_UE::Get_CanAcceptItem(Base, ItemHandle);
-        if (R != Result::Success)
+        if (InRequest.Get_Acceptance() == ECk_AddAcceptance::Validate)
         {
-            // Caller-attributable rejection (e.g. Failed_ItemAlreadyInInventory,
-            // Failed_RejectedByCustomAcceptanceLogic) — surface through the Result
-            // enum, log at Display so the AutoTest framework doesn't escalate the
-            // diagnostic to a test failure.
-            ck::inventory::Display(TEXT("AddItem_Spatial: Failed [{}] for item [{}] in inventory [{}]"),
-                R, ItemHandle, InHandle);
-            return R;
+            R = UCk_Utils_Inventory_UE::Get_CanAcceptItem(Base, ItemHandle);
+            if (R != Result::Success)
+            {
+                // Caller-attributable rejection (e.g. Failed_ItemAlreadyInInventory,
+                // Failed_RejectedByCustomAcceptanceLogic) — surface through the Result
+                // enum, log at Display so the AutoTest framework doesn't escalate the
+                // diagnostic to a test failure.
+                ck::inventory::Display(TEXT("AddItem_Spatial: Failed [{}] for item [{}] in inventory [{}]"),
+                    R, ItemHandle, InHandle);
+                return R;
+            }
         }
 
         if (NOT UCk_Utils_2dGridSystem_UE::Has(ItemHandle))


### PR DESCRIPTION
## Problem

A partial transfer (`DoTransfer` split branch) mints the split-off item from its definition and copies the source's **runtime** tags onto it via a **deferred** `OnSplit` request — but the target's acceptance check (`Get_CanAcceptItem`) runs **synchronously in the same call**. A runtime-tag-gated inventory therefore sees the not-yet-copied tag and refuses **every** split. Deterministic, not a race: entity-preserving whole-item moves are unaffected, which is why throwing/looting an item works but stocking a *stack* by direct interaction doesn't.

(Surfaced as the BusterBlock Rewind Station inbox refusing tapes stocked from a stack.)

## Fix

Decide the **categorical** acceptance against the **source** (whose tags are committed) before minting, then skip only that recheck on the copy via a new internal `ECk_AddAcceptance::AlreadyValidated` flag (defaults to `Validate`, so existing callers are unchanged). Quantitative capacity stays governed by the existing `Get_AbsorbableUnits` clamp, so partial-into-bound transfers still settle as `Success_Partial`. Tags remain deferred — no synchronous state mutation introduced.

Touches: `CkInventory_Fragment_Data.h` (enum + flag), `CkInventory_RequestHandlers.cpp` (split-branch pre-check + gated default add), `CkInventory_Spatial_RequestTraits.cpp` (gated spatial add).

## Verification

- Framework `Inventory` AutoTests: **41/41**.
- Deterministic A/B with a new regression test (`CkAutoTest_Inventory_SplitInheritsRuntimeTag`, lands in CkTests separately): **fails without this change** (`Failed_RejectedByCustomAcceptanceLogic`), **passes with it**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)