### PR TITLE
fix(attribute): make Add_NotRevocable pending-destroy guard owner-aware

### DIFF
--- a/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
+++ b/Source/CkAttribute/Public/CkAttribute/CkAttribute_Utils.inl.h
@@ -181,14 +181,23 @@ namespace ck
             InAttributeHandle, ck::algo::MatchesAttributeModifierWithOperation<AttributeModifierFragmentType, typename AttributeModifierFragmentType::FTag_IsNotRevocableModification>{InModifierOperation});
             ck::IsValid(MaybeExistingModifier))
         {
-            // NotRevocable modifiers are permanent — Request_ClearAllModifiers never destroys them,
-            // so this coalesce target can never be queued for destruction. Tripwire: if a future
-            // code path starts removing NotRevocable modifiers, coalescing into a pending-destroy
-            // entity would silently lose the write when the destroy drains (the replicated-attribute
-            // alternating-override stick). Fail loudly instead of coalescing into a doomed modifier.
-            CK_ENSURE_IF_NOT(NOT UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(MaybeExistingModifier, ECk_EntityLifetime_DestructionPhase::BeginDestroy),
-                TEXT("Add_NotRevocable coalescing into NotRevocable modifier [{}] that is pending destroy."), MaybeExistingModifier)
-            { return; }
+            if (UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(MaybeExistingModifier, ECk_EntityLifetime_DestructionPhase::BeginDestroy))
+            {
+                // The coalesce target is queued for destruction. Two ways that happens:
+                //   1. Entity-lifetime cascade — the owning attribute (or ITS owner) is being destroyed
+                //      this frame, which stamps the attribute AND its child modifiers pending-destroy
+                //      synchronously. The write is moot (the whole attribute is going away); drop it.
+                //   2. A NotRevocable modifier removed out from under a LIVE attribute — the replicated-
+                //      attribute alternating-override stick. Request_ClearAllModifiers preserves
+                //      NotRevocable modifiers, so this should never happen; fail loudly if it does.
+                // Discriminate on whether the attribute itself is also pending-destroy: only case 2 is a bug.
+                CK_ENSURE_IF_NOT(UCk_Utils_EntityLifetime_UE::Get_IsPendingDestroy(InAttributeHandle, ECk_EntityLifetime_DestructionPhase::BeginDestroy),
+                    TEXT("Add_NotRevocable coalescing into NotRevocable modifier [{}] that is pending destroy while its attribute [{}] is alive."),
+                    MaybeExistingModifier, InAttributeHandle)
+                { return; }
+
+                return;
+            }
 
             const auto& CurrentModifierValue = MaybeExistingModifier.template Get<AttributeModifierFragmentType>().Get_ModifierDelta();
 


### PR DESCRIPTION
Coalescing `Add_NotRevocable` ensured whenever its target modifier was pending-destroy. But entity-lifetime cascade legitimately stamps an attribute's modifiers pending-destroy when the owner is destroyed the same frame something writes it — a benign, moot write, not the replicated-attribute alternating-override stick the guard was built to catch.

Now fire only when the modifier is doomed **while its attribute is still alive**; otherwise drop the moot write silently.

Real callers tripping this in BusterBlock: the Float Refill processor's per-tick `Add` on a just-destroyed owner, and an item's `StackCount` adjusted the frame the item entity is removed (fixture pickup/place). Both are benign teardown races — the ensure was pure noise.

Regression pin lives in a companion CkTests PR (`Ck_AutoTest_Attribute_NotRevocable_OwnerTeardownNoEnsure`); full CkAttribute suite stays green (89/89 incl. the new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)