### PR TITLE
feat(CkInteraction/CkEcs): replicated interaction state machines via net-linked InteractTarget

### DIFF
--- a/Source/CkEcs/Public/CkEcs/EntityConstructionScript/CkEntity_ConstructionScript.h
+++ b/Source/CkEcs/Public/CkEcs/EntityConstructionScript/CkEntity_ConstructionScript.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "CkCore/Macros/CkMacros.h"
 #include "CkCore/Types/DataAsset/CkDataAsset.h"
 
 #include "CkEcs/Handle/CkHandle.h"
@@ -7,6 +8,29 @@
 #include <StructUtils/InstancedStruct.h>
 
 #include "CkEntity_ConstructionScript.generated.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ck
+{
+    // Carries an optional, by-value construction config (a typed payload wrapped in an FInstancedStruct)
+    // onto a freshly-built entity so a GENERIC construction script can read it instead of relying on a
+    // per-type subclass CDO. Stamped (when present) immediately before Construct on both host and client
+    // by the EntityReplicationDriver build loops, so the config rides replication via
+    // FCk_EntityReplicationDriver_ConstructionInfo::_ConstructionConfig.
+    struct CKECS_API FFragment_EntityConstructionConfig
+    {
+        CK_GENERATED_BODY(FFragment_EntityConstructionConfig);
+
+    private:
+        FInstancedStruct _Config;
+
+    public:
+        CK_PROPERTY_GET(_Config);
+
+        CK_DEFINE_CONSTRUCTORS(FFragment_EntityConstructionConfig, _Config);
+    };
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
+++ b/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Fragment.cpp
@@ -188,6 +188,9 @@ auto
 
     for (const auto& ConstructionInfo : ConstructionInfos)
     {
+        if (ConstructionInfo.Get_ConstructionConfig().IsValid())
+        { _AssociatedEntity.AddOrGet<ck::FFragment_EntityConstructionConfig>(ConstructionInfo.Get_ConstructionConfig()); }
+
         if (ck::IsValid(ConstructionInfo.Get_ConstructionScriptArchetype()))
         {
             ConstructionInfo.Get_ConstructionScriptArchetype()->Construct(_AssociatedEntity);

--- a/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.h
+++ b/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.h
@@ -8,6 +8,8 @@
 #include "CkEcs/EntityScript/CkEntityScript.h"
 #include "CkEcs/Request/CkRequest_Data.h"
 
+#include <StructUtils/InstancedStruct.h>
+
 #include "CkEntityReplicationDriver_Fragment_Data.generated.h"
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -29,9 +31,18 @@ private:
         meta=(AllowPrivateAccess=true))
     TObjectPtr<const UCk_Entity_ConstructionScript_PDA> _ConstructionScriptArchetype;
 
+    // Optional by-value recipe a GENERIC construction script reads (in lieu of a per-type subclass CDO).
+    // Net-translates because TSubclassOf/FGameplayTag inside the wrapped struct are net-stable — exactly
+    // like _SpawnParams on FCk_EntityReplicationDriver_ReplicationData_EntityScript. Empty by default; set
+    // via the generated setter, so existing callers are unaffected.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite,
+        meta=(AllowPrivateAccess=true))
+    FInstancedStruct _ConstructionConfig;
+
 public:
     CK_PROPERTY_GET(_ConstructionScript);
     CK_PROPERTY(_ConstructionScriptArchetype);
+    CK_PROPERTY(_ConstructionConfig);
 
     CK_DEFINE_CONSTRUCTORS(FCk_EntityReplicationDriver_ConstructionInfo, _ConstructionScript);
 };

--- a/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Utils.cpp
@@ -1,6 +1,7 @@
 #include "CkEntityReplicationDriver_Utils.h"
 
 #include "CkEcs/CkEcsLog.h"
+#include "CkEcs/EntityConstructionScript/CkEntity_ConstructionScript.h"
 #include "CkEcs/EntityScript/CkEntityScript_Utils.h"
 #include "CkEcs/OwningActor/CkOwningActor_Utils.h"
 
@@ -155,6 +156,9 @@ auto
 
     for (const auto& ConstructionInfo : InConstructionInfos)
     {
+        if (ConstructionInfo.Get_ConstructionConfig().IsValid())
+        { NewEntity.AddOrGet<ck::FFragment_EntityConstructionConfig>(ConstructionInfo.Get_ConstructionConfig()); }
+
         if (ck::IsValid(ConstructionInfo.Get_ConstructionScriptArchetype()))
         {
             ConstructionInfo.Get_ConstructionScriptArchetype()->Construct(NewEntity);

--- a/Source/CkInteraction/CkInteraction.Build.cs
+++ b/Source/CkInteraction/CkInteraction.Build.cs
@@ -25,7 +25,8 @@ public class CkInteraction : CkModuleRules
             "CkProvider",
             "CkRecord",
             "CkSettings",
-            "CkAttribute"
+            "CkAttribute",
+            "CkStateMachine"
         });
     }
 }

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.cpp
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.cpp
@@ -1,0 +1,49 @@
+#include "CkInteractTarget_ConstructionScript.h"
+
+#include "CkInteraction/InteractTarget/CkInteractTarget_Fragment.h"
+
+#include "CkLabel/CkLabel_Utils.h"
+
+#include "CkStateMachine/StateMachine/CkStateMachine_Utils.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_InteractTarget_ConstructionScript::
+    DoConstruct_Implementation(
+        FCk_Handle& InHandle) const
+    -> void
+{
+    // Mirrors UCk_Utils_InteractTarget_UE::Add's composition (minus the owner-side Record wiring, which
+    // the replication-built entity does not own — Add connects the Record on the authority), then folds
+    // the SM onto the SAME entity. CompletionPolicy rides separately because it is a private CK_PROPERTY
+    // a subclass `default` can't reach.
+    auto ParamsToUse = InteractTargetParams;
+    ParamsToUse.Set_CompletionPolicy(CompletionPolicy);
+
+    InHandle.Add<ck::FFragment_InteractTarget_Params>(ParamsToUse);
+    InHandle.Add<ck::FFragment_InteractTarget_Current>();
+    InHandle.Add<ck::FTag_InteractTarget_RequiresSetup>();
+
+    UCk_Utils_GameplayLabel_UE::Add(InHandle, ParamsToUse.Get_InteractionChannel());
+
+    // This construction script exists to NET-LINK the SM, so force Replicates regardless of the
+    // CDO-baked default (SmParams only needs to carry the root state class). Setup then creates the
+    // WithHistory container here because the entity has a driver (TryAdd in Request_BuildAndReplicate).
+    auto SmParamsToUse = SmParams;
+    SmParamsToUse.Set_Replication(ECk_Replication::Replicates);
+
+    // Register the per-target override states through params so FProcessor_Sm_Setup builds the same
+    // override table on the server and the client (the authority-only Request_AddOverrideState would be
+    // dropped — and ensure — on a non-authority client).
+    auto OverrideStates = TArray<TSubclassOf<UCk_SmState_EntityScript>>{};
+    if (ck::IsValid(InteractionStateClass))
+    { OverrideStates.Emplace(InteractionStateClass); }
+    if (ck::IsValid(FocusedStateClass))
+    { OverrideStates.Emplace(FocusedStateClass); }
+
+    if (NOT OverrideStates.IsEmpty())
+    { SmParamsToUse.Set_OverrideStates(OverrideStates); }
+
+    UCk_Utils_StateMachine_UE::Add(InHandle, SmParamsToUse);
+}

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.cpp
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.cpp
@@ -2,9 +2,60 @@
 
 #include "CkInteraction/InteractTarget/CkInteractTarget_Fragment.h"
 
+#include "CkEcs/EntityConstructionScript/CkEntity_ConstructionScript.h"
+
 #include "CkLabel/CkLabel_Utils.h"
 
 #include "CkStateMachine/StateMachine/CkStateMachine_Utils.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ck_interact_target_construction_script
+{
+    // Mirrors UCk_Utils_InteractTarget_UE::Add's composition (minus the owner-side Record wiring, which
+    // the replication-built entity does not own — Add connects the Record on the authority), then folds
+    // the SM onto the SAME entity. CompletionPolicy rides separately because it is a private CK_PROPERTY
+    // neither a subclass `default` nor an FInstancedStruct field can set on the params struct directly.
+    static auto
+        DoBuild(
+            FCk_Handle& InHandle,
+            const FCk_Fragment_InteractTarget_ParamsData& InInteractTargetParams,
+            ECk_Interaction_CompletionPolicy InCompletionPolicy,
+            const FCk_Fragment_StateMachine_ParamsData& InSmParams,
+            const TSubclassOf<UCk_SmState_EntityScript>& InInteractionStateClass,
+            const TSubclassOf<UCk_SmState_EntityScript>& InFocusedStateClass)
+        -> void
+    {
+        auto ParamsToUse = InInteractTargetParams;
+        ParamsToUse.Set_CompletionPolicy(InCompletionPolicy);
+
+        InHandle.Add<ck::FFragment_InteractTarget_Params>(ParamsToUse);
+        InHandle.Add<ck::FFragment_InteractTarget_Current>();
+        InHandle.Add<ck::FTag_InteractTarget_RequiresSetup>();
+
+        UCk_Utils_GameplayLabel_UE::Add(InHandle, ParamsToUse.Get_InteractionChannel());
+
+        // This construction script exists to NET-LINK the SM, so force Replicates regardless of the
+        // baked default (SmParams only needs to carry the root state class). Setup then creates the
+        // WithHistory container here because the entity has a driver (TryAdd in Request_BuildAndReplicate).
+        auto SmParamsToUse = InSmParams;
+        SmParamsToUse.Set_Replication(ECk_Replication::Replicates);
+
+        // Register the per-target override states through params so FProcessor_Sm_Setup builds the same
+        // override table on the server and the client (the authority-only Request_AddOverrideState would be
+        // dropped — and ensure — on a non-authority client).
+        auto OverrideStates = TArray<TSubclassOf<UCk_SmState_EntityScript>>{};
+        if (ck::IsValid(InInteractionStateClass))
+        { OverrideStates.Emplace(InInteractionStateClass); }
+        if (ck::IsValid(InFocusedStateClass))
+        { OverrideStates.Emplace(InFocusedStateClass); }
+
+        if (NOT OverrideStates.IsEmpty())
+        { SmParamsToUse.Set_OverrideStates(OverrideStates); }
+
+        UCk_Utils_StateMachine_UE::Add(InHandle, SmParamsToUse);
+    }
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -14,36 +65,20 @@ auto
         FCk_Handle& InHandle) const
     -> void
 {
-    // Mirrors UCk_Utils_InteractTarget_UE::Add's composition (minus the owner-side Record wiring, which
-    // the replication-built entity does not own — Add connects the Record on the authority), then folds
-    // the SM onto the SAME entity. CompletionPolicy rides separately because it is a private CK_PROPERTY
-    // a subclass `default` can't reach.
-    auto ParamsToUse = InteractTargetParams;
-    ParamsToUse.Set_CompletionPolicy(CompletionPolicy);
+    // Prefer the by-value config stamped on the entity (the GENERIC-recipe path: one shared CDO + a
+    // replicated FCk_InteractTarget_ConstructionConfig). Falls back to this instance's CDO fields when no
+    // config is present, so existing per-type subclasses build byte-identically to before.
+    if (InHandle.Has<ck::FFragment_EntityConstructionConfig>())
+    {
+        if (const auto* Config = InHandle.Get<ck::FFragment_EntityConstructionConfig>().Get_Config()
+                .GetPtr<FCk_InteractTarget_ConstructionConfig>())
+        {
+            ck_interact_target_construction_script::DoBuild(InHandle, Config->InteractTargetParams,
+                Config->CompletionPolicy, Config->SmParams, Config->InteractionStateClass, Config->FocusedStateClass);
+            return;
+        }
+    }
 
-    InHandle.Add<ck::FFragment_InteractTarget_Params>(ParamsToUse);
-    InHandle.Add<ck::FFragment_InteractTarget_Current>();
-    InHandle.Add<ck::FTag_InteractTarget_RequiresSetup>();
-
-    UCk_Utils_GameplayLabel_UE::Add(InHandle, ParamsToUse.Get_InteractionChannel());
-
-    // This construction script exists to NET-LINK the SM, so force Replicates regardless of the
-    // CDO-baked default (SmParams only needs to carry the root state class). Setup then creates the
-    // WithHistory container here because the entity has a driver (TryAdd in Request_BuildAndReplicate).
-    auto SmParamsToUse = SmParams;
-    SmParamsToUse.Set_Replication(ECk_Replication::Replicates);
-
-    // Register the per-target override states through params so FProcessor_Sm_Setup builds the same
-    // override table on the server and the client (the authority-only Request_AddOverrideState would be
-    // dropped — and ensure — on a non-authority client).
-    auto OverrideStates = TArray<TSubclassOf<UCk_SmState_EntityScript>>{};
-    if (ck::IsValid(InteractionStateClass))
-    { OverrideStates.Emplace(InteractionStateClass); }
-    if (ck::IsValid(FocusedStateClass))
-    { OverrideStates.Emplace(FocusedStateClass); }
-
-    if (NOT OverrideStates.IsEmpty())
-    { SmParamsToUse.Set_OverrideStates(OverrideStates); }
-
-    UCk_Utils_StateMachine_UE::Add(InHandle, SmParamsToUse);
+    ck_interact_target_construction_script::DoBuild(InHandle, InteractTargetParams, CompletionPolicy, SmParams,
+        InteractionStateClass, FocusedStateClass);
 }

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.h
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.h
@@ -13,6 +13,39 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
+// By-value recipe for a NET-LINKED InteractTarget whose interaction SM replicates, carried inside an
+// FInstancedStruct via FCk_EntityReplicationDriver_ConstructionInfo::_ConstructionConfig so the GENERIC
+// UCk_InteractTarget_ConstructionScript can build from it — no per-type subclass CDO required. Mirrors the
+// five CDO recipe fields below; net-stable because TSubclassOf / FGameplayTag inside it net-translate. When
+// present on the built entity (as ck::FFragment_EntityConstructionConfig), DoConstruct reads THESE instead
+// of the CDO fields, leaving existing subclass-CDO callers byte-identical.
+USTRUCT(BlueprintType)
+struct CKINTERACTION_API FCk_InteractTarget_ConstructionConfig
+{
+    GENERATED_BODY()
+
+public:
+    CK_GENERATED_BODY(FCk_InteractTarget_ConstructionConfig);
+
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    FCk_Fragment_InteractTarget_ParamsData InteractTargetParams;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    ECk_Interaction_CompletionPolicy CompletionPolicy = ECk_Interaction_CompletionPolicy::Timed;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    FCk_Fragment_StateMachine_ParamsData SmParams;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    TSubclassOf<UCk_SmState_EntityScript> InteractionStateClass;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    TSubclassOf<UCk_SmState_EntityScript> FocusedStateClass;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 // The construction-script recipe for a NET-LINKED InteractTarget whose interaction SM replicates.
 // It composes the InteractTarget's (C++-internal) fragments AND a replicated SM onto the SAME entity.
 // Built via Request_BuildAndReplicate from a driver-bearing owner so the InteractTarget gets its own

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.h
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "CkEcs/EntityConstructionScript/CkEntity_ConstructionScript.h"
+
+#include "CkInteraction/InteractTarget/CkInteractTarget_Fragment_Data.h"
+
+#include "CkStateMachine/StateMachine/CkStateMachine_Fragment_Data.h"
+// Full definition (not just the forward decl in _Fragment_Data.h) is required: the scalar
+// TSubclassOf<UCk_SmState_EntityScript> UPROPERTYs below make UHT emit UCk_SmState_EntityScript::StaticClass().
+#include "CkStateMachine/State/EntityScripts/CkSmState_EntityScript.h"
+
+#include "CkInteractTarget_ConstructionScript.generated.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// The construction-script recipe for a NET-LINKED InteractTarget whose interaction SM replicates.
+// It composes the InteractTarget's (C++-internal) fragments AND a replicated SM onto the SAME entity.
+// Built via Request_BuildAndReplicate from a driver-bearing owner so the InteractTarget gets its own
+// replication driver (TryAdd) — which is exactly what FProcessor_Sm_Setup's TryAddContainerFragment
+// needs to create the SM's WithHistory container server-side. The stored ConstructionInfos then
+// rebuild InteractTarget+SM on the client, where the replicated history applies via the rep handler.
+//
+// The framework names no game-specific state class: the SM root + per-target override states ride in
+// via SmParams / the override-class fields. Callers bake config into a SUBCLASS CDO and pass the CLASS
+// (not a transient archetype) to Request_BuildAndReplicate — the class is net-stable, so the client
+// rebuilds IT+SM from the same CDO. A runtime-NewObject archetype would serialize as null on the
+// client (no netGUID) and the client would fall back to the empty-CDO else-branch, silently dropping
+// the SM. AngelScript subclasses set these via `default ... = ...;` (no DoConstruct override needed):
+// the scalar fields exist because `default` can populate neither a struct's private CK_PROPERTY
+// sub-field (CompletionPolicy) nor a TArray (override states) — DoConstruct assembles them.
+UCLASS(BlueprintType, Blueprintable, EditInlineNew)
+class CKINTERACTION_API UCk_InteractTarget_ConstructionScript : public UCk_Entity_ConstructionScript_PDA
+{
+    GENERATED_BODY()
+
+public:
+    CK_GENERATED_BODY(UCk_InteractTarget_ConstructionScript);
+
+public:
+    auto
+    DoConstruct_Implementation(
+        FCk_Handle& InHandle) const -> void override;
+
+public:
+    // Public + non-underscore on purpose: AngelScript subclasses CDO-bake these via `default`. Not the
+    // usual private+CK_PROPERTY shape because they must be settable from script defaults.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    FCk_Fragment_InteractTarget_ParamsData InteractTargetParams;
+
+    // _CompletionPolicy is a private CK_PROPERTY on the params struct, so a subclass `default` can't
+    // reach it. Carry it as a scalar and apply it onto a copy of InteractTargetParams in DoConstruct.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    ECk_Interaction_CompletionPolicy CompletionPolicy = ECk_Interaction_CompletionPolicy::Timed;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    FCk_Fragment_StateMachine_ParamsData SmParams;
+
+    // Per-target override states folded into SmParams.OverrideStates (symmetric build on every machine).
+    // Scalar (not a TArray) because a subclass `default` can't populate an array sub-field.
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    TSubclassOf<UCk_SmState_EntityScript> InteractionStateClass;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "InteractTarget")
+    TSubclassOf<UCk_SmState_EntityScript> FocusedStateClass;
+};
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.cpp
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.cpp
@@ -51,6 +51,7 @@ auto
         const FCk_Fragment_InteractTarget_ParamsData& InParams,
         ECk_Replication InReplicates,
         TSubclassOf<UCk_InteractTarget_ConstructionScript> InReplicatedConstructionScript,
+        const FInstancedStruct& InConstructionConfig,
         const UObject* InWorldContextObject)
     -> FCk_Handle_InteractTarget
 {
@@ -71,7 +72,10 @@ auto
         if (auto DriverOwner = ck_interact_target::DoFind_DriverBearingOwner(InInteractTargetOwner);
             ck::IsValid(DriverOwner))
         {
-            const auto CtorInfo = FCk_EntityReplicationDriver_ConstructionInfo{InReplicatedConstructionScript};
+            // Carry the optional by-value recipe so the GENERIC UCk_InteractTarget_ConstructionScript can
+            // build from it on both host and client; empty config => the supplied subclass CDO is used.
+            const auto CtorInfo = FCk_EntityReplicationDriver_ConstructionInfo{InReplicatedConstructionScript}
+                .Set_ConstructionConfig(InConstructionConfig);
             auto NewReplicatedTarget = UCk_Utils_EntityReplicationDriver_UE::Request_BuildAndReplicate(DriverOwner, CtorInfo);
 
             if (ck::Is_NOT_Valid(NewReplicatedTarget))
@@ -130,7 +134,7 @@ auto
     return ck::algo::Transform<TArray<FCk_Handle_InteractTarget>>(
         InParams.Get_InteractTargetParams(), [&](const FCk_Fragment_InteractTarget_ParamsData& InParam)
     {
-        return Add(InInteractTargetOwner, InParam, InReplicates, nullptr, InWorldContextObject);
+        return Add(InInteractTargetOwner, InParam, InReplicates, nullptr, FInstancedStruct{}, InWorldContextObject);
     });
 }
 

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.cpp
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.cpp
@@ -1,9 +1,46 @@
 #include "CkInteractTarget_Utils.h"
 
 #include "CkInteraction/InteractTarget/CkInteractTarget_Fragment.h"
+#include "CkInteraction/InteractTarget/CkInteractTarget_ConstructionScript.h"
 #include "CkInteraction/CkInteraction_Log.h"
 #include "CkInteraction/InteractSource/CkInteractSource_Utils.h"
 #include "CkInteraction/Interaction/CkInteraction_Utils.h"
+
+#include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
+#include "CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Utils.h"
+#include "CkEcs/Net/EntityReplicationDriver/CkEntityReplicationDriver_Fragment_Data.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ck_interact_target
+{
+    // Walk the lifetime chain from InStart (inclusive) to the nearest entity that owns a replication
+    // driver — the only valid owner for Request_BuildAndReplicate. The InteractTarget owner handed to
+    // Add (e.g. an Interactable probe-node) usually has none; its replicated ancestor (the entity-script
+    // root) does. Guards against a malformed/cyclic chain (Get_LifetimeOwner returns self at the root).
+    static auto
+        DoFind_DriverBearingOwner(
+            const FCk_Handle& InStart)
+        -> FCk_Handle
+    {
+        auto Current = InStart;
+        auto Guard = 0;
+
+        while (ck::IsValid(Current) && Guard++ < 64)
+        {
+            if (UCk_Utils_EntityReplicationDriver_UE::Has(Current))
+            { return Current; }
+
+            const auto Owner = UCk_Utils_EntityLifetime_UE::Get_LifetimeOwner(Current);
+            if (Owner == Current)
+            { break; }
+
+            Current = Owner;
+        }
+
+        return {};
+    }
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -13,9 +50,47 @@ auto
         FCk_Handle& InInteractTargetOwner,
         const FCk_Fragment_InteractTarget_ParamsData& InParams,
         ECk_Replication InReplicates,
+        TSubclassOf<UCk_InteractTarget_ConstructionScript> InReplicatedConstructionScript,
         const UObject* InWorldContextObject)
     -> FCk_Handle_InteractTarget
 {
+    // Replicated path: a supplied construction-script class is the REAL opt-in (not the InReplicates
+    // enum, whose default is Replicates and is relied on by every plain caller). When set, net-link the
+    // InteractTarget via Request_BuildAndReplicate so its construction-script-folded SM replicates. The
+    // class — net-stable — is the recipe the client re-runs to rebuild IT+SM; a runtime archetype would
+    // null out on the client. Build under the nearest driver-bearing ancestor; the host returns a valid
+    // InteractTarget, the client returns invalid (build is host-only) and receives the replicated copy.
+    if (InReplicates == ECk_Replication::Replicates && ck::IsValid(InReplicatedConstructionScript))
+    {
+        // Host-only build. On a client this Add runs again during the entity-script reconstruction, but
+        // the replicated InteractTarget arrives via replication — building a local duplicate here would
+        // shadow it. Return invalid so the caller skips local wiring and waits for the replicated copy.
+        if (NOT UCk_Utils_Net_UE::Get_IsEntityNetMode_Host(InInteractTargetOwner))
+        { return {}; }
+
+        if (auto DriverOwner = ck_interact_target::DoFind_DriverBearingOwner(InInteractTargetOwner);
+            ck::IsValid(DriverOwner))
+        {
+            const auto CtorInfo = FCk_EntityReplicationDriver_ConstructionInfo{InReplicatedConstructionScript};
+            auto NewReplicatedTarget = UCk_Utils_EntityReplicationDriver_UE::Request_BuildAndReplicate(DriverOwner, CtorInfo);
+
+            if (ck::Is_NOT_Valid(NewReplicatedTarget))
+            { return {}; }
+
+            auto NewReplicatedTargetTyped = Cast(NewReplicatedTarget);
+
+            // Connect into the owner's Record (lifetime-independent) so Get_AllInteractTargets finds it —
+            // the target was built under DriverOwner, not necessarily under InInteractTargetOwner.
+            RecordOfInteractTargets_Utils::AddIfMissing(InInteractTargetOwner, ECk_Record_EntryHandlingPolicy::Default);
+            RecordOfInteractTargets_Utils::Request_Connect(InInteractTargetOwner, NewReplicatedTargetTyped);
+
+            return NewReplicatedTargetTyped;
+        }
+
+        ck::interaction::Warning(TEXT("InteractTarget replication requested for owner [{}] but no driver-bearing "
+            "entity exists in its lifetime chain — falling back to a non-replicated InteractTarget."), InInteractTargetOwner);
+    }
+
     auto NewInteractTargetEntity = UCk_Utils_EntityLifetime_UE::Request_CreateEntity_AsTypeSafe<FCk_Handle_InteractTarget>(InInteractTargetOwner);
 
     auto FixedParams = InParams;
@@ -55,7 +130,7 @@ auto
     return ck::algo::Transform<TArray<FCk_Handle_InteractTarget>>(
         InParams.Get_InteractTargetParams(), [&](const FCk_Fragment_InteractTarget_ParamsData& InParam)
     {
-        return Add(InInteractTargetOwner, InParam, InReplicates, InWorldContextObject);
+        return Add(InInteractTargetOwner, InParam, InReplicates, nullptr, InWorldContextObject);
     });
 }
 

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.h
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.h
@@ -14,6 +14,10 @@
 
 // --------------------------------------------------------------------------------------------------------------------
 
+class UCk_InteractTarget_ConstructionScript;
+
+// --------------------------------------------------------------------------------------------------------------------
+
 UCLASS(NotBlueprintable, Meta = (ScriptMixin = "FCk_Handle_InteractTarget"))
 class CKINTERACTION_API UCk_Utils_InteractTarget_UE :  public UBlueprintFunctionLibrary
 {
@@ -36,6 +40,7 @@ public:
         UPARAM(ref) FCk_Handle& InInteractTargetOwner,
         const FCk_Fragment_InteractTarget_ParamsData& InParams,
         ECk_Replication InReplicates = ECk_Replication::Replicates,
+        TSubclassOf<UCk_InteractTarget_ConstructionScript> InReplicatedConstructionScript = nullptr,
         const UObject* InWorldContextObject = nullptr);
 
     UFUNCTION(BlueprintCallable,

--- a/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.h
+++ b/Source/CkInteraction/Public/CkInteraction/InteractTarget/CkInteractTarget_Utils.h
@@ -41,6 +41,7 @@ public:
         const FCk_Fragment_InteractTarget_ParamsData& InParams,
         ECk_Replication InReplicates = ECk_Replication::Replicates,
         TSubclassOf<UCk_InteractTarget_ConstructionScript> InReplicatedConstructionScript = nullptr,
+        const FInstancedStruct& InConstructionConfig = FInstancedStruct(),
         const UObject* InWorldContextObject = nullptr);
 
     UFUNCTION(BlueprintCallable,

--- a/Source/CkInteraction/Public/CkInteraction/InteractionResolver/CkInteractionResolver_Fragment_Data.cpp
+++ b/Source/CkInteraction/Public/CkInteraction/InteractionResolver/CkInteractionResolver_Fragment_Data.cpp
@@ -1,7 +1,8 @@
 #include "CkInteractionResolver_Fragment_Data.h"
 
-#include <NativeGameplayTags.h>
-
 // --------------------------------------------------------------------------------------------------------------------
 
-UE_DEFINE_GAMEPLAY_TAG_STATIC(TAG_Label_InteractionChannel, TEXT("InteractionChannel"));
+// NOTE: TAG_Label_InteractionChannel ("InteractionChannel") is registered by the Interaction core
+// (CkInteraction_Fragment_Data.cpp). The duplicate UE_DEFINE_GAMEPLAY_TAG_STATIC that used to live here
+// was dead (registration side-effect only, never referenced) and collided with the core definition under
+// unity builds (C2374) — removed. The tag is still registered exactly once, module-wide.

--- a/Source/CkStateMachine/Public/CkStateMachine/StateMachine/CkStateMachine_Fragment.h
+++ b/Source/CkStateMachine/Public/CkStateMachine/StateMachine/CkStateMachine_Fragment.h
@@ -236,6 +236,7 @@ namespace ck
     public:
         CK_GENERATED_BODY(FFragment_Sm_StateOverrides);
 
+        friend class FProcessor_Sm_Setup;
         friend class FProcessor_Sm_HandleRequests;
         friend class ::UCk_Utils_StateMachine_UE;
         friend class ::UCk_Utils_SmState_UE;

--- a/Source/CkStateMachine/Public/CkStateMachine/StateMachine/CkStateMachine_Fragment_Data.h
+++ b/Source/CkStateMachine/Public/CkStateMachine/StateMachine/CkStateMachine_Fragment_Data.h
@@ -236,12 +236,28 @@ private:
                 EditCondition = "_Replication == ECk_Replication::Replicates"))
     ECk_Sm_ReplicationModel _ReplicationModel = ECk_Sm_ReplicationModel::WithHistory;
 
+    // Construct-time, SYMMETRIC override registration. Registered into
+    // FFragment_Sm_StateOverrides by FProcessor_Sm_Setup on EVERY machine (not just
+    // the authority), so a Replicates SM resolves and fingerprints states identically
+    // server-side and client-side. This is the replication-safe alternative to the
+    // authority-only runtime Request_AddOverrideState, which a non-authority client
+    // can't enqueue (single-authority rule) and which never lands on the wire.
+    //
+    // Deliberately NOT SaveGame: FFragment_Sm_StateOverrides owns its own snapshot
+    // restore (its SerializeSnapshot), so persisting here too would double-register on
+    // the restore-redrive's re-run of Setup. Construct-time population is unaffected
+    // (the field is set in-memory by Add, not via serialization).
+    UPROPERTY(EditAnywhere, BlueprintReadWrite,
+        meta = (AllowPrivateAccess = true))
+    TArray<TSubclassOf<UCk_SmState_EntityScript>> _OverrideStates;
+
 public:
     CK_PROPERTY_GET(_InitialStateClass);
     CK_PROPERTY(_AutoStart);
     CK_PROPERTY(_Replication);
     CK_PROPERTY(_AuthorityModel);
     CK_PROPERTY(_ReplicationModel);
+    CK_PROPERTY(_OverrideStates);
 
 public:
     CK_DEFINE_CONSTRUCTORS(FCk_Fragment_StateMachine_ParamsData, _InitialStateClass);

--- a/Source/CkStateMachine/Public/CkStateMachine/StateMachine/CkStateMachine_Processor.cpp
+++ b/Source/CkStateMachine/Public/CkStateMachine/StateMachine/CkStateMachine_Processor.cpp
@@ -79,6 +79,32 @@ namespace ck
             }
         }
 
+        // Symmetric override registration (replication-safe path). Mirrors the runtime
+        // DoHandleRequest(FCk_Request_Sm_AddOverrideState) handler below but WITHOUT the
+        // single-authority gate — that omission is the whole point: every machine (server +
+        // clients) must build the same override table so a Replicates SM resolves and
+        // fingerprints states identically. Setup RunBefore HandleRequests, so the table is in
+        // place before the first Get_ResolvedStateClass (the Start handler's DoEnterState).
+        // _OverrideStates is non-SaveGame, so a restore-redrive re-run of Setup sees it empty and
+        // leaves the snapshot-restored FFragment_Sm_StateOverrides untouched. Empty params (the
+        // default / opt-out path) skip the block entirely — non-opted-in SMs are byte-identical.
+        for (const auto& OverrideClass : InParams.Get_OverrideStates())
+        {
+            if (ck::Is_NOT_Valid(OverrideClass))
+            { continue; }
+
+            const auto* CDO = OverrideClass->GetDefaultObject<UCk_SmState_EntityScript>();
+            const auto StatesToOverride = CDO->Get_StatesToOverride();
+
+            CK_ENSURE_IF_NOT(StatesToOverride.Num() > 0,
+                TEXT("SM [{}] params _OverrideStates class [{}] returns empty Get_StatesToOverride()"),
+                InHandle, *OverrideClass->GetName())
+            { continue; }
+
+            auto& Overrides = InHandle.AddOrGet<FFragment_Sm_StateOverrides>();
+            Overrides._Overrides.Add(FFragment_Sm_StateOverrides::FEntry{OverrideClass, StatesToOverride});
+        }
+
         if (InParams.Get_AutoStart() == ECk_SmAutoStart::OnSetup)
         {
             auto& Requests = InHandle.AddOrGet<FFragment_Sm_Requests>();
@@ -626,8 +652,18 @@ namespace ck
                 // and clients can verify on commit. On the very first instantiation of a class
                 // anywhere in this process, the lookup returns 0; the Construct backfill path
                 // (DoBackfillFingerprintToRepData) cleans up that single zero asynchronously.
+                //
+                // RESOLVE the override before the cache lookup: TargetStateClass is the REQUESTED
+                // (base) class, but DoEnterState spawns the override-RESOLVED class, whose Construct
+                // caches the fingerprint under the override's name. Publishing the base's hash for an
+                // overridden state ships the wrong expectation — the receiving client computes the
+                // override's hash locally and determinism-faults on the mismatch. Resolving here makes
+                // the published fingerprint describe the state actually entered. (Non-overridden states:
+                // Get_ResolvedStateClass returns the input unchanged, so this is a no-op for them.)
+                const auto ResolvedTargetStateClass =
+                    UCk_Utils_SmState_UE::Get_ResolvedStateClass(InHandle, TargetStateClass);
                 auto NewStateFingerprint =
-                    UCk_SmState_EntityScript::Get_CachedFingerprint(TargetStateClass);
+                    UCk_SmState_EntityScript::Get_CachedFingerprint(ResolvedTargetStateClass);
 
 #if WITH_DEV_AUTOMATION_TESTS
                 // Test-only fake-fingerprint injection (spec §13 tests 8 + 9). When armed via


### PR DESCRIPTION
Enables an interactable's interaction state machine to **replicate** to clients (debugger-visible) — the foundation BusterBlock's MP store-manager / held-station work builds on. Rebased onto `dev`; additive + backward-compatible.

### Commits
- **feat(statemachine): params-based symmetric override-state registration** — register a SM's override states through `FCk_Fragment_StateMachine_ParamsData` so `FProcessor_Sm_Setup` builds the same override table on every machine, instead of the authority-only runtime `Request_AddOverrideState` (which a client drops/ensures). Prereq for replicating any override-bearing SM.
- **feat(CkInteraction): InteractTarget interaction-SM replication recipe** — a net-linked InteractTarget (own rep driver via `Request_BuildAndReplicate` + a construction-script recipe) replicates its interaction SM server→client.
- **fix(CkInteraction): dedup duplicate InteractionChannel tag (unity C2374)**.
- **feat(CkEcs): by-value construction config — generic InteractTarget recipe** — the recipe (channel + completion + SM root + override-state classes) rides by value via an `FInstancedStruct` on `FCk_EntityReplicationDriver_ConstructionInfo`, stamped as `FFragment_EntityConstructionConfig` before Construct. Removes the need for a per-feature `UCk_InteractTarget_ConstructionScript` subclass; the generic script reads the config (CDO-field fallback keeps existing subclasses byte-identical).

### Verification
Built clean (Development editor). 2-player PIE + listen-server: net-linked InteractTarget replicates its SM, the interaction SM replays on the client, no real-PIE regressions. Replicating CkInteraction's `Interaction`/source itself remains deferred (handle net-translation; sidestepped by the consuming project).

### Test coverage
The statemachine override-registration AutoTest ships in a companion CkTests PR.