### PR TITLE
fix(CkAttribute): don't coalesce a new value into a modifier queued for destroy

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
@@ -177,9 +177,17 @@ namespace ck
             ECk_AttributeValueChange_SyncPolicy InSyncPolicy)
         -> void
     {
+        // A same-frame Request_ClearAllModifiers (the replicated-attribute apply path does
+        // exactly this) marks the existing NotRevocable modifier for DEFERRED destroy
+        // (FTag_DestroyEntity_Initiate) without erasing it yet. Coalescing the new delta into
+        // that doomed modifier silently loses the write the moment the destroy drains — which is
+        // why a replicated attribute Override'd in alternating frames sticks on the client every
+        // other edge. Treat a pending-destroy modifier as absent so we fall through and create a
+        // fresh one that survives.
         if (auto MaybeExistingModifier = RecordOfAttributeModifiers_Utils::Get_ValidEntry_If(
             InAttributeHandle, ck::algo::MatchesAttributeModifierWithOperation<AttributeModifierFragmentType, typename AttributeModifierFragmentType::FTag_IsNotRevocableModification>{InModifierOperation});
-            ck::IsValid(MaybeExistingModifier))
+            ck::IsValid(MaybeExistingModifier) &&
+            NOT UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(MaybeExistingModifier, ECk_EntityLifetime_DestructionPhase::BeginDestroy))
         {
             const auto& CurrentModifierValue = MaybeExistingModifier.template Get<AttributeModifierFragmentType>().Get_ModifierDelta();
 


### PR DESCRIPTION
## Problem
Replicated Ck attributes `Request_Override`'d to alternating values (0→1→0→1, ≥1 frame apart) stuck on the client every *other* edge. The client apply ran each time (the "Replicating … to" log fired) but the value never changed.

## Root cause
`ApplyReplicatedByteAttributeEntry` does `Request_ClearAllModifiers` + `Request_Override`. `ClearAllModifiers` marks the prior NotRevocable Override modifier for **deferred** destroy (stamps `FTag_DestroyEntity_Initiate` immediately), and `Add_NotRevocable` then coalesced the new base **into that doomed modifier** before it was erased. The deferred destroy drained and took the new value with it. First override creates a fresh modifier (works); every subsequent one coalesces-into-doomed (sticks) → the alternation. Generic to all attribute types (shared templated `Add_NotRevocable`).

## Fix
Skip pending-destroy modifiers in the coalesce check so it falls through and creates a fresh modifier that survives. Only changes the broken pending-destroy case; normal coalescing untouched.

## Verification
- Full CkAttribute automation suite: **88/88**, zero regressions.
- New guard `CkAutoTest_Net_Byte_AlternatingOverrideTracksOnClient` (CkTests PR): fails before this fix, passes after.

Root cause of the OpenSign multiplayer toggle stick.
