### PR TITLE
fix(shipping): packaged AngelScript boots clean (handle-mixin use-after-free + TESTONLY gate)

### DIFF
--- a/Source/CkDynamic/Public/CkDynamic/CkDynamic_AngelScript.cpp
+++ b/Source/CkDynamic/Public/CkDynamic/CkDynamic_AngelScript.cpp
@@ -229,6 +229,14 @@ auto
     // by directory iteration (thread-safe, no IPluginManager dependency so this is safe on the
     // packaged off-thread PreCompile path), merged with the same dedup-by-TypeName rule — canonical
     // and stub entries always win, so a test registry can never override a real handle type.
+    //
+    // SHIPPING/TEST GATE: this merge is strictly "for automation tests". Test plugins (CkTests, etc.)
+    // are disabled in Shipping/Test client builds, so their `FCk_Handle_TESTONLY_*` types have NO C++
+    // backing — registering them yields asINVALID_TYPE and cascades through every handle mixin
+    // (StoreVar_*, GetVar_*, ...) registered onto the dead types. The staged `.TESTONLY.json` is
+    // harmless as data; it must simply never be merged outside dev/editor builds. Condition mirrors
+    // the engine's WITH_AS_DEBUGSERVER gate (!UE_BUILD_SHIPPING && !UE_BUILD_TEST).
+#if !UE_BUILD_SHIPPING && !UE_BUILD_TEST
     {
         auto TestRegistryFiles = TArray<FString>{};
 
@@ -303,6 +311,7 @@ auto
             }
         }
     }
+#endif // !UE_BUILD_SHIPPING && !UE_BUILD_TEST
 
     if (HandleTypesArray.Num() == 0)
     {

--- a/Source/CkEcs/Public/CkEcs/Handle/CkHandle_AngelScript_Registry.cpp
+++ b/Source/CkEcs/Public/CkEcs/Handle/CkHandle_AngelScript_Registry.cpp
@@ -814,7 +814,9 @@ auto
     for (const auto& SourcePair : Types)
     {
         const auto& SourceType = SourcePair.Value;
-        auto SourceBind = FAngelscriptBinds::ExistingClass(TCHAR_TO_ANSI(*SourceType->TypeName));
+        // Pass the FString (owned copy) — a TCHAR_TO_ANSI() temporary would dangle in FBindString and
+        // corrupt later RegisterObjectMethod object-type args. See the note in BindBaseMixinMethods.
+        auto SourceBind = FAngelscriptBinds::ExistingClass(SourceType->TypeName);
         if (SourceBind.GetTypeInfo() == nullptr)
         {
             continue;
@@ -1199,7 +1201,14 @@ auto
     for (const auto& Entry : Entries)
     {
         const auto& DerivedType = Entry.TypeInfo;
-        auto DerivedBind = FAngelscriptBinds::ExistingClass(TCHAR_TO_ANSI(*DerivedType->TypeName));
+        // Pass the FString so FBindString owns a copy of the name. FBindString stores a
+        // `const ANSICHAR*` by raw pointer, so a TCHAR_TO_ANSI() temporary would dangle the moment this
+        // statement ends — and this binder is used later in the loop. The freed slot then gets reused by
+        // the TCHAR_TO_ANSI() of a method declaration, so the binder's object-type name reads back as the
+        // declaration string, corrupting RegisterObjectMethod's object-type argument (asINVALID_TYPE ->
+        // the engine's configFailed flag latches -> every subsequent AS registration fails). This only
+        // bit packaged builds, where the freed-slot reuse is deterministic.
+        auto DerivedBind = FAngelscriptBinds::ExistingClass(DerivedType->TypeName);
 
         auto* DerivedTypeInfo = DerivedBind.GetTypeInfo();
         if (DerivedTypeInfo == nullptr)
@@ -1279,7 +1288,14 @@ auto
     for (const auto& Entry : Entries)
     {
         const auto& DerivedType = Entry.TypeInfo;
-        auto DerivedBind = FAngelscriptBinds::ExistingClass(TCHAR_TO_ANSI(*DerivedType->TypeName));
+        // Pass the FString so FBindString owns a copy of the name. FBindString stores a
+        // `const ANSICHAR*` by raw pointer, so a TCHAR_TO_ANSI() temporary would dangle the moment this
+        // statement ends — and this binder is used later in the loop. The freed slot then gets reused by
+        // the TCHAR_TO_ANSI() of a method declaration, so the binder's object-type name reads back as the
+        // declaration string, corrupting RegisterObjectMethod's object-type argument (asINVALID_TYPE ->
+        // the engine's configFailed flag latches -> every subsequent AS registration fails). This only
+        // bit packaged builds, where the freed-slot reuse is deterministic.
+        auto DerivedBind = FAngelscriptBinds::ExistingClass(DerivedType->TypeName);
 
         if (DerivedBind.GetTypeInfo() == nullptr)
         { continue; }


### PR DESCRIPTION
## Summary
Makes the packaged (Shipping/Test) AngelScript layer boot and run cleanly. Two fixes:

### 1. Use-after-free in handle-mixin propagation (the real fix)
`BindBaseMixinMethods` / `BindParentChainConversions` / `BindBaseHandleMethods` built their per-type binder with `ExistingClass(TCHAR_TO_ANSI(*Type->TypeName))`. `FBindString` stores the `const ANSICHAR*` **by raw pointer**, and the `TCHAR_TO_ANSI` temporary dies at the end of the statement — but the binder is used later in the loop. The freed slot gets reused by the next method declaration's `TCHAR_TO_ANSI`, so the binder's object-type name reads back as the **declaration string**. `RegisterObjectMethod` then returns `asINVALID_TYPE`, the SDK latches `configFailed`, and **every** subsequent AngelScript registration fails — a ~28k-error cascade that killed all AS in packaged builds.

Only manifested in Shipping/Test (deterministic freed-slot reuse there); the editor's live-reflection bind path never reaches it, which is why it survived until a Shipping client first got past preprocessing. Fix: pass the `FString` so `FBindString` owns a copy.

### 2. Gate the TESTONLY dynamic-handle merge (hygiene)
`LoadFromJsonRegistry` merged `DynamicHandleTypes.TESTONLY.json` "for automation tests" with no Shipping gate. CkTests is disabled in Shipping/Test, so those test handle types have no C++ backing — registering them is pollution (~294 of the failures + an AS-error modal). Gated with `!UE_BUILD_SHIPPING && !UE_BUILD_TEST`.

## Verification
Staged Shipping client cooked + booted into `BB_MainMap1_P`: **0** `asINVALID_TYPE`, **0** `'is not declared'`, **0** crashes; AS gameplay functional (hands-on play session, log-clean). Boot log shrank 14.8 MB → 185 KB.