### PR TITLE
feat(CkAngelscriptGenerator): route plugin-authored net-test stubs to the owning plugin's module

### DIFF
--- a/Source/CkAngelscriptGenerator/AutoTests/CkAutoTestNetStubGenerator.cpp
+++ b/Source/CkAngelscriptGenerator/AutoTests/CkAutoTestNetStubGenerator.cpp
@@ -9,6 +9,7 @@
 
 #include <HAL/FileManager.h>
 #include <Interfaces/IPluginManager.h>
+#include <ModuleDescriptor.h>
 #include <Misc/App.h>
 #include <Misc/FileHelper.h>
 #include <Misc/Paths.h>
@@ -376,10 +377,96 @@ namespace ck_autotest_netstub_generator
         return ProjectModuleDir / TEXT("Tests") / TEXT("Net") / TEXT("Generated");
     }
 
-    // Buckets by (output root, feature): plugin-authored tests group under CkTests, project-
-    // authored ones under the project's own source tree — see the header docstring for why the
-    // split matters. Classes whose root is unavailable are skipped with a warning (never
-    // silently, never rerouted across repos).
+    // Longest-base-dir-prefix match of a source path against every enabled plugin. Mirrors
+    // FCkAutoTestWrapperGenerator::Find_PluginByPathPrefix verbatim — the proven in-repo way to
+    // resolve an AS source file's owning plugin (this engine fork has no path->plugin lookup we
+    // rely on; the wrapper generator uses exactly this).
+    auto Find_PluginByPathPrefix(const FString& InPath) -> const IPlugin*
+    {
+        if (InPath.IsEmpty())
+        { return nullptr; }
+
+        auto NormalizedPath = FPaths::ConvertRelativePathToFull(InPath);
+        FPaths::NormalizeFilename(NormalizedPath);
+
+        const IPlugin* BestMatch = nullptr;
+        auto BestMatchLen = int32{0};
+
+        for (const auto& Plugin : IPluginManager::Get().GetEnabledPlugins())
+        {
+            auto PluginDir = FPaths::ConvertRelativePathToFull(Plugin->GetBaseDir());
+            FPaths::NormalizeDirectoryName(PluginDir);
+
+            if (NormalizedPath.StartsWith(PluginDir, ESearchCase::IgnoreCase))
+            {
+                if (PluginDir.Len() > BestMatchLen)
+                {
+                    BestMatch = &Plugin.Get();
+                    BestMatchLen = PluginDir.Len();
+                }
+            }
+        }
+        return BestMatch;
+    }
+
+    // Output root for a test authored in a plugin OTHER than CkTests that ships its own compiled
+    // C++ module to host the stub: `<Plugin>/Source/<Module>/Private/Net/Generated`, mirroring
+    // CkTests' own layout. Returns empty (caller falls back to CkTests, preserving prior behavior)
+    // when:
+    //   * the source path resolves to no enabled plugin,
+    //   * the owning plugin IS CkTests (keep its dedicated, byte-stable Get_CkTestsOutputDir branch),
+    //   * the plugin has no host-able code module (script-only plugin), or
+    //   * the chosen module's Source dir doesn't exist on disk (refuse to guess, same precedent as
+    //     Get_ProjectOutputDir).
+    // A plugin hosting these stubs MUST have a module that publicly depends on CkTests — the emitted
+    // C++ #includes the CkTests/Net/* harness headers (same requirement the project module carries).
+    auto Get_PluginOutputDir(const FString& InSourcePath) -> FString
+    {
+        const auto* Plugin = Find_PluginByPathPrefix(InSourcePath);
+        if (Plugin == nullptr)
+        { return {}; }
+
+        // CkTests keeps its dedicated root so its own net tests stay byte-identical (its module
+        // dir would resolve to the same path here, but routing it explicitly through
+        // Get_CkTestsOutputDir leaves that code path untouched).
+        if (Plugin->GetName() == TEXT("CkTests"))
+        { return {}; }
+
+        // Pick a host-able module: prefer Runtime (matches where CkTests itself hosts net stubs),
+        // then UncookedOnly / DeveloperTool. Editor-typed modules are intentionally skipped — the
+        // stub bodies are WITH_DEV_AUTOMATION_TESTS-guarded, but the file must still compile in the
+        // editor target's build, which a Runtime/UncookedOnly module in an Editor-gated plugin does.
+        auto HostModuleName = FString{};
+        const auto& Modules = Plugin->GetDescriptor().Modules;
+        for (const auto& Module : Modules)
+        {
+            if (Module.Type == EHostType::Runtime)
+            { HostModuleName = Module.Name.ToString(); break; }
+        }
+        if (HostModuleName.IsEmpty())
+        {
+            for (const auto& Module : Modules)
+            {
+                if (Module.Type == EHostType::UncookedOnly || Module.Type == EHostType::DeveloperTool)
+                { HostModuleName = Module.Name.ToString(); break; }
+            }
+        }
+        if (HostModuleName.IsEmpty())
+        { return {}; }
+
+        const auto ModuleDir = Plugin->GetBaseDir() / TEXT("Source") / HostModuleName;
+        if (NOT IFileManager::Get().DirectoryExists(*ModuleDir))
+        { return {}; }
+
+        return ModuleDir / TEXT("Private") / TEXT("Net") / TEXT("Generated");
+    }
+
+    // Buckets by (output root, feature) using a THREE-way routing decision: the project's own
+    // Script tree -> the project module; a plugin (other than CkTests) that ships its own code
+    // module -> that plugin's module; everything else (CkTests' own tests, or a plugin with no
+    // hostable module) -> CkTests. The plugin branch keeps a plugin's committed stub in the SAME
+    // repo as its .as test — the same atomicity the project/CkTests split already enforces. Classes
+    // whose root is unavailable are skipped with a warning (never silently, never rerouted cross-repo).
     auto Bucket_ClassesByFeature(const TArray<UClass*>& InClasses) -> TArray<FFeatureBucket>
     {
         const auto CkTestsOutputDir = Get_CkTestsOutputDir();
@@ -395,7 +482,19 @@ namespace ck_autotest_netstub_generator
             const auto IsProjectAuthored = FCkAutoTestNetStubGenerator::Get_IsProjectAuthoredPath(
                 SourcePath, FPaths::ProjectDir());
 
-            const auto& OutputDir = IsProjectAuthored ? ProjectOutputDir : CkTestsOutputDir;
+            // Three-way routing (see the function header). A plugin with its own code module roots
+            // its stub there; otherwise we keep the prior project-vs-CkTests outcome unchanged.
+            auto OutputDir = FString{};
+            if (IsProjectAuthored)
+            {
+                OutputDir = ProjectOutputDir;
+            }
+            else
+            {
+                const auto PluginOutputDir = Get_PluginOutputDir(SourcePath);
+                OutputDir = PluginOutputDir.IsEmpty() ? CkTestsOutputDir : PluginOutputDir;
+            }
+
             if (OutputDir.IsEmpty())
             {
                 (IsProjectAuthored ? SkippedNoProjectDir : SkippedNoCkTests)++;
@@ -646,13 +745,30 @@ auto
     if (AllSubclasses.Num() > 0)
     {
         auto ExpectedPaths = TSet<FString>{};
+        auto OutputRoots   = TSet<FString>{};
         for (const auto& Bucket : Buckets)
-        { ExpectedPaths.Add(FPaths::ConvertRelativePathToFull(Bucket.OutputFilePath)); }
+        {
+            ExpectedPaths.Add(FPaths::ConvertRelativePathToFull(Bucket.OutputFilePath));
+            OutputRoots.Add(FPaths::ConvertRelativePathToFull(FPaths::GetPath(Bucket.OutputFilePath)));
+        }
 
-        ck_autotest_netstub_generator::Prune_StaleStubs(
-            ck_autotest_netstub_generator::Get_CkTestsOutputDir(), ExpectedPaths);
-        ck_autotest_netstub_generator::Prune_StaleStubs(
-            ck_autotest_netstub_generator::Get_ProjectOutputDir(), ExpectedPaths);
+        // Always prune the two fixed roots even when this pass wrote nothing to them, so a feature
+        // whose LAST test was deleted (its bucket vanishes -> root absent from OutputRoots) still
+        // gets its orphaned stub removed — preserving the original unconditional two-root prune.
+        // Plugin roots only appear when a bucket targeted them this pass, which is correct: never
+        // enumerate (and risk deleting in) a plugin dir the current pass knows nothing about.
+        const auto CkTestsRoot = ck_autotest_netstub_generator::Get_CkTestsOutputDir();
+        if (NOT CkTestsRoot.IsEmpty())
+        { OutputRoots.Add(FPaths::ConvertRelativePathToFull(CkTestsRoot)); }
+
+        const auto ProjectRoot = ck_autotest_netstub_generator::Get_ProjectOutputDir();
+        if (NOT ProjectRoot.IsEmpty())
+        { OutputRoots.Add(FPaths::ConvertRelativePathToFull(ProjectRoot)); }
+
+        // Membership is by full path, so the single combined ExpectedPaths set is safe across every
+        // root — a stub expected in root A is never pruned by the pass over root B.
+        for (const auto& Root : OutputRoots)
+        { ck_autotest_netstub_generator::Prune_StaleStubs(Root, ExpectedPaths); }
     }
     else
     {

--- a/Source/CkAngelscriptGenerator/AutoTests/CkAutoTestNetStubGenerator.h
+++ b/Source/CkAngelscriptGenerator/AutoTests/CkAutoTestNetStubGenerator.h
@@ -13,12 +13,17 @@
 // harness latent commands.
 //
 // Output convention (one file per "feature" derived from the AS source path; falls back to `AS`
-// when no convention matches):
-//   * Plugin-authored tests (`Plugins/<X>/Script/Ck<Feature>/...`):
-//       Plugins/CkTests/Source/CkTests/Private/Net/Generated/<Feature>_NetAutoTestStubs.spec.cpp
-//   * Project-authored tests (`<ProjectDir>/Script/Tests/<Feature>/...`, or anywhere under the
-//     project's `Script/` tree):
+// when no convention matches). THREE destinations, chosen so a committed stub always lands in the
+// SAME git repo as the .as test class it references:
+//   * Project-authored tests (anywhere under `<ProjectDir>/Script/`):
 //       <ProjectDir>/Source/<ProjectName>/Tests/Net/Generated/<Feature>_NetAutoTestStubs.spec.cpp
+//   * Tests authored in a plugin OTHER than CkTests that ships its own compiled C++ module
+//     (e.g. an editor-only test plugin like `BusterBlockTests`):
+//       Plugins/<X>/Source/<Module>/Private/Net/Generated/<Feature>_NetAutoTestStubs.spec.cpp
+//     (`<Module>` = the plugin's first Runtime, else UncookedOnly/DeveloperTool, module.)
+//   * Everything else — CkTests' OWN net tests, or a plugin that has no hostable C++ module
+//     (script-only) — falls back to CkTests:
+//       Plugins/CkTests/Source/CkTests/Private/Net/Generated/<Feature>_NetAutoTestStubs.spec.cpp
 //
 // The split is load-bearing, not cosmetic: these stubs are COMMITTED (UBT must compile them
 // before the editor can ever boot to regenerate them), and the generator actively prunes stale
@@ -26,13 +31,16 @@
 // keeps the pair atomic across branch switches. Before the split, a project-authored test's stub
 // landed in the CkTests submodule; any machine whose project checkout lacked that class (older
 // branch, different host project) had the committed file pruned, surfacing as a mysterious
-// deletion in the submodule on every boot.
+// deletion in the submodule on every boot. The plugin-module destination extends that same
+// guarantee to plugins that own their tests: routing a plugin's stub into the CkTests submodule
+// would re-create exactly that cross-repo churn for the plugin's repo.
 //
-// Plugin-authored output is rooted under `CkTests` so the emitted C++ sees the harness API
-// (`CkTests/Net/CkAutoTest_NetSubject.h`, `CkTests/Net/CkNetAutomation_Common.h`) and the
-// generator does not need a build-dependency on `CkTests` itself — only the runtime path is
-// crossed. Project-authored output requires the project's primary module to depend on `CkTests`
-// (the harness headers are public and the latent commands are `CKTESTS_API`-exported).
+// Whichever destination is chosen, the emitted C++ #includes the CkTests harness API
+// (`CkTests/Net/CkAutoTest_NetSubject.h`, `CkTests/Net/CkNetAutomation_Common.h`) and resolves
+// the subject actor via `/Script/CkTests.Ck_AutoTest_NetSubject` — so the HOSTING module (the
+// project's primary module, or the plugin's chosen module) must publicly depend on `CkTests` (the
+// harness headers are public and the latent commands are `CKTESTS_API`-exported). The generator
+// itself needs no build-dependency on `CkTests`; only the emitted runtime path crosses to it.
 // `_NetMode` and `_TimeoutSeconds` are read off the CDO via reflection (same pattern the wrapper
 // generator uses), so this generator's module deps stay unchanged.
 //


### PR DESCRIPTION
## What

The net-autotest C++ stub generator (`FCkAutoTestNetStubGenerator`) routed by AS source location with only **two** destinations: a test under the project's `Script/` → the project's primary module; **everything else → the CkTests submodule**. So a net test authored in any *other* plugin had its committed `.spec.cpp` stub dumped into the CkTests submodule — the cross-repo churn the project/CkTests split exists to prevent, just never generalized to arbitrary plugins.

This adds a **third route**: a plugin (other than CkTests) that ships its own compiled module gets its stub emitted into `<Plugin>/Source/<Module>/Private/Net/Generated/`.

- Owning plugin + module resolved from the AS source path via `Find_PluginByPathPrefix` (mirrors the wrapper generator) + the plugin descriptor's first `Runtime` (else `UncookedOnly`/`DeveloperTool`) module.
- **CkTests special-cased** to its dedicated dir → its own output is byte-identical (no churn on existing stubs).
- Prune generalized to every output root seen in the pass (membership by full path → no cross-root deletion), kept inside the existing zero-class guard and the **G5 ownership gate**.
- Header docstring updated to the 3-way contract.

## Why

Unblocks consumers (e.g. BusterBlock) hosting their net-test stubs in their *own* editor-only test plugin module instead of leaking them into the CkTests submodule.

## Verification

Exercised end-to-end from BusterBlock: the 3 BB net tests (ChangeablePoster/OpenSign/Vendor), now resident in an editor-only `BusterBlockTests` plugin with its own Runtime module, route their stubs into that module and **pass** (AutoTests 95/95, no regression in CkTests' own net tests). CkTests' own net stubs regenerated byte-identical (diff-skip, no churn). The generator is `#if WITH_EDITOR` / editor-module only, so packaged/Shipping builds are unaffected.

## Follow-up

The new plugin-routing branch resolves through `IPluginManager` (live state), so it is covered by the BB e2e rather than the pure-path unit tests in `Tests/Test_NetStubGenerator.cpp` (which still pass for the project/CkTests classification). A pure, parameterized seam for the plugin-module path could be added if we want it pinned by a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)