### PR TITLE
fix(CkNavigation): opt-in vertical half-extent for the Start/End projection box

### DIFF
--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_DrawNavProjection_Processor.cpp
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_DrawNavProjection_Processor.cpp
@@ -69,7 +69,9 @@ namespace ck
         // Without the NavData arg, ProjectPointToNavigation falls back to the default agent's
         // nav data which can disagree with the specific RecastNavMesh used by path queries.
         auto* NavData = Cast<ARecastNavMesh>(NavSys->GetDefaultNavDataInstance(FNavigationSystem::DontCreate));
-        const auto Extent = FVector(UCk_Utils_Nav_Settings_UE::Get_NavQuerySearchHalfExtent());
+        // Mirror the asymmetric projection box the path-query gate uses so the overlay's verdict
+        // stays honest when a project opts into a tight vertical extent.
+        const auto Extent = UCk_Utils_Nav_Settings_UE::Get_NavQueryProjectionExtentVec();
         auto ProjectedLoc = FNavLocation{};
         const auto bProjected = (NavData != nullptr)
             && NavSys->ProjectPointToNavigation(AgentPos, ProjectedLoc, Extent, NavData);

--- a/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.cpp
+++ b/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.cpp
@@ -30,6 +30,7 @@ auto
         const FVector&       InEnd,
         bool                 InAllowPartial,
         float                InProjectionHalfExtent,
+        float                InProjectionVerticalHalfExtent,
         float                InAgentRadiusForFirstSkip,
         FCk_Nav_PathResult&  OutResult,
         TSubclassOf<UNavigationQueryFilter> InFilterClass)
@@ -55,7 +56,14 @@ auto
     // surface, that lookup misses and FindPath returns Error with an allocated-but-empty
     // path. Projecting up-front with a generous extent guarantees the path query receives
     // points that lie ON the navmesh surface.
-    const auto ProjectionExtent = FVector{InProjectionHalfExtent};
+    // Vertical (Z) reach is a separate opt-in knob: a negative InProjectionVerticalHalfExtent
+    // reproduces the uniform cube (today's behavior); a smaller value keeps the horizontal
+    // reach but stops Start/End from snapping onto a stray navmesh surface far above/below the
+    // intended floor (the checkout sink/float root cause).
+    const auto VerticalHalfExtent = (InProjectionVerticalHalfExtent < 0.0f)
+        ? InProjectionHalfExtent
+        : InProjectionVerticalHalfExtent;
+    const auto ProjectionExtent = FVector{InProjectionHalfExtent, InProjectionHalfExtent, VerticalHalfExtent};
     auto StartProj = FNavLocation{};
     auto EndProj   = FNavLocation{};
     auto bStartProjected = false;

--- a/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.cpp
+++ b/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.cpp
@@ -106,9 +106,9 @@ auto
         // clamp regression or a pre-existing content/nav defect.
         const auto LegacyCubeApplies = VerticalHalfExtent < InProjectionHalfExtent;
         auto LegacyProj = FNavLocation{};
-        const auto bLegacyOk = LegacyCubeApplies
+        const auto LegacyOk = LegacyCubeApplies
             && InNavSys.ProjectPointToNavigation(InPoint, LegacyProj, FVector{InProjectionHalfExtent}, &InNavData);
-        const auto LegacyCubeStr = FString{NOT LegacyCubeApplies ? TEXT("n/a") : bLegacyOk ? TEXT("OK") : TEXT("FAIL")};
+        const auto LegacyCubeStr = FString{NOT LegacyCubeApplies ? TEXT("n/a") : LegacyOk ? TEXT("OK") : TEXT("FAIL")};
 
         ck::nav::Warning(TEXT("FindPathSync: [{}] projection FAILED. "
             "Point=[{}] Extent=[{}]. NavBounds=[{} -> {}] (valid=[{}]). "
@@ -123,7 +123,7 @@ auto
             bBigOk ? BigProj.Location : FVector::ZeroVector,
             InProjectionHalfExtent,
             LegacyCubeStr,
-            bLegacyOk ? LegacyProj.Location : FVector::ZeroVector,
+            LegacyOk ? LegacyProj.Location : FVector::ZeroVector,
             static_cast<int32>(InNavData.GetDefaultQueryFilter().IsValid()),
             InNavData.GetConfig().AgentRadius, InNavData.GetConfig().AgentHeight, InNavData.GetConfig().AgentStepHeight);
     };

--- a/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.cpp
+++ b/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.cpp
@@ -100,9 +100,20 @@ auto
 
         const auto BigOkStr = FString{bBigOk ? TEXT("OK") : TEXT("FAIL")};
 
+        // Legacy-cube probe: when the vertical clamp is active, ALSO test the pre-clamp
+        // uniform cube so the log line itself answers "would the old behavior have snapped
+        // this point?" — the decisive datum when triaging whether a NO PATH report is a
+        // clamp regression or a pre-existing content/nav defect.
+        const auto LegacyCubeApplies = VerticalHalfExtent < InProjectionHalfExtent;
+        auto LegacyProj = FNavLocation{};
+        const auto bLegacyOk = LegacyCubeApplies
+            && InNavSys.ProjectPointToNavigation(InPoint, LegacyProj, FVector{InProjectionHalfExtent}, &InNavData);
+        const auto LegacyCubeStr = FString{NOT LegacyCubeApplies ? TEXT("n/a") : bLegacyOk ? TEXT("OK") : TEXT("FAIL")};
+
         ck::nav::Warning(TEXT("FindPathSync: [{}] projection FAILED. "
             "Point=[{}] Extent=[{}]. NavBounds=[{} -> {}] (valid=[{}]). "
             "Retry@[{}]uu=[{}] (snapped=[{}]). "
+            "LegacyCube@[{}]uu=[{}] (snapped=[{}]). "
             "DefaultFilterValid=[{}] AgentCfg=[r=[{}] h=[{}] step=[{}]]"),
             InWhich,
             InPoint, ProjectionExtent,
@@ -110,6 +121,9 @@ auto
             BigHalfExtentUu,
             BigOkStr,
             bBigOk ? BigProj.Location : FVector::ZeroVector,
+            InProjectionHalfExtent,
+            LegacyCubeStr,
+            bLegacyOk ? LegacyProj.Location : FVector::ZeroVector,
             static_cast<int32>(InNavData.GetDefaultQueryFilter().IsValid()),
             InNavData.GetConfig().AgentRadius, InNavData.GetConfig().AgentHeight, InNavData.GetConfig().AgentStepHeight);
     };

--- a/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.h
+++ b/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Algorithm.h
@@ -36,7 +36,8 @@ struct CKNAVIGATION_API FCk_Nav_Algorithm
         const FVector&       InStart,
         const FVector&       InEnd,
         bool                 InAllowPartial,
-        float                InProjectionHalfExtent,    // cm; from project setting (default 500)
+        float                InProjectionHalfExtent,         // cm; from project setting (default 500)
+        float                InProjectionVerticalHalfExtent, // cm; < 0 => use horizontal extent (uniform cube, today's behavior)
         float                InAgentRadiusForFirstSkip, // cm; 0 disables the skip-first-waypoint pass (Gate 2+ wires this in)
         FCk_Nav_PathResult&  OutResult,
         TSubclassOf<UNavigationQueryFilter> InFilterClass = {}) -> bool; // null -> NavData's default filter

--- a/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Processor.cpp
+++ b/Source/CkNavigation/Public/CkNavigation/Nav/CkNav_Processor.cpp
@@ -111,7 +111,9 @@ namespace ck
                 }
                 {
                     const auto StartLocation = UCk_Utils_Transform_UE::Get_EntityCurrentLocation(TransformHandle);
-                    const auto Extent = FVector(UCk_Utils_Nav_Settings_UE::Get_NavQuerySearchHalfExtent());
+                    // Match the asymmetric projection box FindPathSync uses so the re-issue decision
+                    // agrees with what the real query will accept.
+                    const auto Extent = UCk_Utils_Nav_Settings_UE::Get_NavQueryProjectionExtentVec();
                     auto ProbeProj = FNavLocation{};
                     INC_DWORD_STAT(STAT_Nav_DeferredReprojections);
                     const auto bReady = NavSys->ProjectPointToNavigation(StartLocation, ProbeProj, Extent, NavData);
@@ -212,6 +214,7 @@ namespace ck
         const auto StartLocation = UCk_Utils_Transform_UE::Get_EntityCurrentLocation(TransformHandle);
 
         const auto ProjectionExtent = UCk_Utils_Nav_Settings_UE::Get_NavQuerySearchHalfExtent();
+        const auto ProjectionVerticalExtent = UCk_Utils_Nav_Settings_UE::Get_NavQueryVerticalHalfExtent();
 
         // Per-point readiness check: defer only if this agent's start location does NOT yet
         // project onto baked navmesh. Same projection call FindPathSync uses internally — same
@@ -221,7 +224,10 @@ namespace ck
         // (incremental tile updates), and the queue never drained even when the agent's spot was
         // bakeable. The green "navmesh projection" overlay uses the same call, so when the dev
         // sees a green circle but path requests fail, this gate is what's wrong.
-        const auto ExtentVec = FVector(ProjectionExtent);
+        // Match the asymmetric box FindPathSync uses (below), or a start reachable only via a
+        // stray vertical surface would pass this gate yet fail the real query — spinning the
+        // deferred-requeue loop until the force-fail timeout.
+        const auto ExtentVec = UCk_Utils_Nav_Settings_UE::Get_NavQueryProjectionExtentVec();
         auto StartProbe = FNavLocation{};
         const auto bStartReady = (NavData != nullptr)
             && NavSys->ProjectPointToNavigation(StartLocation, StartProbe, ExtentVec, NavData);
@@ -265,6 +271,7 @@ namespace ck
                         InFindPath.Get_TargetLocation(),
                         InFindPath.Get_AllowPartialPath(),
                         ProjectionExtent,
+                        ProjectionVerticalExtent,
                         /*InAgentRadiusForFirstSkip*/ 0.0f,
                         InResult,
                         FilterClass);

--- a/Source/CkNavigation/Public/CkNavigation/Settings/CkNav_ProjectSettings.cpp
+++ b/Source/CkNavigation/Public/CkNavigation/Settings/CkNav_ProjectSettings.cpp
@@ -35,6 +35,32 @@ auto
 
 auto
     UCk_Utils_Nav_Settings_UE::
+    Get_NavQueryVerticalHalfExtent()
+    -> float
+{
+    const auto& Settings = UCk_Utils_Object_UE::Get_ClassDefaultObject<UCk_Nav_ProjectSettings_UE>();
+    if (ck::Is_NOT_Valid(Settings))
+    { return -1.0f; }
+    return Settings->Get_NavQueryVerticalHalfExtent();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_Nav_Settings_UE::
+    Get_NavQueryProjectionExtentVec()
+    -> FVector
+{
+    const auto HExt    = Get_NavQuerySearchHalfExtent();
+    const auto VExtRaw = Get_NavQueryVerticalHalfExtent();
+    const auto VExt    = VExtRaw < 0.0f ? HExt : VExtRaw;
+    return FVector{HExt, HExt, VExt};
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_Nav_Settings_UE::
     Get_QueryFilterClass(
         const FGameplayTag& InFilterTag)
     -> TSubclassOf<UNavigationQueryFilter>

--- a/Source/CkNavigation/Public/CkNavigation/Settings/CkNav_ProjectSettings.h
+++ b/Source/CkNavigation/Public/CkNavigation/Settings/CkNav_ProjectSettings.h
@@ -37,6 +37,17 @@ private:
             ToolTip = "Half-extent (cm) used to project Start/End onto the navmesh. Default 500cm covers the rental-store geometry; bump higher for steep slopes or thin navmesh."))
     float _NavQuerySearchHalfExtent = 500.0f;
 
+    // Vertical (Z) half-extent (cm) for the Start/End navmesh-projection box. -1 (default)
+    // means "use _NavQuerySearchHalfExtent for Z too" -> the box stays the uniform cube it is
+    // today. A non-negative value opts in to an ASYMMETRIC box FVector(XY, XY, Z), so a tight
+    // Z stops projection from snapping onto stray navmesh surfaces far above/below the intended
+    // floor (a multi-level nav overhang / gap under a counter) while horizontal reach is
+    // unchanged. Keep it comfortably larger than any legitimate step/ramp the agent must cross.
+    UPROPERTY(Config, EditDefaultsOnly, Category = "Pathfinding",
+        meta = (AllowPrivateAccess = true, ClampMin = -1.0, UIMin = -1.0, ClampMax = 5000.0, UIMax = 5000.0,
+            ToolTip = "Vertical (Z) half-extent (cm) for the projection box. -1 (default) = use the horizontal extent (uniform cube, today's behavior). >= 0 opts in to an asymmetric XY/XY/Z box."))
+    float _NavQueryVerticalHalfExtent = -1.0f;
+
     // Maps FCk_Request_Nav_FindPath::_QueryFilter tags to UNavigationQueryFilter
     // classes (the "Phase 2" mapping the request field reserved). Unmapped/empty
     // tags fall back to NavData's default filter.
@@ -47,6 +58,7 @@ private:
 public:
     CK_PROPERTY_GET(_MaxPathQueriesPerFrame);
     CK_PROPERTY_GET(_NavQuerySearchHalfExtent);
+    CK_PROPERTY_GET(_NavQueryVerticalHalfExtent);
     CK_PROPERTY_GET(_QueryFilters);
 };
 
@@ -66,6 +78,18 @@ public:
 
     UFUNCTION(BlueprintPure, Category = "Ck|Utils|Nav|Settings")
     static float Get_NavQuerySearchHalfExtent();
+
+    // Vertical (Z) projection half-extent. Returns the raw setting value, which may be
+    // negative (the "unset" sentinel meaning "use the horizontal extent"). Call sites fold
+    // the sentinel into the horizontal value when building the projection box.
+    UFUNCTION(BlueprintPure, Category = "Ck|Utils|Nav|Settings")
+    static float Get_NavQueryVerticalHalfExtent();
+
+    // The folded Start/End projection box — FVector(XY, XY, Z) with the vertical sentinel
+    // resolved. Every probe that must agree with FindPathSync's internal projection builds
+    // its box from THIS, so a new call site can't accidentally use the raw scalar cube.
+    UFUNCTION(BlueprintPure, Category = "Ck|Utils|Nav|Settings")
+    static FVector Get_NavQueryProjectionExtentVec();
 
     // Resolves a request's QueryFilter tag through the settings map. Empty tag or
     // no mapping -> null class (callers fall back to NavData's default filter);

--- a/Source/CkNavigation/Public/CkNavigation/Utils/CkNav_Utils.cpp
+++ b/Source/CkNavigation/Public/CkNavigation/Utils/CkNav_Utils.cpp
@@ -122,7 +122,8 @@ auto
         FCk_Handle& InHandle,
         FVector InWorldPosition,
         float InHalfExtentUu,
-        FVector& OutSnappedPosition)
+        FVector& OutSnappedPosition,
+        float InVerticalHalfExtentUu)
     -> bool
 {
     SCOPE_CYCLE_COUNTER(STAT_Nav_ProjectOntoNavmesh);
@@ -140,7 +141,10 @@ auto
     { return false; }
 
     const auto HalfExt = FMath::Max(InHalfExtentUu, 1.0f);
-    const auto ProjectionExtent = FVector{HalfExt, HalfExt, HalfExt};
+    // Negative vertical extent (the default) preserves the uniform cube; a caller with a known
+    // floor band passes a tight Z so the snap can't select a stray surface far above/below.
+    const auto VertHalfExt = (InVerticalHalfExtentUu < 0.0f) ? HalfExt : FMath::Max(InVerticalHalfExtentUu, 1.0f);
+    const auto ProjectionExtent = FVector{HalfExt, HalfExt, VertHalfExt};
 
     auto Projected = FNavLocation{};
     const auto bSuccess = NavSys->ProjectPointToNavigation(InWorldPosition, Projected, ProjectionExtent);

--- a/Source/CkNavigation/Public/CkNavigation/Utils/CkNav_Utils.h
+++ b/Source/CkNavigation/Public/CkNavigation/Utils/CkNav_Utils.h
@@ -94,7 +94,8 @@ public:
         UPARAM(ref) FCk_Handle& InHandle,
         FVector InWorldPosition,
         float InHalfExtentUu,
-        FVector& OutSnappedPosition);
+        FVector& OutSnappedPosition,
+        float InVerticalHalfExtentUu = -1.0f);
 
 public:
     // Bind a delegate to fire whenever a FindPath request on this entity succeeds.


### PR DESCRIPTION
## Problem

The Start/End navmesh projection in `FindPathSync` uses a **uniform cube** (`_NavQuerySearchHalfExtent`, default 500uu). Near multi-layer geometry, `ProjectPointToNavigation` can snap a path's Start or End onto a stray walkable layer far **above or below** the intended floor. Crowd agents have no gravity/floor collision — Z is pure steering integration — so they faithfully walk to those wrong-Z waypoints. Observed in BusterBlock as checkout NPCs **sinking into the basement / floating upward** (agent Z −465..+388 against a Z=1 floor; 35k below-floor recovery events in one session).

## Fix

New opt-in `_NavQueryVerticalHalfExtent` project setting:

- **`-1` (default): behavior is byte-for-byte today's uniform cube** — no existing consumer or project changes unless its ini opts in.
- `>= 0`: the projection box becomes asymmetric `FVector(XY, XY, Z)`, so horizontal reach is unchanged while stray vertical layers fall out of range.

Threaded consistently so no probe can disagree with the real query:
- `FindPathSync` — new `InProjectionVerticalHalfExtent` param (both callers updated; the CkGameplayDebugger health-check caller passes `-1`).
- Both `CkNav_Processor` readiness probes (defer gate + deferred-drain re-probe) and the `CkCrowd` `DrawNavProjection` overlay — all via a new shared `Get_NavQueryProjectionExtentVec()`.
- `Try_ProjectOntoNavmesh` — defaulted trailing param, existing BP/AS callers source-compatible.
- The 8x diagnostic retry deliberately stays a cube: it reports whether the tight box was the constraint.

## Tuning guidance (learned the hard way)

The vertical extent must still cover **legitimate elevated path goals**: shelf/gondola pivots sit ~185uu above the floor and direct-to-pivot paths fail End-projection below that (Gauntlet-proven at 150). BusterBlock ships `200`.

## Verification

- CkCrowd pathfinding/separation AutoTests: 8/8 green (default `-1` path).
- BusterBlock Gauntlet `PlayerStoreLoop_EndToEnd`: green with `200` on real store navmesh (and red at `150`, which is how the shelf-pivot constraint was found).
- Live PIE on the originating map: below/above-floor recovery events went from 35,435/session to **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
