### PR TITLE
feat(CkEcs): entity-carried spawn params + NotInstanced lifecycle correctness

### DIFF
--- a/Source/CkCue/Public/CkCue/CkCueSubsystem_Base.cpp
+++ b/Source/CkCue/Public/CkCue/CkCueSubsystem_Base.cpp
@@ -138,7 +138,17 @@ namespace ck_cue_subsystem_base
                     ck::IsValid(CueScript))
                 {
                     ck::cue::Verbose(TEXT("Restarting existing cue [{}] on entity [{}]"), InCueName, InOwnerEntity);
-                    UCk_Utils_EntityScript_UE::TryInjectEntityScriptSpawnParams(CueScript, InSpawnParams);
+                    if (ck::IsValid(InSpawnParams))
+                    {
+                        // Keep the entity's stored params (Get_SpawnParams) coherent with the restart's params.
+                        UCk_Utils_EntityScript_UE::Set_SpawnParams(ExistingCue, InSpawnParams);
+
+                        // CDO-shared scripts must never have members injected — see the spawn processor.
+                        if (CueScript->Get_InstancingPolicy() == ECk_EntityScript_InstancingPolicy::InstancedPerEntity)
+                        {
+                            UCk_Utils_EntityScript_UE::TryInjectEntityScriptSpawnParams(CueScript, InSpawnParams);
+                        }
+                    }
                     CueScript->Restart();
                     return FCk_Handle_PendingEntityScript{ExistingCue};
                 }

--- a/Source/CkEcs/Claude.md
+++ b/Source/CkEcs/Claude.md
@@ -169,6 +169,17 @@ class UCk_EntityScript_UE : public UCk_GameWorldContextObject_UE
 - `Get_AssociatedEntity()` — the entity this script is attached to (from C++).
 - `DoGet_ScriptEntity()` — same, exposed as a Blueprint callable (use from BPs/AS).
 - Instancing policy: `InstancedPerEntity` (default) creates one instance per spawned entity; `NotInstanced` shares the CDO — use the CDO mode only for stateless scripts.
+- Spawn params live on the entity: `FFragment_EntityScript_Current` carries the spawn request's
+  `FInstancedStruct`, readable via `UCk_Utils_EntityScript_UE::Get_SpawnParams` /
+  `TryGet_SpawnParams<T>` (C++) or `DoGet_SpawnParams()` on the script (BP/AS; extract typed via
+  `FInstancedStruct.Get(StructType)` in AS).
+- `NotInstanced` contract: ExposeOnSpawn member injection is SKIPPED for CDO-shared scripts (a
+  later same-class spawn would clobber the shared object's members before the deferred BeginPlay
+  processor runs, and injection would permanently mutate class defaults). CDO-shared scripts read
+  per-entity data via `DoGet_SpawnParams()`; the lifecycle processors re-stamp `_AssociatedEntity`
+  before every deferred callback (ContinueConstruction/BeginPlay/EndPlay), so
+  `DoGet_ScriptEntity()` is per-callback-correct on the shared object. User-declared mutable
+  members remain shared state — keep CDO-mode scripts stateless.
 
 ---
 

--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript.cpp
@@ -70,6 +70,29 @@ auto
 
 auto
     UCk_EntityScript_UE::
+    DoGet_SpawnParams() const
+    -> FInstancedStruct
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(_AssociatedEntity),
+        TEXT("Cannot read SpawnParams — ScriptEntity is [{}]. {}\n{}"),
+        _AssociatedEntity,
+        _AssociatedEntity.Has<ck::FTag_EntityScript_HasEndedPlay>()
+        ? TEXT("The Script has ALREADY EndedPlay. Ensure that no lingering Latent Actions are still being performed")
+        : TEXT("It's possible that this was not set correctly by the Processor that spawned the entity script"),
+        ck::Context(this))
+    { return {}; }
+
+    CK_ENSURE_IF_NOT(_AssociatedEntity.Has<ck::FFragment_EntityScript_Current>(),
+        TEXT("ScriptEntity [{}] has no EntityScript fragment when reading SpawnParams.\n{}"),
+        _AssociatedEntity,
+        ck::Context(this))
+    { return {}; }
+
+    return _AssociatedEntity.Get<ck::FFragment_EntityScript_Current>().Get_SpawnParams();
+}
+
+auto
+    UCk_EntityScript_UE::
     DoFinishConstruction()
     -> void
 {

--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript.h
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript.h
@@ -5,6 +5,8 @@
 #include "CkEcs/Handle/CkHandle.h"
 #include "CoreMinimal.h"
 
+#include <StructUtils/InstancedStruct.h>
+
 #include "CkEntityScript.generated.h"
 
 // -----------------------------------------------------------------------------------------------------------
@@ -12,6 +14,9 @@
 namespace ck
 {
     class FProcessor_EntityScript_SpawnEntity_HandleRequests;
+    class FProcessor_EntityScript_ContinueConstruction;
+    class FProcessor_EntityScript_BeginPlay;
+    class FProcessor_EntityScript_EndPlay;
 }
 
 // -----------------------------------------------------------------------------------------------------------
@@ -55,6 +60,11 @@ public:
 
 public:
     friend class ck::FProcessor_EntityScript_SpawnEntity_HandleRequests;
+    // Lifecycle processors re-stamp _AssociatedEntity before each deferred callback so that
+    // NotInstanced (CDO-shared) scripts resolve self-access against the entity being processed.
+    friend class ck::FProcessor_EntityScript_ContinueConstruction;
+    friend class ck::FProcessor_EntityScript_BeginPlay;
+    friend class ck::FProcessor_EntityScript_EndPlay;
     friend class UCk_Utils_EntityScript_UE;
 
 public:
@@ -99,6 +109,18 @@ protected:
         meta = (CompactNodeTitle="ScriptEntity", Keywords="this, associated", HideSelfPin = true))
     FCk_Handle
     DoGet_ScriptEntity() const;
+
+    // Per-entity spawn params, read from the script entity's fragment. This — not injected member
+    // properties — is the supported way for a NotInstanced (CDO-shared) script to read its params
+    // in BeginPlay/EndPlay: member injection is skipped for CDO-shared scripts since a later
+    // same-class spawn would overwrite the shared object's members before this script's deferred
+    // callbacks run. AS/BP extract the typed struct via FInstancedStruct.Get(StructType).
+    UFUNCTION(BlueprintPure,
+        Category = "Ck|EntityScript",
+        DisplayName = "[Ck][EntityScript] Get Spawn Params",
+        meta = (CompactNodeTitle="SpawnParams", Keywords="this, params, exposed", HideSelfPin = true))
+    FInstancedStruct
+    DoGet_SpawnParams() const;
 
     UFUNCTION(BlueprintCallable,
               Category = "Ck|EntityScript",

--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Fragment.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Fragment.cpp
@@ -18,8 +18,10 @@ namespace ck
 {
     FFragment_EntityScript_Current::
         FFragment_EntityScript_Current(
-            UCk_EntityScript_UE* InScript)
+            UCk_EntityScript_UE* InScript,
+            FInstancedStruct InSpawnParams)
         : _Script(InScript)
+        , _SpawnParams(MoveTemp(InSpawnParams))
     {
     }
 
@@ -51,6 +53,10 @@ namespace ck
 
         if (_Script.IsValid())
         { _Script->Serialize(InAr); }
+
+        // FInstancedStruct round-trips its own struct-type path + payload. NOTE: this widens the
+        // snapshot stream — snapshots captured before _SpawnParams existed cannot be restored.
+        _SpawnParams.Serialize(InAr);
     }
 
     FRequest_EntityScript_Replicate::

--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Fragment.h
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Fragment.h
@@ -10,6 +10,8 @@
 #include "CkEcs/Handle/CkDebugCallstack_Macros.h"
 #include "CkEcs/Concepts/CkSnapshot_Concepts.h" // forward-declares ck::FSnapshotContext for the SerializeSnapshot decl
 
+#include <StructUtils/InstancedStruct.h>
+
 // --------------------------------------------------------------------------------------------------------------------
 
 class UCk_EntityScript_UE;
@@ -64,13 +66,20 @@ namespace ck
 
         explicit
         FFragment_EntityScript_Current(
-            UCk_EntityScript_UE* InScript);
+            UCk_EntityScript_UE* InScript,
+            FInstancedStruct InSpawnParams = {});
 
     private:
         TStrongObjectPtr<UCk_EntityScript_UE> _Script;
 
+        // Per-entity copy of the spawn request's params. Authoritative for NotInstanced (CDO-shared)
+        // scripts, whose deferred callbacks (BeginPlay/EndPlay) cannot rely on member injection —
+        // a second same-class spawn before BeginPlay would have clobbered the shared object's members.
+        FInstancedStruct _SpawnParams;
+
     public:
         CK_PROPERTY_GET(_Script);
+        CK_PROPERTY_GET(_SpawnParams);
 
     public:
         // Path #3 (Section 1): round-trips the EntityScript instance via its class-path + UObject::Serialize.

--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Processor.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Processor.cpp
@@ -128,13 +128,20 @@ namespace ck
         if (const auto& SpawnParams = InRequest.Get_SpawnParams();
             ck::IsValid(SpawnParams))
         {
-            UCk_Utils_EntityScript_UE::TryInjectEntityScriptSpawnParams(NewEntityScript, SpawnParams);
+            // NotInstanced scripts share one object (the CDO) across every spawned entity — member
+            // injection there both clobbers an earlier same-frame spawn's values (BeginPlay runs in a
+            // later processor) and permanently mutates class defaults. CDO-shared scripts read their
+            // params from the entity instead (FFragment_EntityScript_Current, populated below).
+            if (EntityScriptClassArchetype->Get_InstancingPolicy() == ECk_EntityScript_InstancingPolicy::InstancedPerEntity)
+            {
+                UCk_Utils_EntityScript_UE::TryInjectEntityScriptSpawnParams(NewEntityScript, SpawnParams);
+            }
         }
 
         auto NewEntity = InRequest.Get_NewEntity();
 
         NewEntityScript->_AssociatedEntity = NewEntity;
-        NewEntity.Add<FFragment_EntityScript_Current>(NewEntityScript);
+        NewEntity.Add<FFragment_EntityScript_Current>(NewEntityScript, InRequest.Get_SpawnParams());
 
         CK_CALLSTACK_RECORD_MSG(ck::FFragment_EntityScript_Current, NewEntity,
             TEXT("EntityScript created: {}"), EntityScriptClassArchetype);
@@ -279,6 +286,12 @@ namespace ck
         { return; }
 
         CK_CALLSTACK_RECORD(ck::FFragment_EntityScript_Current, InHandle);
+
+        // Flyweight context switch: a NotInstanced (CDO-shared) script's back-pointer holds whichever
+        // entity was spawned LAST — re-stamp it for this callback so DoGet_ScriptEntity()/
+        // DoGet_SpawnParams() resolve against the entity actually being processed. No-op re-assign
+        // for InstancedPerEntity scripts.
+        EntityScript->_AssociatedEntity = InHandle;
         EntityScript->ContinueConstruction(InHandle);
     }
 
@@ -458,6 +471,9 @@ namespace ck
         { return; }
 
         CK_CALLSTACK_RECORD(ck::FFragment_EntityScript_Current, InHandle);
+
+        // Flyweight context switch — see FProcessor_EntityScript_ContinueConstruction.
+        EntityScript->_AssociatedEntity = InHandle;
         EntityScript->BeginPlay();
 
         InHandle.Add<FTag_EntityScript_HasBegunPlay>();
@@ -479,6 +495,9 @@ namespace ck
         { return; }
 
         CK_CALLSTACK_RECORD(ck::FFragment_EntityScript_Current, InHandle);
+
+        // Flyweight context switch — see FProcessor_EntityScript_ContinueConstruction.
+        EntityScript->_AssociatedEntity = InHandle;
         EntityScript->EndPlay();
         InHandle.Add<FTag_EntityScript_HasEndedPlay>();
     }

--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Utils.cpp
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Utils.cpp
@@ -65,6 +65,29 @@ auto
 
 auto
     UCk_Utils_EntityScript_UE::
+    Get_SpawnParams(
+        const FCk_Handle_EntityScript& InHandle)
+    -> FInstancedStruct
+{
+    return InHandle.Get<ck::FFragment_EntityScript_Current>().Get_SpawnParams();
+}
+
+auto
+    UCk_Utils_EntityScript_UE::
+    Set_SpawnParams(
+        FCk_Handle& InScriptEntity,
+        const FInstancedStruct& InSpawnParams)
+    -> void
+{
+    CK_ENSURE_IF_NOT(InScriptEntity.Has<ck::FFragment_EntityScript_Current>(),
+        TEXT("Entity [{}] has no EntityScript fragment — cannot set SpawnParams"), InScriptEntity)
+    { return; }
+
+    InScriptEntity.Get<ck::FFragment_EntityScript_Current>()._SpawnParams = InSpawnParams;
+}
+
+auto
+    UCk_Utils_EntityScript_UE::
     Relink_AssociatedEntities_AfterRestore(
         UWorld* InWorld)
     -> int32

--- a/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Utils.h
+++ b/Source/CkEcs/Public/CkEcs/EntityScript/CkEntityScript_Utils.h
@@ -65,6 +65,25 @@ public:
     Get_ScriptClass(
         const FCk_Handle_EntityScript& InHandle);
 
+    // Per-entity copy of the params the entity was spawned with. Invalid (empty) when the spawn
+    // passed none. This — not injected member properties — is the supported read for NotInstanced
+    // (CDO-shared) scripts. BP/AS extract the typed struct via FInstancedStruct.Get(StructType);
+    // C++ prefers TryGet_SpawnParams<T> below (no payload copy).
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|EntityScript",
+              DisplayName="[Ck][EntityScript] Get_SpawnParams")
+    static FInstancedStruct
+    Get_SpawnParams(
+        const FCk_Handle_EntityScript& InHandle);
+
+public:
+    // C++-only typed access — nullptr when the entity carries no spawn params or they hold a
+    // different struct type.
+    template <typename T_ParamsStruct>
+    static auto
+    TryGet_SpawnParams(
+        const FCk_Handle_EntityScript& InHandle) -> const T_ParamsStruct*;
+
 public:
     // Re-establish every entity script's _AssociatedEntity back-pointer to its owning entity after a CkSnapshot
     // restore. The back-pointer is a Transient field set only at spawn (see FProcessor_EntityScript_SpawnEntity),
@@ -123,6 +142,14 @@ public:
         UCk_EntityScript_UE* InEntityScript,
         const FInstancedStruct& InSpawnParams) -> void;
 
+    // Replaces the entity's stored spawn params (FFragment_EntityScript_Current). For in-place
+    // re-parameterization flows where no new spawn request runs (e.g. cue RestartExisting) —
+    // keeps Get_SpawnParams/DoGet_SpawnParams coherent with what the script was last given.
+    static auto
+    Set_SpawnParams(
+        FCk_Handle& InScriptEntity,
+        const FInstancedStruct& InSpawnParams) -> void;
+
     // Establishes entity-script replication for an already-constructed, driver-bearing entity on the authority:
     // resolves the owning driver, accounts for a just-created owner's dependent count, calls Request_Replicate (which
     // sets the driver's ReplicationData_EntityScript — the payload Iris pushes so clients materialise + re-derive the
@@ -137,6 +164,21 @@ public:
         const FInstancedStruct& InSpawnParams,
         const TOptional<FCk_Handle>& InContextOwnerOverride = {}) -> void;
 };
+
+// --------------------------------------------------------------------------------------------------------------------
+
+template <typename T_ParamsStruct>
+auto
+    UCk_Utils_EntityScript_UE::
+    TryGet_SpawnParams(
+        const FCk_Handle_EntityScript& InHandle)
+    -> const T_ParamsStruct*
+{
+    if (NOT InHandle.Has<ck::FFragment_EntityScript_Current>())
+    { return nullptr; }
+
+    return InHandle.Get<ck::FFragment_EntityScript_Current>().Get_SpawnParams().template GetPtr<T_ParamsStruct>();
+}
 
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/Source/CkSnapshot/Public/CkSnapshot/SaveGame/CkSnapshot_Header.h
+++ b/Source/CkSnapshot/Public/CkSnapshot/SaveGame/CkSnapshot_Header.h
@@ -50,7 +50,9 @@ public:
     //   1 — initial format.
     //   2 — dynamic-fragment handle remap covers TYPED handles (IsChildOf, not exact-match) + TSet/TMap containers,
     //       so v2 streams carry handle ids a v1 reader would not expect (and vice versa) — no cross-compatibility.
-    static constexpr uint16 CurrentFormatVersion = 2;
+    //   3 — FFragment_EntityScript_Current now serializes _SpawnParams (FInstancedStruct) after the script object,
+    //       widening every entity-script entity's stream — a v2 reader would misparse it.
+    static constexpr uint16 CurrentFormatVersion = 3;
 
 private:
     UPROPERTY() uint16              _FormatVersion = CurrentFormatVersion;


### PR DESCRIPTION
## Problem

`NotInstanced` entity scripts share one object (the CDO), but BeginPlay/EndPlay run in later processors than spawn handling. Two same-frame spawns of one class meant the second `TryInjectEntityScriptSpawnParams` clobbered the first entity's injected members **and** the shared `_AssociatedEntity` back-pointer before either BeginPlay ran — both entities then observed the second spawn's params and identity. Injection into the CDO also permanently mutated class defaults.

## Design

Per-entity data moves onto the entity; the shared script object becomes a proper flyweight:

- **`FFragment_EntityScript_Current` carries the spawn request's `FInstancedStruct`** — read via `UCk_Utils_EntityScript_UE::Get_SpawnParams` / `TryGet_SpawnParams<T>` (C++), or `DoGet_SpawnParams()` on the script (BP/AS — AS extracts typed via `FInstancedStruct.Get(StructType)`, so no generator changes needed).
- **CDO-shared scripts skip ExposeOnSpawn member injection entirely** (`InstancedPerEntity` injection unchanged).
- **Lifecycle processors re-stamp `_AssociatedEntity` before every deferred callback** (ContinueConstruction/BeginPlay/EndPlay), so `DoGet_ScriptEntity()` is per-callback-correct on the shared object.
- **Cue `RestartExisting`** now updates the stored params (`Set_SpawnParams`) so `Get_SpawnParams` stays coherent across in-place restarts, and respects the CDO injection rule.
- **Snapshot format v2 → v3** — the fragment stream widened (`_SpawnParams` serialized after the script object); v2 snapshots are rejected loudly at load instead of misparsing.
- Docs: `Source/CkEcs/Claude.md` EntityScript section documents the NotInstanced contract.

`Construct` was never affected (params arrive as an argument); the broken window was exactly the deferred callbacks reading injected member state.

## Gates (all on the final Development binary, BusterBlock host)

- `Ck.Snapshot.*`: **51/51**
- EntityScript AutoTests: **6/6**, including the new regression pin `Ck_AutoTest_EntityScript_CdoSharedDistinctParams` (chainkemists/CkTests PR — `feature/entityscript-cdo-spawnparams-tests`)
- Cue AutoTests: **8/8**
- Full CkTests sweep (pre cue-coherence fix): **688/688**

## Known gaps / follow-ups (not blockers)

- `NotInstanced` + `Replicates` remains unguarded (pre-existing; conceptually broken combo, zero in-tree users — `Get_AreSpawnParamsMatching` reads member values which CDO scripts no longer receive). Suggest a follow-up ensure.
- EndPlay/ContinueConstruction stamping is code-identical to the tested BeginPlay stamp but not separately asserted.
- Cue `RestartExisting` has gym coverage only (`CkCueGym_Restart`) — no headless AutoTest exercises that branch.
- Optional sugar deferred: per-class typed `Get_SpawnParams` emission in `CkAngelscriptEntityScriptParamsGenerator` (AS `FInstancedStruct.Get(StructType)` already covers typed access).
- `[EDITOR-VERIFY]`: drop the `Get Spawn Params` node in a BP graph (BP surface inferred from reflection, not manually exercised).
