### PR TITLE
feat: optional gamma-correction toggle on RenderWidgetToTexture

### DIFF
--- a/Source/CkUI/Public/CkUI/WidgetRasterizer/CkWidgetRasterizer_Utils.cpp
+++ b/Source/CkUI/Public/CkUI/WidgetRasterizer/CkWidgetRasterizer_Utils.cpp
@@ -29,7 +29,8 @@ auto
     UCk_Utils_WidgetRasterizer_UE::
     RenderWidgetToTexture(
         UUserWidget* InWidget,
-        FIntPoint InRenderSize)
+        FIntPoint InRenderSize,
+        ECk_WidgetRasterizer_GammaCorrection InGammaCorrection)
     -> UTexture2D*
 {
     if (ck::Is_NOT_Valid(InWidget))
@@ -52,10 +53,11 @@ auto
     RenderTarget->UpdateResourceImmediate(true);
 
     // ---- Widget renderer + headless virtual window ----
-    // bUseGammaCorrection=true matches the legacy BB cover generator; the art
-    // reads correctly with the RT left in sRGB and the texture marked SRGB.
+    // The RT is left sRGB (encodes on write). With GammaCorrection::Enabled the renderer ALSO
+    // encodes, double-applying gamma (washed-out); Disabled lets the sRGB RT do the single encode.
 
-    FWidgetRenderer* WidgetRenderer = new FWidgetRenderer(/*bUseGammaCorrection*/ true);
+    const auto UseGammaCorrection = InGammaCorrection == ECk_WidgetRasterizer_GammaCorrection::Enabled;
+    FWidgetRenderer* WidgetRenderer = new FWidgetRenderer(UseGammaCorrection);
     if (WidgetRenderer == nullptr)
     { return nullptr; }
 

--- a/Source/CkUI/Public/CkUI/WidgetRasterizer/CkWidgetRasterizer_Utils.h
+++ b/Source/CkUI/Public/CkUI/WidgetRasterizer/CkWidgetRasterizer_Utils.h
@@ -13,6 +13,21 @@ class UTexture2D;
 
 // --------------------------------------------------------------------------------------------------------------------
 
+UENUM(BlueprintType)
+enum class ECk_WidgetRasterizer_GammaCorrection : uint8
+{
+    // Renderer applies gamma correction (linear->sRGB). Correct when the render target is left
+    // linear; against an sRGB render target it double-encodes (washes the result out). Default
+    // to preserve existing callers.
+    Enabled,
+
+    // Renderer skips gamma correction — the source widget's sRGB art is drawn as-is so the sRGB
+    // render target does the single encode. Use this when Enabled looks washed-out / too light.
+    Disabled
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 /**
  * Off-screen UMG widget -> transient UTexture2D rasterizer (no viewport needed).
  *
@@ -51,7 +66,8 @@ public:
     static UTexture2D*
     RenderWidgetToTexture(
         UUserWidget* InWidget,
-        FIntPoint InRenderSize);
+        FIntPoint InRenderSize,
+        ECk_WidgetRasterizer_GammaCorrection InGammaCorrection = ECk_WidgetRasterizer_GammaCorrection::Enabled);
 
     /** Whether widget rasterization can run on this process (real RHI + Slate renderer present). */
     UFUNCTION(BlueprintPure,


### PR DESCRIPTION
Add ECk_WidgetRasterizer_GammaCorrection (Enabled/Disabled) param to RenderWidgetToTexture. Default Enabled preserves existing callers; Disabled skips the renderer's gamma so an sRGB render target single-encodes instead of double-encoding (washed-out result).