### PR TITLE
fix(CkAttribute): preserve NotRevocable modifiers in ClearAllModifiers

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
@@ -177,18 +177,19 @@ namespace ck
             ECk_AttributeValueChange_SyncPolicy InSyncPolicy)
         -> void
     {
-        // A same-frame Request_ClearAllModifiers (the replicated-attribute apply path does
-        // exactly this) marks the existing NotRevocable modifier for DEFERRED destroy
-        // (FTag_DestroyEntity_Initiate) without erasing it yet. Coalescing the new delta into
-        // that doomed modifier silently loses the write the moment the destroy drains — which is
-        // why a replicated attribute Override'd in alternating frames sticks on the client every
-        // other edge. Treat a pending-destroy modifier as absent so we fall through and create a
-        // fresh one that survives.
         if (auto MaybeExistingModifier = RecordOfAttributeModifiers_Utils::Get_ValidEntry_If(
             InAttributeHandle, ck::algo::MatchesAttributeModifierWithOperation<AttributeModifierFragmentType, typename AttributeModifierFragmentType::FTag_IsNotRevocableModification>{InModifierOperation});
-            ck::IsValid(MaybeExistingModifier) &&
-            NOT UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(MaybeExistingModifier, ECk_EntityLifetime_DestructionPhase::BeginDestroy))
+            ck::IsValid(MaybeExistingModifier))
         {
+            // NotRevocable modifiers are permanent — Request_ClearAllModifiers never destroys them,
+            // so this coalesce target can never be queued for destruction. Tripwire: if a future
+            // code path starts removing NotRevocable modifiers, coalescing into a pending-destroy
+            // entity would silently lose the write when the destroy drains (the replicated-attribute
+            // alternating-override stick). Fail loudly instead of coalescing into a doomed modifier.
+            CK_ENSURE_IF_NOT(NOT UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(MaybeExistingModifier, ECk_EntityLifetime_DestructionPhase::BeginDestroy),
+                TEXT("Add_NotRevocable coalescing into NotRevocable modifier [{}] that is pending destroy."), MaybeExistingModifier)
+            { return; }
+
             const auto& CurrentModifierValue = MaybeExistingModifier.template Get<AttributeModifierFragmentType>().Get_ModifierDelta();
 
             switch (InModifierOperation)
@@ -261,6 +262,13 @@ namespace ck
             }, [](
             AttributeModifierHandleType InAttributeModifier)
             {
+                // NotRevocable modifiers are permanent (set-once / accumulate) and must never be
+                // cleared. Clearing them queued the EmptyTag Override modifier for deferred destroy
+                // and let a same-frame Add_NotRevocable coalesce into a doomed entity — the
+                // replicated-attribute alternating-override stick.
+                if (InAttributeModifier.template Has<typename AttributeModifierFragmentType::FTag_IsNotRevocableModification>())
+                { return false; }
+
                 if (UCk_Utils_GameplayLabel_UE::Has(InAttributeModifier) &&
                     UCk_Utils_GameplayLabel_UE::MatchesAny(InAttributeModifier, TagsToIgnore))
                 { return false; }


### PR DESCRIPTION
Root-cause fix for the replicated-attribute alternating-override stick, replacing the symptom-level guard from `bff15a946` with the approach the framework owner requested.

**Change**
- `Request_ClearAllModifiers` now preserves `NotRevocable` modifiers (skips them in the clear predicate). They are permanent by contract and must never be cleared.
- `Add_NotRevocable` drops the prior pending-destroy skip (now unreachable — the coalesce target can no longer be queued for destruction) and asserts the invariant with `CK_ENSURE_IF_NOT`, so any future path that removes a `NotRevocable` modifier fails loudly instead of silently losing the write.

**Bug**
A replicated attribute `Request_Override`'d to alternating values stuck on the client every other server edge. The client apply does `ClearAllModifiers` + `Override`; the clear queued the prior `EmptyTag` Override modifier for deferred destroy, and the same-frame `Add_NotRevocable` (which `Request_Override` funnels through) coalesced the new base into that doomed modifier — lost when the destroy drained. Generic to all attribute types; was the real cause of the BusterBlock OpenSign multiplayer toggle stick.

**Verification**
- 88/88 CkAttribute suite green — no regression from preserving `NotRevocable` across all callers.
- `Ck.Attribute.Net.AS_Byte_AlternatingOverrideTracksOnClient` passes (server overrides twice with a settle gap, client observes both edges; fails-before / passes-after).