### PR TITLE
fix(shipping): #if EDITOR-wrap project autotest wrappers for packaged builds

### DIFF
--- a/Source/CkAngelscriptGenerator/AutoTests/CkAutoTestWrapperGenerator.cpp
+++ b/Source/CkAngelscriptGenerator/AutoTests/CkAutoTestWrapperGenerator.cpp
@@ -525,10 +525,26 @@ auto
     {
         auto Content = FString{ck_autotest_wrapper_generator::FileHeader};
 
+        // Guard the PROJECT's wrapper file (<Project>_AutoTestActors.as) in #if EDITOR. Its wrappers
+        // inherit ACk_AutoTestRunner (CkTests — non-redistributable, disabled in Shipping/Test). The
+        // project Script root is ALWAYS compiled (unlike a disabled plugin's), so without the guard
+        // these wrappers reference the absent base and break the cook/packaged AS compile
+        // (bUseEditorScripts=false makes the base absent AND #if EDITOR false → bodies skipped, file
+        // inert). Plugin wrapper files are deliberately NOT guarded: a disabled test plugin excludes
+        // its whole Script root at runtime anyway, and its sibling *Assets.as references these wrapper
+        // types OUTSIDE an EDITOR block (autotest-map OFPA actor accessors) — guarding them would make
+        // those accessors fail "Cannot use editor-only type outside of an EDITOR block" in the editor.
+        const auto IsProjectBucket = Bucket.PluginName == FApp::GetProjectName();
+        if (IsProjectBucket)
+        { Content += TEXT("#if EDITOR\n\n"); }
+
         for (auto* Class : Bucket.Classes)
         {
             Content += ck_autotest_wrapper_generator::Format_WrapperBlock(Class);
         }
+
+        if (IsProjectBucket)
+        { Content += TEXT("#endif // EDITOR\n"); }
 
         const auto OutputDir = FPaths::GetPath(Bucket.OutputFilePath);
         IFileManager::Get().MakeDirectory(*OutputDir, true);


### PR DESCRIPTION
## What
`#if EDITOR`-wrap the **project bucket's** `<Project>_AutoTestActors.as` autotest wrappers (one 16-line addition in `CkAutoTestWrapperGenerator.cpp`).

## Why
The generated wrappers inherit `ACk_AutoTestRunner` (CkTests — non-redistributable, disabled in Shipping+Test), and the **project** Script root is *always* compiled (cook + packaged runtime). Without a guard they reference the absent base and break the packaged AngelScript compile. Guarding the project bucket in `#if EDITOR` makes the committed file inert there (`bUseEditorScripts=false` ⇒ base absent **and** `#if EDITOR` false ⇒ bodies skipped) while it still compiles + is populator-discoverable in-editor.

**Only the project bucket** is wrapped — plugin wrapper files (e.g. CkTests') stay unwrapped: a disabled test plugin excludes its whole Script root anyway, and its sibling `*Assets.as` references those wrapper types **outside** an EDITOR block (autotest-map OFPA accessors), so guarding them would fail "Cannot use editor-only type outside of an EDITOR block" in-editor.

## Context
Framework half of the BusterBlock Shipping boot-clean effort. Consumer: chainkemists/BusterBlock `bugfix/shipping-test-gym-exclusion` (its gitlink points here — **merge this first**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)