### PR TITLE
fix(CkInventory): honor CanStackWith on the implicit stack-fill path

### DIFF
--- a/Source/CkInventory/Public/CkInventory/ItemTrait/Stackable/CkItemTrait_Stackable_Utils.cpp
+++ b/Source/CkInventory/Public/CkInventory/ItemTrait/Stackable/CkItemTrait_Stackable_Utils.cpp
@@ -385,6 +385,15 @@ auto
         if (UCk_Utils_Item_UE::Get_Definition(ExistingItem) != InDefinition)
         { continue; }
 
+        // Mirror the trait-level stack-compatibility gate that Get_CanStackItems applies on the
+        // explicit StackItems path. Same-definition items can still be unstackable when a trait
+        // distinguishes runtime state (e.g. the Tags trait — VHS rewound vs NotRewound). Without
+        // this, AddByDefinition / Transfer pre-fill silently merges items that a direct StackItems
+        // request would reject. InSourceItem is invalid for definition-driven fills (AddByDefinition),
+        // which have no runtime source to compare — gate only when it is valid.
+        if (ck::IsValid(InSourceItem) && NOT InDefinition->CanStackWith(InSourceItem, ExistingItem))
+        { continue; }
+
         // The inventory's custom stack hooks must also gate this fill path — otherwise a
         // per-inventory stacking restriction is enforced on direct StackItems requests but
         // silently bypassed by AddByDefinition / Transfer pre-fill. InSourceItem may be invalid


### PR DESCRIPTION
## Problem

In BusterBlock, picking up an **unrewound** VHS tape merged it into a **rewound** stack of the same title (and vice versa). A same-title tape is a single `UCk_InventoryItem_Definition`; rewound/unrewound is a runtime gameplay tag (`Product.Movie.State.VHS.NotRewound`) on the item's `UCk_ItemTrait_Tags` TagSet (absent = rewound). They should never stack together.

## Root cause

Two stacking-decision paths disagreed:

- **Explicit** — `Request_StackItems` → `Get_CanStackItems` → `Definition->CanStackWith()` → iterates traits → `UCk_ItemTrait_Tags::DoCanStackWith` compares the runtime TagSet. Correctly **blocks** rewound vs unrewound.
- **Implicit** — `Request_FillExistingStacks` (the `DoTransfer` pre-fill, and the `AddByDefinition` pre-fill) matched existing stacks by **definition only** plus the custom stack hook — it never called `CanStackWith()`. The transfer `_Policy` defaults to `PreferStacking` and the pickup/loot paths use it, so differently-tagged same-definition items silently merged on pickup.

The fill path had already been taught to mirror the *custom* stack hook (with a comment calling out the StackItems-vs-fill asymmetry), but the trait-level `CanStackWith()` gate was never mirrored alongside it.

## Fix

Mirror the `CanStackWith()` gate in `Request_FillExistingStacks`, beside the existing custom-hook gate:

```cpp
if (ck::IsValid(InSourceItem) && NOT InDefinition->CanStackWith(InSourceItem, ExistingItem))
{ continue; }
```

`InSourceItem` is invalid for definition-driven `AddByDefinition` fills (no runtime source item to compare), so the gate is skipped there — that path's born-default-tag edge case is a separate, lower-priority follow-up.

## Verification

- Built the BusterBlock editor (Development) — compiles clean.
- Added a BusterBlock AutoTest, `Bb_AutoTest_ItemStacking_RewoundUnrewoundNoMerge`, that transfers an unrewound tape into an inventory holding a rewound tape of the same title with `PreferStacking` and asserts they remain **two** separate entries (stack count 1 each). **Passes** with this fix. (The BusterBlock-side test commit lands separately once BusterBlock `dev` is current — it carries generated wrapper + map + tag artifacts.)
- The full BB AutoTest suite's other failures are pre-existing StoreDriver-bringup timeouts (reproduced deterministically in isolation), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
