### PR TITLE
fix(shipping): guard editor-only AS debugger + ensure machinery for Test/Shipping

### DIFF
--- a/Source/CkCore/Public/CkCore/AngelScript/CkAngelscriptDebugger.h
+++ b/Source/CkCore/Public/CkCore/AngelScript/CkAngelscriptDebugger.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#if WITH_ANGELSCRIPT_CK
+// FAngelscriptManager::DebugServer exists only when the engine's WITH_AS_DEBUGSERVER is
+// set — i.e. (!UE_BUILD_TEST && !UE_BUILD_SHIPPING). Mirror that condition here (using the
+// always-defined core build macros so we don't depend on include order) so this header
+// compiles in Test/Shipping, where the AngelScript debug server is stripped.
+#if WITH_ANGELSCRIPT_CK && !UE_BUILD_SHIPPING && !UE_BUILD_TEST
 #include <AngelscriptCode/Private/Debugging/AngelscriptDebugServer.h>
 #endif
 
@@ -18,7 +22,7 @@ namespace ck
         Is_AngelscriptDebugger_Paused()
         -> bool
     {
-    #if WITH_ANGELSCRIPT_CK
+    #if WITH_ANGELSCRIPT_CK && !UE_BUILD_SHIPPING && !UE_BUILD_TEST
         auto* DebugServer = FAngelscriptManager::Get().DebugServer;
         return DebugServer != nullptr && DebugServer->bIsDebugging && DebugServer->bIsPaused;
     #else

--- a/Source/CkCore/Public/CkCore/Ensure/CkEnsure_Utils.cpp
+++ b/Source/CkCore/Public/CkCore/Ensure/CkEnsure_Utils.cpp
@@ -65,40 +65,7 @@ auto
       ck::ensure::Do_Pop_EnsureIsFromScript();
     };
 
-    if (![&]() -> bool
-    {
-        const auto ExpressionResult = InExpression;
-        if ((!!(ExpressionResult)))
-        {
-            return true;
-        }
-        const auto& Message = ck::Format_UE(L"{}", InMsg);
-        const auto& ExpressionText = L"InExpression";
-        auto ShouldBreakInCode = false;
-        auto ShouldBreakInScript = false;
-        ck::ensure::Ensure_Impl(Message, ExpressionText, "CkEnsure_Utils.cpp", 8, ShouldBreakInCode, ShouldBreakInScript);
-        if (ShouldBreakInCode)
-        {
-            ((!!(!!(false))) || [&]() __declspec(noinline) __declspec(code_seg(".uedbg"))
-            {
-                ;
-                std::atomic<uint8>& bEnsureHasExecuted = ::bGEnsureHasExecuted<FileLineHashForEnsure("CkEnsure_Utils.cpp", 8)>;
-                static constexpr ::UE::Assert::Private::FStaticEnsureRecord ENSURE_Static(L"[DEBUG BREAK HIT]", "false",
-                    __builtin_FILE(), __builtin_LINE(), true);
-                if (::UE::Assert::Private::CheckEnsureFailed(true, bEnsureHasExecuted) && ::UE::Assert::Private::EnsureFailed(
-                    bEnsureHasExecuted, &ENSURE_Static))
-                {
-                    (__nop(), __debugbreak());
-                }
-                return false;
-            }());
-            if (ShouldBreakInScript)
-            {
-                ck::ensure::Do_BreakInScript();
-            }
-        }
-        return false;
-    }())
+    CK_ENSURE_IF_NOT(InExpression, TEXT("{}"), InMsg)
     {
         OutHitStatus = ECk_ValidInvalid::Invalid;
         return;


### PR DESCRIPTION
First compile of CkCore in a `-clientconfig=Shipping` client surfaced two latent Shipping-compile breaks — both framework code assuming editor/dev-only engine features exist:

- **`CkAngelscriptDebugger.h`** accessed `FAngelscriptManager::DebugServer` under `WITH_ANGELSCRIPT_CK`, but the engine gates `DebugServer` with `WITH_AS_DEBUGSERVER` = `(!UE_BUILD_TEST && !UE_BUILD_SHIPPING)`. Tightened the Ck guard to match (`!UE_BUILD_SHIPPING && !UE_BUILD_TEST`, always-defined core macros — no include-order dependency).
- **`CkEnsure_Utils.cpp::EnsureMsgf`** carried a stale hand-inlined expansion of an older `CK_ENSURE` that used UE internal ensure machinery (`bGEnsureHasExecuted`, `FStaticEnsureRecord`, `FileLineHashForEnsure`), which compiles out in Shipping (`DO_ENSURE=0`) → undefined-symbol syntax cascade. Replaced with the current Shipping-safe `CK_ENSURE_IF_NOT` macro, mirroring `EnsureMsgf_IsValid` directly below it.

Both are config-inert in Development/Editor (the guards evaluate identically there); verified by a full editor rebuild + cook. Part of the BusterBlock Shipping-packaging work (pairs with the CkGameplayDebugger Shipping-link PR and the BB parent PR).