### PR TITLE
feat(editor-tools): shared CkStyle tokens module + structured Insights Analyzer GUI

### DIFF
--- a/CkFoundation.uplugin
+++ b/CkFoundation.uplugin
@@ -367,6 +367,16 @@
       ]
     },
     {
+      "Name": "CkEditorTools",
+      "Type": "Runtime",
+      "LoadingPhase": "Default",
+      "WhitelistPlatforms": [
+        "Win64",
+        "Mac",
+        "Linux"
+      ]
+    },
+    {
       "Name": "CkEditorGraph",
       "Type": "UncookedOnly",
       "LoadingPhase": "Default",

--- a/Source/CLAUDE.md
+++ b/Source/CLAUDE.md
@@ -93,6 +93,7 @@ Before writing any code, navigate the documentation in this order:
 | physics-substep ticking | `CkSubstep` |
 | project settings exposed to editor | `CkSettings` |
 | console variables / runtime tuning | `CkCVar` |
+| style tokens for editor-tool Slate UI (colors, fonts, tones) | `CkEditorTools` + `CkStyle::` |
 | log a message | `CkLog` (per-module `ck::<feature>` functions — root CLAUDE.md) |
 | profile a processor | `CkProfile` + `SCOPE_CYCLE_COUNTER` |
 | generate AngelScript accessors | `CkAngelscriptGenerator` (Editor module) |
@@ -119,6 +120,7 @@ but **deps must never point to a higher band**. Editor/UncookedOnly modules are 
 |---|---|
 | CkCVar | Core,Log |
 | CkCore | BuildConfig,Log,Settings,ThirdParty |
+| CkEditorTools | Settings (added 2026-07-09; Runtime on purpose — consumed by CkGameplayDebugger's Runtime modules; hosts the shared `CkStyle::` tokens + `UCk_Style_UserSettings_UE`) |
 | CkLog | Settings,ThirdParty |
 | CkMemory | Core,Log |
 | CkPerception | Core,Log,ThirdParty |

--- a/Source/CkEditorTools/CkEditorTools.Build.cs
+++ b/Source/CkEditorTools/CkEditorTools.Build.cs
@@ -1,0 +1,20 @@
+using UnrealBuildTool;
+
+public class CkEditorTools : CkModuleRules
+{
+    public CkEditorTools(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PublicDependencyModuleNames.AddRange(new string[]
+        {
+            "Core",
+            "CoreUObject",
+            "Engine",
+            "DeveloperSettings",
+            "Slate",
+            "SlateCore",
+
+            // For UCk_Plugin_UserSettings_UE base class.
+            "CkSettings",
+        });
+    }
+}

--- a/Source/CkEditorTools/CkEditorTools_Module.cpp
+++ b/Source/CkEditorTools/CkEditorTools_Module.cpp
@@ -1,0 +1,21 @@
+#include "CkEditorTools_Module.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCkEditorToolsModule::
+    StartupModule()
+    -> void
+{
+}
+
+auto
+    FCkEditorToolsModule::
+    ShutdownModule()
+    -> void
+{
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+IMPLEMENT_MODULE(FCkEditorToolsModule, CkEditorTools)

--- a/Source/CkEditorTools/CkEditorTools_Module.h
+++ b/Source/CkEditorTools/CkEditorTools_Module.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+class FCkEditorToolsModule : public IModuleInterface
+{
+public:
+    auto StartupModule() -> void override;
+    auto ShutdownModule() -> void override;
+};
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkEditorTools/Claude.md
+++ b/Source/CkEditorTools/Claude.md
@@ -1,0 +1,34 @@
+# CkEditorTools
+
+**Purpose:** Shared styling tokens for Ck editor tooling UIs — the `CkStyle::` palette/typography
+namespace (`Style/CkStyle.h`), the `ECk_Tone` semantic tone enum, and the backing per-user
+settings class `UCk_Style_UserSettings_UE` (Editor Preferences → Ck → Style). Migrated from
+CkGameplayDebugger's `CkDebuggerCommon/Style/CkDebugStyle` so debugger and CkFoundation editor
+tools (e.g. CkInsightsAnalyzer) share one look.
+
+**Type:** Runtime (NOT UncookedOnly) — deliberate: the consumers include Runtime-type debugger
+modules (`CkDebuggerCommon`, `CkEntityDebugOverlay` in the CkGameplayDebugger plugin), and a
+Runtime module cannot depend on an UncookedOnly one. Same precedent as those modules.
+
+**Depends on:** `CkSettings` (user-settings base). No other Ck deps.
+**Used by:** CkInsightsAnalyzer; the CkGameplayDebugger plugin's Slate debugger modules (via
+`CkDebuggerCommon`).
+
+---
+
+## Key API
+
+- `CkStyle::` — lazy accessors for every palette/typography token (`Bg1()`, `Text()`, `Accent()`,
+  `FontSizeBody()`, …), spacing constants (`SpaceS/M/L/…`), `GetFilledBrush()`,
+  `GetToneColor(ECk_Tone)`.
+- `ECk_Tone` — Neutral/Info/Ok/Warn/Err/Accent semantic tones.
+- `UCk_Style_UserSettings_UE` — the tunables; read live via `GetDefault<>`, never cached.
+
+---
+
+## Anti-patterns
+
+- Don't hardcode colors/font sizes in Ck editor tool Slate — route through `CkStyle::`.
+- Don't add a constructor to the settings class (base only accepts FObjectInitializer); defaults
+  are inline on each UPROPERTY.
+- Don't allocate brushes in paint paths — use `CkStyle::GetFilledBrush()`.

--- a/Source/CkEditorTools/Public/CkEditorTools/Settings/CkStyleSettings.h
+++ b/Source/CkEditorTools/Public/CkEditorTools/Settings/CkStyleSettings.h
@@ -1,0 +1,331 @@
+#pragma once
+
+#include "CkSettings/UserSettings/CkUserSettings.h"
+
+#include "CkStyleSettings.generated.h"
+
+// ====================================================================================================================
+// Editor-time tunables for Ck editor tooling UIs (debuggers, analyzers, future
+// Slate tools). Displayed in Editor Preferences under "Ck → Style".
+// All values are read live via GetDefault<UCk_Style_UserSettings_UE>(),
+// normally through the CkStyle:: accessors in CkEditorTools/Style/CkStyle.h.
+//
+// Defaults are set inline on each UPROPERTY below — do NOT add a constructor;
+// the inherited UCk_Plugin_UserSettings_UE only accepts FObjectInitializer.
+// ====================================================================================================================
+
+UCLASS(meta = (DisplayName = "Style"))
+class CKEDITORTOOLS_API UCk_Style_UserSettings_UE : public UCk_Plugin_UserSettings_UE
+{
+	GENERATED_BODY()
+
+public:
+	virtual auto GetCategoryName() const -> FName override { return TEXT("Ck"); }
+	virtual auto GetSectionName()  const -> FName override { return TEXT("Style"); }
+
+	// ----- Palette: Backgrounds — each tier slightly lighter than the last --
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Backgrounds")
+	FLinearColor BgRoot = FLinearColor(FColor(0x0b, 0x0e, 0x13, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Backgrounds")
+	FLinearColor Bg1 = FLinearColor(FColor(0x11, 0x15, 0x1c, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Backgrounds")
+	FLinearColor Bg2 = FLinearColor(FColor(0x16, 0x1b, 0x24, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Backgrounds")
+	FLinearColor Bg3 = FLinearColor(FColor(0x1b, 0x22, 0x30, 255));
+
+	// ----- Palette: Borders --------------------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Borders")
+	FLinearColor Border = FLinearColor(FColor(0x23, 0x2a, 0x38, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Borders")
+	FLinearColor BorderStrong = FLinearColor(FColor(0x32, 0x39, 0x4a, 255));
+
+	// ----- Palette: Text -----------------------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Text")
+	FLinearColor Text = FLinearColor(FColor(0xe5, 0xe7, 0xed, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Text")
+	FLinearColor TextDim = FLinearColor(FColor(0x8a, 0x92, 0xa4, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Text")
+	FLinearColor TextMute = FLinearColor(FColor(0x5a, 0x62, 0x77, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Text")
+	FLinearColor TextStrong = FLinearColor(0.95f, 0.95f, 0.95f);
+
+	// ----- Palette: Selection & Hover ---------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Selection")
+	FLinearColor Selection = FLinearColor(0.2f, 0.4f, 0.8f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Selection")
+	FLinearColor SelectionInactive = FLinearColor(0.15f, 0.15f, 0.2f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Selection")
+	FLinearColor Hover = FLinearColor(0.06f, 0.06f, 0.08f);
+
+	// ----- Palette: Domain (ECS / component semantics) ----------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor None = FLinearColor(0.4f, 0.4f, 0.4f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor EntityId = FLinearColor(0.51f, 0.69f, 1.0f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor Transform = FLinearColor(0.76f, 0.91f, 0.55f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor Network = FLinearColor(1.0f, 0.8f, 0.01f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor Relationship = FLinearColor(0.97f, 0.73f, 0.85f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor Attribute = FLinearColor(0.55f, 0.85f, 0.95f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor Reference = FLinearColor(0.51f, 0.69f, 1.0f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor PickMarker_Default = FLinearColor(0.35f, 0.75f, 0.95f, 0.65f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Domain")
+	FLinearColor PickMarker_Hover = FLinearColor(1.0f, 0.9f, 0.2f, 1.0f);
+
+	// ----- Palette: Value-type colors ---------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Bool_True = FLinearColor(0.2f, 1.0f, 0.4f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Bool_False = FLinearColor(1.0f, 0.4f, 0.4f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Numeric = FLinearColor(0.6f, 0.9f, 0.6f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_String = FLinearColor(1.0f, 0.85f, 0.5f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Math = FLinearColor(0.7f, 0.7f, 1.0f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Tag = FLinearColor(0.8f, 0.6f, 1.0f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Enum = FLinearColor(0.5f, 0.9f, 0.9f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Object = FLinearColor(0.9f, 0.7f, 0.4f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Values")
+	FLinearColor Value_Handle = FLinearColor(0.4f, 0.8f, 1.0f);
+
+	// ----- Palette: State colors --------------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|States")
+	FLinearColor State_Enabled = FLinearColor(0.0f, 1.0f, 0.5f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|States")
+	FLinearColor State_Disabled = FLinearColor(1.0f, 0.5f, 0.5f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|States")
+	FLinearColor State_Overlapping = FLinearColor(1.0f, 0.95f, 0.0f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|States")
+	FLinearColor State_Config = FLinearColor(1.0f, 0.8f, 0.01f);
+
+	// ----- Palette: Status colors (objective / task progress) --------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Status")
+	FLinearColor Status_NotStarted = FLinearColor(0.5f, 0.5f, 0.5f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Status")
+	FLinearColor Status_Active = FLinearColor(0.55f, 0.78f, 0.95f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Status")
+	FLinearColor Status_Completed = FLinearColor(0.6f, 0.85f, 0.55f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Status")
+	FLinearColor Status_Failed = FLinearColor(0.95f, 0.35f, 0.3f);
+
+	// ----- Palette: Graph canvas colors -------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Graph")
+	FLinearColor Graph_Background = FLinearColor(FColor(0x0D, 0x0D, 0x14));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Graph")
+	FLinearColor Graph_Edge = FLinearColor(0.4f, 0.4f, 0.45f);
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Graph")
+	FLinearColor Graph_Node_Center = FLinearColor(FColor(0x2D, 0x2D, 0x3D));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Graph")
+	FLinearColor Graph_Node_Default = FLinearColor(FColor(0x1E, 0x1E, 0x2E));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Graph")
+	FLinearColor Graph_Node_Border_Default = FLinearColor(FColor(0x60, 0x7D, 0x8B));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Graph")
+	FLinearColor Graph_Node_Border_Center = FLinearColor(FColor(0x4C, 0xAF, 0x50));
+
+	// ----- Palette: Semantic -------------------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Semantic")
+	FLinearColor Accent = FLinearColor(FColor(0xf5, 0xc8, 0x42, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Semantic")
+	FLinearColor Ok = FLinearColor(FColor(0x55, 0xc4, 0x7a, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Semantic")
+	FLinearColor Err = FLinearColor(FColor(0xd6, 0x5a, 0x5a, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Semantic")
+	FLinearColor Warn = FLinearColor(FColor(0xe6, 0xa5, 0x45, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Semantic")
+	FLinearColor Info = FLinearColor(FColor(0x5f, 0xb3, 0xd4, 255));
+
+	// ----- Palette: Action Categories ---------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Categories")
+	FLinearColor CategoryGather = FLinearColor(FColor(0x4e, 0xa8, 0x4e, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Categories")
+	FLinearColor CategoryBuild = FLinearColor(FColor(0xc2, 0x8a, 0x2a, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Categories")
+	FLinearColor CategoryResearch = FLinearColor(FColor(0x5f, 0xb3, 0xd4, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Categories")
+	FLinearColor CategoryTrain = FLinearColor(FColor(0xc7, 0x4c, 0x4c, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Categories")
+	FLinearColor CategoryAge = FLinearColor(FColor(0xb4, 0x6f, 0xd0, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Palette|Categories")
+	FLinearColor CategoryTrade = FLinearColor(FColor(0xd4, 0xb1, 0x5f, 255));
+
+	// ----- Typography --------------------------------------------------------
+	// Global scale. Per-widget sizes below override these where needed.
+	UPROPERTY(Config, EditAnywhere, Category = "Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 FontSizeH2 = 12;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 FontSizeH3 = 10;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 FontSizeH4 = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 FontSizeBody = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 FontSizeSmall = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 FontSizeMicro = 8;
+
+	// ----- Pane Headings -----------------------------------------------------
+	// Every pane header is a separate tunable so nothing sneaks through with a
+	// hardcoded size/color.
+	UPROPERTY(Config, EditAnywhere, Category = "Pane Headings", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PaneHeadingFontSize = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Pane Headings")
+	FLinearColor PaneHeadingColor = FLinearColor(FColor(0x8a, 0x92, 0xa4, 255));
+
+	// ----- Plan Strip --------------------------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PlanStrip_TitleFontSize = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PlanStrip_MetaFontSize = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PlanStrip_GoalLabelFontSize = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PlanStrip_GoalNameFontSize = 10;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PlanStrip_StepNameFontSize = 10;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PlanStrip_StepCostFontSize = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip", meta = (ClampMin = 6, ClampMax = 24))
+	int32 PlanStrip_StepStateFontSize = 7;
+
+	// Step pill color trios. Opaque fills, not tints — flat translucent
+	// overlays read as a saturated wash, opaque gives depth.
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Pending Step")
+	FLinearColor PlanStep_Fill_Pending = FLinearColor(FColor(0x16, 0x1b, 0x24, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Pending Step")
+	FLinearColor PlanStep_Border_Pending = FLinearColor(FColor(0x23, 0x2a, 0x38, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Pending Step")
+	FLinearColor PlanStep_Badge_Pending = FLinearColor(FColor(0x1b, 0x22, 0x30, 255));
+
+	// Active (currently-executing) step uses a teal family so it reads as
+	// distinct from goals (amber Accent) and the rest of the plan (Info blue).
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Active Step")
+	FLinearColor PlanStep_Fill_Active = FLinearColor(FColor(0x0a, 0x28, 0x22, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Active Step")
+	FLinearColor PlanStep_Border_Active = FLinearColor(FColor(0x5f, 0xd4, 0xb3, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Active Step")
+	FLinearColor PlanStep_Badge_Active = FLinearColor(FColor(0x5f, 0xd4, 0xb3, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Done Step")
+	FLinearColor PlanStep_Fill_Done = FLinearColor(FColor(0x10, 0x22, 0x17, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Done Step")
+	FLinearColor PlanStep_Border_Done = FLinearColor(FColor(0x55, 0xc4, 0x7a, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Done Step")
+	FLinearColor PlanStep_Badge_Done = FLinearColor(FColor(0x55, 0xc4, 0x7a, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Goal Pill")
+	FLinearColor PlanStrip_GoalFill = FLinearColor(FColor(0x2a, 0x22, 0x0a, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Plan Strip|Goal Pill")
+	FLinearColor PlanStrip_GoalBorder = FLinearColor(FColor(0xf5, 0xc8, 0x42, 255));
+
+	// ----- Graph Nodes -------------------------------------------------------
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Inactive")
+	FLinearColor NodeFill_Inactive = FLinearColor(FColor(0x16, 0x1b, 0x24, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Inactive")
+	FLinearColor NodeBorder_Inactive = FLinearColor(FColor(0x23, 0x2a, 0x38, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|In Plan")
+	FLinearColor NodeFill_InPlan = FLinearColor(FColor(0x14, 0x23, 0x35, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|In Plan")
+	FLinearColor NodeBorder_InPlan = FLinearColor(FColor(0x5f, 0xb3, 0xd4, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Goal")
+	FLinearColor NodeFill_Goal = FLinearColor(FColor(0x2a, 0x22, 0x0a, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Goal")
+	FLinearColor NodeBorder_Goal = FLinearColor(FColor(0xf5, 0xc8, 0x42, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Goal")
+	FLinearColor NodeFill_GoalInactive = FLinearColor(FColor(0x15, 0x13, 0x08, 255));
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 NodeTitleFontSize = 10;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 NodeCostFontSize = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes|Typography", meta = (ClampMin = 6, ClampMax = 24))
+	int32 NodeMetaFontSize = 9;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes", meta = (ClampMin = 0.5, ClampMax = 5))
+	float NodeBorderThickness = 1.5f;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Graph Nodes", meta = (ClampMin = 0.1, ClampMax = 1))
+	float NodeInactiveOpacity = 0.55f;
+};
+
+// ====================================================================================================================

--- a/Source/CkEditorTools/Public/CkEditorTools/Style/CkStyle.cpp
+++ b/Source/CkEditorTools/Public/CkEditorTools/Style/CkStyle.cpp
@@ -1,0 +1,171 @@
+#include "CkStyle.h"
+
+#include "CkEditorTools/Settings/CkStyleSettings.h"
+
+#include "Styling/AppStyle.h"
+
+// ====================================================================================================================
+
+namespace ck_style
+{
+	auto DoSettings() -> const UCk_Style_UserSettings_UE*
+	{
+		return GetDefault<UCk_Style_UserSettings_UE>();
+	}
+}
+
+#define CK_STYLE_GETTER(Name) \
+	auto CkStyle::Name() -> decltype(UCk_Style_UserSettings_UE::Name) \
+	{ \
+		return ck_style::DoSettings()->Name; \
+	}
+
+// ====================================================================================================================
+
+CK_STYLE_GETTER(BgRoot)
+CK_STYLE_GETTER(Bg1)
+CK_STYLE_GETTER(Bg2)
+CK_STYLE_GETTER(Bg3)
+CK_STYLE_GETTER(Border)
+CK_STYLE_GETTER(BorderStrong)
+CK_STYLE_GETTER(Text)
+CK_STYLE_GETTER(TextDim)
+CK_STYLE_GETTER(TextMute)
+CK_STYLE_GETTER(TextStrong)
+CK_STYLE_GETTER(Accent)
+CK_STYLE_GETTER(Ok)
+CK_STYLE_GETTER(Err)
+CK_STYLE_GETTER(Warn)
+CK_STYLE_GETTER(Info)
+
+CK_STYLE_GETTER(Selection)
+CK_STYLE_GETTER(SelectionInactive)
+CK_STYLE_GETTER(Hover)
+
+CK_STYLE_GETTER(None)
+CK_STYLE_GETTER(EntityId)
+CK_STYLE_GETTER(Transform)
+CK_STYLE_GETTER(Network)
+CK_STYLE_GETTER(Relationship)
+CK_STYLE_GETTER(Attribute)
+CK_STYLE_GETTER(Reference)
+CK_STYLE_GETTER(PickMarker_Default)
+CK_STYLE_GETTER(PickMarker_Hover)
+
+CK_STYLE_GETTER(Value_Bool_True)
+CK_STYLE_GETTER(Value_Bool_False)
+CK_STYLE_GETTER(Value_Numeric)
+CK_STYLE_GETTER(Value_String)
+CK_STYLE_GETTER(Value_Math)
+CK_STYLE_GETTER(Value_Tag)
+CK_STYLE_GETTER(Value_Enum)
+CK_STYLE_GETTER(Value_Object)
+CK_STYLE_GETTER(Value_Handle)
+
+CK_STYLE_GETTER(State_Enabled)
+CK_STYLE_GETTER(State_Disabled)
+CK_STYLE_GETTER(State_Overlapping)
+CK_STYLE_GETTER(State_Config)
+
+CK_STYLE_GETTER(Status_NotStarted)
+CK_STYLE_GETTER(Status_Active)
+CK_STYLE_GETTER(Status_Completed)
+CK_STYLE_GETTER(Status_Failed)
+
+CK_STYLE_GETTER(Graph_Background)
+CK_STYLE_GETTER(Graph_Edge)
+CK_STYLE_GETTER(Graph_Node_Center)
+CK_STYLE_GETTER(Graph_Node_Default)
+CK_STYLE_GETTER(Graph_Node_Border_Default)
+CK_STYLE_GETTER(Graph_Node_Border_Center)
+
+CK_STYLE_GETTER(CategoryGather)
+CK_STYLE_GETTER(CategoryBuild)
+CK_STYLE_GETTER(CategoryResearch)
+CK_STYLE_GETTER(CategoryTrain)
+CK_STYLE_GETTER(CategoryAge)
+CK_STYLE_GETTER(CategoryTrade)
+
+CK_STYLE_GETTER(FontSizeH2)
+CK_STYLE_GETTER(FontSizeH3)
+CK_STYLE_GETTER(FontSizeH4)
+CK_STYLE_GETTER(FontSizeBody)
+CK_STYLE_GETTER(FontSizeSmall)
+CK_STYLE_GETTER(FontSizeMicro)
+
+CK_STYLE_GETTER(PaneHeadingFontSize)
+CK_STYLE_GETTER(PaneHeadingColor)
+
+CK_STYLE_GETTER(PlanStrip_TitleFontSize)
+CK_STYLE_GETTER(PlanStrip_MetaFontSize)
+CK_STYLE_GETTER(PlanStrip_GoalLabelFontSize)
+CK_STYLE_GETTER(PlanStrip_GoalNameFontSize)
+CK_STYLE_GETTER(PlanStrip_StepNameFontSize)
+CK_STYLE_GETTER(PlanStrip_StepCostFontSize)
+CK_STYLE_GETTER(PlanStrip_StepStateFontSize)
+
+CK_STYLE_GETTER(PlanStep_Fill_Pending)
+CK_STYLE_GETTER(PlanStep_Border_Pending)
+CK_STYLE_GETTER(PlanStep_Badge_Pending)
+CK_STYLE_GETTER(PlanStep_Fill_Active)
+CK_STYLE_GETTER(PlanStep_Border_Active)
+CK_STYLE_GETTER(PlanStep_Badge_Active)
+CK_STYLE_GETTER(PlanStep_Fill_Done)
+CK_STYLE_GETTER(PlanStep_Border_Done)
+CK_STYLE_GETTER(PlanStep_Badge_Done)
+CK_STYLE_GETTER(PlanStrip_GoalFill)
+CK_STYLE_GETTER(PlanStrip_GoalBorder)
+
+CK_STYLE_GETTER(NodeFill_Inactive)
+CK_STYLE_GETTER(NodeBorder_Inactive)
+CK_STYLE_GETTER(NodeFill_InPlan)
+CK_STYLE_GETTER(NodeBorder_InPlan)
+CK_STYLE_GETTER(NodeFill_Goal)
+CK_STYLE_GETTER(NodeBorder_Goal)
+CK_STYLE_GETTER(NodeFill_GoalInactive)
+CK_STYLE_GETTER(NodeTitleFontSize)
+CK_STYLE_GETTER(NodeCostFontSize)
+CK_STYLE_GETTER(NodeMetaFontSize)
+CK_STYLE_GETTER(NodeBorderThickness)
+CK_STYLE_GETTER(NodeInactiveOpacity)
+
+#undef CK_STYLE_GETTER
+
+// ====================================================================================================================
+
+auto
+	CkStyle::
+	GetFilledBrush()
+	-> const FSlateBrush*
+{
+	return FAppStyle::GetBrush(TEXT("GenericWhiteBox"));
+}
+
+auto
+	CkStyle::
+	GetRoundedBrush()
+	-> const FSlateBrush*
+{
+	// RoundedSelection_16x is not reliably registered across UE builds — when
+	// missing, Slate falls back to the "missing texture" checkerboard. Square
+	// corners with GenericWhiteBox render reliably everywhere.
+	return FAppStyle::GetBrush(TEXT("GenericWhiteBox"));
+}
+
+auto
+	CkStyle::
+	GetToneColor(ECk_Tone InTone)
+	-> FLinearColor
+{
+	switch (InTone)
+	{
+		case ECk_Tone::Info:   return Info();
+		case ECk_Tone::Ok:     return Ok();
+		case ECk_Tone::Warn:   return Warn();
+		case ECk_Tone::Err:    return Err();
+		case ECk_Tone::Accent: return Accent();
+		default:               return TextDim();
+	}
+}
+
+// ====================================================================================================================

--- a/Source/CkEditorTools/Public/CkEditorTools/Style/CkStyle.h
+++ b/Source/CkEditorTools/Public/CkEditorTools/Style/CkStyle.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+// ====================================================================================================================
+// Color, font-size, and node-visual tokens shared by Ck editor tooling UIs
+// (debuggers, analyzers, and future Slate tools). All non-constexpr values
+// route through UCk_Style_UserSettings_UE so users can tune the palette from
+// Editor Preferences → Ck → Style. The function accessors are lazy-resolved
+// so there are no static init order surprises.
+// ====================================================================================================================
+
+struct FSlateBrush;
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Semantic tone for status-style UI (pills, badges, severity-colored text).
+ * Resolve to a color via CkStyle::GetToneColor.
+ */
+enum class ECk_Tone : uint8
+{
+	Neutral,
+	Info,
+	Ok,
+	Warn,
+	Err,
+	Accent,
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CkStyle
+{
+	// ----- Helpers ------------------------------------------------------------
+	inline auto Rgb(uint8 R, uint8 G, uint8 B) -> FLinearColor
+	{
+		return FLinearColor(FColor(R, G, B, 255));
+	}
+
+	inline auto OverlayOf(const FLinearColor& InBase, float InAlpha) -> FLinearColor
+	{
+		auto C = InBase; C.A = InAlpha; return C;
+	}
+
+	// ----- Palette ------------------------------------------------------------
+	CKEDITORTOOLS_API auto BgRoot()       -> FLinearColor;
+	CKEDITORTOOLS_API auto Bg1()          -> FLinearColor;
+	CKEDITORTOOLS_API auto Bg2()          -> FLinearColor;
+	CKEDITORTOOLS_API auto Bg3()          -> FLinearColor;
+
+	CKEDITORTOOLS_API auto Border()       -> FLinearColor;
+	CKEDITORTOOLS_API auto BorderStrong() -> FLinearColor;
+
+	CKEDITORTOOLS_API auto Text()         -> FLinearColor;
+	CKEDITORTOOLS_API auto TextDim()      -> FLinearColor;
+	CKEDITORTOOLS_API auto TextMute()     -> FLinearColor;
+	CKEDITORTOOLS_API auto TextStrong()   -> FLinearColor;
+
+	CKEDITORTOOLS_API auto Accent()       -> FLinearColor;
+	CKEDITORTOOLS_API auto Ok()           -> FLinearColor;
+	CKEDITORTOOLS_API auto Err()          -> FLinearColor;
+	CKEDITORTOOLS_API auto Warn()         -> FLinearColor;
+	CKEDITORTOOLS_API auto Info()         -> FLinearColor;
+
+	// ----- Selection & Hover --------------------------------------------------
+	CKEDITORTOOLS_API auto Selection()         -> FLinearColor;
+	CKEDITORTOOLS_API auto SelectionInactive() -> FLinearColor;
+	CKEDITORTOOLS_API auto Hover()             -> FLinearColor;
+
+	// ----- Domain (ECS / component semantics) --------------------------------
+	CKEDITORTOOLS_API auto None()               -> FLinearColor;
+	CKEDITORTOOLS_API auto EntityId()           -> FLinearColor;
+	CKEDITORTOOLS_API auto Transform()          -> FLinearColor;
+	CKEDITORTOOLS_API auto Network()            -> FLinearColor;
+	CKEDITORTOOLS_API auto Relationship()       -> FLinearColor;
+	CKEDITORTOOLS_API auto Attribute()          -> FLinearColor;
+	CKEDITORTOOLS_API auto Reference()          -> FLinearColor;
+	CKEDITORTOOLS_API auto PickMarker_Default() -> FLinearColor;
+	CKEDITORTOOLS_API auto PickMarker_Hover()   -> FLinearColor;
+
+	// ----- Value-type colors -------------------------------------------------
+	CKEDITORTOOLS_API auto Value_Bool_True()  -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_Bool_False() -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_Numeric()    -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_String()     -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_Math()       -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_Tag()        -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_Enum()       -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_Object()     -> FLinearColor;
+	CKEDITORTOOLS_API auto Value_Handle()     -> FLinearColor;
+
+	// ----- State colors ------------------------------------------------------
+	CKEDITORTOOLS_API auto State_Enabled()     -> FLinearColor;
+	CKEDITORTOOLS_API auto State_Disabled()    -> FLinearColor;
+	CKEDITORTOOLS_API auto State_Overlapping() -> FLinearColor;
+	CKEDITORTOOLS_API auto State_Config()      -> FLinearColor;
+
+	// ----- Status colors (objective / task progress) -------------------------
+	CKEDITORTOOLS_API auto Status_NotStarted() -> FLinearColor;
+	CKEDITORTOOLS_API auto Status_Active()     -> FLinearColor;
+	CKEDITORTOOLS_API auto Status_Completed()  -> FLinearColor;
+	CKEDITORTOOLS_API auto Status_Failed()     -> FLinearColor;
+
+	// ----- Graph canvas colors -----------------------------------------------
+	CKEDITORTOOLS_API auto Graph_Background()         -> FLinearColor;
+	CKEDITORTOOLS_API auto Graph_Edge()               -> FLinearColor;
+	CKEDITORTOOLS_API auto Graph_Node_Center()        -> FLinearColor;
+	CKEDITORTOOLS_API auto Graph_Node_Default()       -> FLinearColor;
+	CKEDITORTOOLS_API auto Graph_Node_Border_Default()-> FLinearColor;
+	CKEDITORTOOLS_API auto Graph_Node_Border_Center() -> FLinearColor;
+
+	CKEDITORTOOLS_API auto CategoryGather()   -> FLinearColor;
+	CKEDITORTOOLS_API auto CategoryBuild()    -> FLinearColor;
+	CKEDITORTOOLS_API auto CategoryResearch() -> FLinearColor;
+	CKEDITORTOOLS_API auto CategoryTrain()    -> FLinearColor;
+	CKEDITORTOOLS_API auto CategoryAge()      -> FLinearColor;
+	CKEDITORTOOLS_API auto CategoryTrade()    -> FLinearColor;
+
+	// ----- Typography ---------------------------------------------------------
+	CKEDITORTOOLS_API auto FontSizeH2()    -> int32;
+	CKEDITORTOOLS_API auto FontSizeH3()    -> int32;
+	CKEDITORTOOLS_API auto FontSizeH4()    -> int32;
+	CKEDITORTOOLS_API auto FontSizeBody()  -> int32;
+	CKEDITORTOOLS_API auto FontSizeSmall() -> int32;
+	CKEDITORTOOLS_API auto FontSizeMicro() -> int32;
+
+	// ----- Pane headings ------------------------------------------------------
+	CKEDITORTOOLS_API auto PaneHeadingFontSize() -> int32;
+	CKEDITORTOOLS_API auto PaneHeadingColor()    -> FLinearColor;
+
+	// ----- Plan strip ---------------------------------------------------------
+	CKEDITORTOOLS_API auto PlanStrip_TitleFontSize()     -> int32;
+	CKEDITORTOOLS_API auto PlanStrip_MetaFontSize()      -> int32;
+	CKEDITORTOOLS_API auto PlanStrip_GoalLabelFontSize() -> int32;
+	CKEDITORTOOLS_API auto PlanStrip_GoalNameFontSize()  -> int32;
+	CKEDITORTOOLS_API auto PlanStrip_StepNameFontSize()  -> int32;
+	CKEDITORTOOLS_API auto PlanStrip_StepCostFontSize()  -> int32;
+	CKEDITORTOOLS_API auto PlanStrip_StepStateFontSize() -> int32;
+
+	CKEDITORTOOLS_API auto PlanStep_Fill_Pending()   -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Border_Pending() -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Badge_Pending()  -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Fill_Active()    -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Border_Active()  -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Badge_Active()   -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Fill_Done()      -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Border_Done()    -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStep_Badge_Done()     -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStrip_GoalFill()      -> FLinearColor;
+	CKEDITORTOOLS_API auto PlanStrip_GoalBorder()    -> FLinearColor;
+
+	// ----- Graph node visuals -------------------------------------------------
+	CKEDITORTOOLS_API auto NodeFill_Inactive()     -> FLinearColor;
+	CKEDITORTOOLS_API auto NodeBorder_Inactive()   -> FLinearColor;
+	CKEDITORTOOLS_API auto NodeFill_InPlan()       -> FLinearColor;
+	CKEDITORTOOLS_API auto NodeBorder_InPlan()     -> FLinearColor;
+	CKEDITORTOOLS_API auto NodeFill_Goal()         -> FLinearColor;
+	CKEDITORTOOLS_API auto NodeBorder_Goal()       -> FLinearColor;
+	CKEDITORTOOLS_API auto NodeFill_GoalInactive() -> FLinearColor;
+	CKEDITORTOOLS_API auto NodeTitleFontSize()     -> int32;
+	CKEDITORTOOLS_API auto NodeCostFontSize()      -> int32;
+	CKEDITORTOOLS_API auto NodeMetaFontSize()      -> int32;
+	CKEDITORTOOLS_API auto NodeBorderThickness()   -> float;
+	CKEDITORTOOLS_API auto NodeInactiveOpacity()   -> float;
+
+	// ----- Spacing (compile-time constants — no need to tune) -----------------
+	constexpr auto SpaceXS  = 2.0f;
+	constexpr auto SpaceS   = 4.0f;
+	constexpr auto SpaceM   = 8.0f;
+	constexpr auto SpaceL   = 12.0f;
+	constexpr auto SpaceXL  = 16.0f;
+	constexpr auto SpaceXXL = 24.0f;
+
+	// ----- Brushes / helpers --------------------------------------------------
+	CKEDITORTOOLS_API auto GetFilledBrush()  -> const FSlateBrush*;
+	CKEDITORTOOLS_API auto GetRoundedBrush() -> const FSlateBrush*;
+	CKEDITORTOOLS_API auto GetToneColor(ECk_Tone InTone) -> FLinearColor;
+}
+
+// ====================================================================================================================

--- a/Source/CkGridEditor/Public/CkGridEditor/EdMode/Ck2dGridSystem_ToolkitWidgets.h
+++ b/Source/CkGridEditor/Public/CkGridEditor/EdMode/Ck2dGridSystem_ToolkitWidgets.h
@@ -14,12 +14,13 @@ struct FSlateBrush;
 
 // --------------------------------------------------------------------------------------------------------------------
 
-// Lightweight, local mirror of the CkDebuggerCommon visual language (section headers, labeled-group cards,
-// key/value rows, count badges, color swatches) for the Grid Paint editor-mode toolkit. We CANNOT depend on
-// CkDebuggerCommon directly: it lives in the CkDebugger plugin which depends on CkFoundation, so a dependency
-// the other way would be a circular plugin dependency. These helpers reproduce the same look using only engine
-// FAppStyle / FCoreStyle brushes and the hardcoded palette below (copied from UCkDebuggerStyleSettings defaults
-// — FLinearColor(FColor(hex)) so the sRGB->linear conversion matches the debugger exactly).
+// Lightweight, local mirror of the shared Ck tooling visual language (section headers, labeled-group cards,
+// key/value rows, count badges, color swatches) for the Grid Paint editor-mode toolkit. Historically we could
+// not depend on the debugger plugin's style (circular plugin dependency), so these helpers reproduce the same
+// look using only engine FAppStyle / FCoreStyle brushes and the hardcoded palette below (copied from the style
+// settings defaults — FLinearColor(FColor(hex)) so the sRGB->linear conversion matches the debugger exactly).
+// NOTE: the canonical tokens now live in CkFoundation's CkEditorTools module (CkStyle:: +
+// UCk_Style_UserSettings_UE), so this mirror could be replaced by a direct CkEditorTools dependency.
 namespace ck::grid_paint_style
 {
     // ----- Palette (sRGB hex -> linear, matching the debugger) ------------------------------------------------

--- a/Source/CkInsightsAnalyzer/CkInsightsAnalyzer.Build.cs
+++ b/Source/CkInsightsAnalyzer/CkInsightsAnalyzer.Build.cs
@@ -26,6 +26,7 @@ public class CkInsightsAnalyzer : CkModuleRules
 
             // CK dependencies
             "CkCore",
+            "CkEditorTools", // Shared CkStyle:: tokens for the analyzer tab UI
             "CkLog",
         });
 

--- a/Source/CkInsightsAnalyzer/Claude.md
+++ b/Source/CkInsightsAnalyzer/Claude.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Unreal Insights integration — tooling for analyzing capture files and correlating them with CkFoundation processor timings. Editor-only analysis tool.
 
-**Depends on:** `CkCore`, `CkLog`.
+**Depends on:** `CkCore`, `CkEditorTools` (shared `CkStyle::` tokens for the tab UI), `CkLog`.
 **Used by:** Developer workflow only; not referenced by gameplay modules.
 
 ---
@@ -10,6 +10,11 @@
 ## Key API
 
 - No `_Utils.h`. Exposes editor commands and subsystem for trace analysis.
+- `SCkInsightsAnalyzerTab` — the "Insights Analyzer" editor tab (Tools → Debug):
+  frame bar chart, structured hot-path tree, category/top-timer panels,
+  worst-frames drill-down, stat-tile summary strip. Styled entirely via `CkStyle::`.
+- `FCk_FrameReport::BuildHotPathTree / ComputeCategorySummary / ComputeTopTimers` —
+  structured (non-markdown) analysis data backing the tab's views.
 
 ---
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.cpp
@@ -1,6 +1,7 @@
 #include "CkInsightsAnalyzer/Core/CkTraceSession.h"
 #include "CkInsightsAnalyzer_Log.h"
 
+#include "CkCore/Ensure/CkEnsure.h"
 #include "CkCore/Macros/CkMacros.h"
 #include "CkCore/Validation/CkIsValid.h"
 
@@ -122,6 +123,52 @@ auto
 
     _FilePath = FilePath;
     return true;
+}
+
+auto
+    FCk_TraceSession::
+    StartAnalysis(const FString& FilePath)
+    -> bool
+{
+    CK_ENSURE_IF_NOT(IsInGameThread(),
+        TEXT("StartAnalysis must be called on the game thread — registered trace modules "
+             "(e.g. ChaosVD) ensure(IsInGameThread()) inside OnAnalysisBegin, which fires "
+             "synchronously here"))
+    { return false; }
+
+    if (ck::Is_NOT_Valid(_AnalysisService))
+    {
+        ck::insights_analyzer::Error(TEXT("StartAnalysis called without PrepareAnalysisService"));
+        return false;
+    }
+
+    if (NOT FPaths::FileExists(FilePath))
+    {
+        ck::insights_analyzer::Error(TEXT("Trace file not found: {}"), FilePath);
+        return false;
+    }
+
+    ck::insights_analyzer::Log(TEXT("Starting trace analysis: {}"), FilePath);
+
+    _Session = _AnalysisService->StartAnalysis(*FilePath);
+
+    if (ck::Is_NOT_Valid(_Session))
+    {
+        ck::insights_analyzer::Error(TEXT("Failed to start analysis for trace: {}"), FilePath);
+        _AnalysisService.Reset();
+        return false;
+    }
+
+    _FilePath = FilePath;
+    return true;
+}
+
+auto
+    FCk_TraceSession::
+    IsAnalysisComplete() const
+    -> bool
+{
+    return _Session.IsValid() && _Session->IsAnalysisComplete();
 }
 
 auto

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.h
@@ -50,10 +50,24 @@ public:
     auto PrepareAnalysisService() -> bool;
 
     /**
-     * Run analysis on a prepared service. Can be called from any thread.
-     * Must call PrepareAnalysisService() first.
+     * Run analysis on a prepared service, blocking until complete. Must call
+     * PrepareAnalysisService() first. Game-thread callers only (registered trace
+     * modules, e.g. ChaosVD, assume OnAnalysisBegin runs on the game thread) —
+     * for non-blocking UI use, prefer StartAnalysis() + IsAnalysisComplete().
      */
     auto AnalyzeFile(const FString& FilePath) -> bool;
+
+    /**
+     * Begin analysis WITHOUT blocking. MUST be called on the game thread —
+     * registered trace modules (e.g. ChaosVD) ensure(IsInGameThread()) in their
+     * OnAnalysisBegin, which fires synchronously here. The heavy processing
+     * continues on TraceServices' own analysis thread; poll IsAnalysisComplete().
+     * Providers are readable (under a read scope) while analysis is running.
+     */
+    auto StartAnalysis(const FString& FilePath) -> bool;
+
+    /** Whether analysis started via StartAnalysis() has finished. */
+    auto IsAnalysisComplete() const -> bool;
 
     /** Close the session and release all resources. */
     auto Close() -> void;

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
@@ -179,10 +179,24 @@ auto
 
         const FString ChildName = GetTimerName(TimerNames, ChildIndex);
 
-        if (IsFrameWrapper(ChildName) && Depth < 5)
+        // Unnamed timers (no entry in the trace's timer table) behave like frame
+        // wrappers: drill through so real work (UWorld_Tick, Slate) surfaces as
+        // roots instead of an opaque UNKNOWN_<id> node covering the whole frame.
+        const bool IsUnnamed = ChildName.StartsWith(TEXT("UNKNOWN_"));
+
+        if ((IsFrameWrapper(ChildName) || IsUnnamed) && Depth < 5)
         {
             // Drill deeper through wrapper
             TMap<uint32, double> Deeper = UnwrapRoots(ChildIndex, Result, TimerNames, Depth + 1);
+
+            if (Deeper.Num() == 0 && IsUnnamed)
+            {
+                // Unnamed LEAF — keep it rather than silently dropping its time
+                double& Existing = Roots.FindOrAdd(ChildIndex, 0.0);
+                Existing += ChildInclSec;
+                continue;
+            }
+
             for (const auto& [K, V] : Deeper)
             {
                 double& Existing = Roots.FindOrAdd(K, 0.0);
@@ -572,15 +586,200 @@ auto
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+// Structured Hot Path Tree
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_FrameReport::
+    DoBuildTreeNode(uint32 TimerIndex, int32 Depth,
+                    double InclMs, double ExclMs, uint32 Count,
+                    const FCk_FrameAnalysisResult& Result,
+                    const FTimerNameMap& TimerNames,
+                    TSet<uint32>& ShownTimers,
+                    const TArray<FString>* PreBreadcrumbs) const
+    -> TSharedPtr<FCk_HotPathNode>
+{
+    // Collapse wrapper chain for this node
+    FCollapsedTimer Collapsed = CollapseWrappers(
+        TimerIndex, InclMs, ExclMs, Count, Result, TimerNames);
+
+    // If already shown by a sibling's subtree, skip (prevents infinite recursion)
+    if (ShownTimers.Contains(Collapsed.TimerIndex))
+    {
+        return nullptr;
+    }
+    ShownTimers.Add(Collapsed.TimerIndex);
+
+    // Merge breadcrumbs from parent-level pre-collapse
+    TArray<FString> AllBreadcrumbs;
+    if (PreBreadcrumbs)
+    {
+        AllBreadcrumbs = *PreBreadcrumbs;
+    }
+    AllBreadcrumbs.Append(Collapsed.Breadcrumbs);
+
+    auto Node = MakeShared<FCk_HotPathNode>();
+    Node->RawName = GetTimerName(TimerNames, Collapsed.TimerIndex);
+    Node->DisplayName = FCk_TimerCategorizer::SimplifyName(Node->RawName);
+    Node->Breadcrumbs = MoveTemp(AllBreadcrumbs);
+    Node->InclusiveMs = Collapsed.InclusiveMs;
+    Node->ExclusiveMs = Collapsed.ExclusiveMs;
+    Node->Count = Collapsed.Count;
+
+    if (Depth >= _Config.MaxTreeDepth)
+    {
+        return Node;
+    }
+
+    // Get children with adaptive threshold (3% of parent, min 0.3ms)
+    const double MinChildMs = FMath::Max(0.3, Collapsed.InclusiveMs * 0.03);
+    TArray<FChildInfo> Children = GetSignificantChildren(
+        Collapsed.TimerIndex, Result, MinChildMs);
+
+    // Pre-collapse each child and deduplicate by collapsed timer_id
+    struct FDedupedChild
+    {
+        uint32 TimerIndex;
+        double InclusiveMs;
+        double ExclusiveMs;
+        uint32 Count;
+        TArray<FString> Breadcrumbs;
+    };
+    TMap<uint32, FDedupedChild> Seen;
+
+    for (const FChildInfo& Child : Children)
+    {
+        FCollapsedTimer CC = CollapseWrappers(
+            Child.TimerIndex, Child.InclusiveMs, Child.ExclusiveMs, Child.Count,
+            Result, TimerNames);
+
+        // Use global stats for display consistency
+        const double GlobalIncl = FMath::Min(
+            Result.GetInclusiveMs(CC.TimerIndex), Collapsed.InclusiveMs);
+        const double GlobalExcl = Result.GetExclusiveMs(CC.TimerIndex);
+        const uint32 GlobalCount = Result.GetCount(CC.TimerIndex);
+
+        const auto Existing = Seen.Find(CC.TimerIndex);
+        if (NOT Existing || GlobalIncl > Existing->InclusiveMs)
+        {
+            Seen.FindOrAdd(CC.TimerIndex) = FDedupedChild{
+                CC.TimerIndex, GlobalIncl, GlobalExcl, GlobalCount, MoveTemp(CC.Breadcrumbs)
+            };
+        }
+    }
+
+    // Sort deduped children by inclusive time, filter self-references, cap at 8
+    TArray<FDedupedChild> Deduped;
+    for (auto& [Key, Val] : Seen)
+    {
+        Deduped.Add(MoveTemp(Val));
+    }
+    ck::algo::Sort(Deduped, [](const FDedupedChild& A, const FDedupedChild& B)
+    {
+        return A.InclusiveMs > B.InclusiveMs;
+    });
+
+    TArray<FDedupedChild> Visible;
+    for (int32 i = 0; i < Deduped.Num() && Visible.Num() < 8; ++i)
+    {
+        if (Deduped[i].TimerIndex == Collapsed.TimerIndex) continue;
+        Visible.Add(MoveTemp(Deduped[i]));
+    }
+
+    for (FDedupedChild& Child : Visible)
+    {
+        TSharedPtr<FCk_HotPathNode> ChildNode = DoBuildTreeNode(
+            Child.TimerIndex, Depth + 1,
+            Child.InclusiveMs, Child.ExclusiveMs, Child.Count,
+            Result, TimerNames, ShownTimers,
+            &Child.Breadcrumbs);
+
+        if (ChildNode.IsValid())
+        {
+            Node->Children.Add(MoveTemp(ChildNode));
+        }
+    }
+
+    return Node;
+}
+
+auto
+    FCk_FrameReport::
+    BuildHotPathTree(const FCk_TraceSession& Session,
+                     const FCk_FrameAnalysisResult& Result) const
+    -> TArray<TSharedPtr<FCk_HotPathNode>>
+{
+    TArray<TSharedPtr<FCk_HotPathNode>> Roots;
+
+    if (NOT Result.IsValid() ||
+        Result.FrameRootTimerIndex == static_cast<uint32>(INDEX_NONE))
+    {
+        return Roots;
+    }
+
+    TraceServices::FAnalysisSessionReadScope ReadScope = Session.CreateReadScope();
+    const FTimerNameMap TimerNames = BuildTimerNameMap(Session);
+
+    TMap<uint32, double> RootChildren = UnwrapRoots(
+        Result.FrameRootTimerIndex, Result, TimerNames);
+
+    struct FRootEntry
+    {
+        uint32 TimerIndex;
+        double InclusiveMs;
+        double ExclusiveMs;
+        uint32 Count;
+    };
+    TArray<FRootEntry> RootList;
+
+    for (const auto& [TimerIndex, InclSeconds] : RootChildren)
+    {
+        const double InclMs = InclSeconds * 1000.0;
+        if (InclMs >= _Config.MinInclusiveMs)
+        {
+            RootList.Add(FRootEntry{
+                TimerIndex,
+                InclMs,
+                Result.GetExclusiveMs(TimerIndex),
+                Result.GetCount(TimerIndex)
+            });
+        }
+    }
+
+    ck::algo::Sort(RootList, [](const FRootEntry& A, const FRootEntry& B)
+    {
+        return A.InclusiveMs > B.InclusiveMs;
+    });
+
+    const int32 MaxRoots = FMath::Min(RootList.Num(), _Config.MaxRootTimers);
+    for (int32 i = 0; i < MaxRoots; ++i)
+    {
+        const FRootEntry& Root = RootList[i];
+        TSet<uint32> ShownTimers; // per-root dedup, same as the markdown tree
+
+        TSharedPtr<FCk_HotPathNode> Node = DoBuildTreeNode(
+            Root.TimerIndex, 0,
+            Root.InclusiveMs, Root.ExclusiveMs, Root.Count,
+            Result, TimerNames, ShownTimers);
+
+        if (Node.IsValid())
+        {
+            Roots.Add(MoveTemp(Node));
+        }
+    }
+
+    return Roots;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
 // Category Summary
 // --------------------------------------------------------------------------------------------------------------------
 
 auto
     FCk_FrameReport::
-    GenerateCategorySummary(const FCk_FrameAnalysisResult& Result,
-                           const FTimerNameMap& TimerNames,
-                           TArray<FString>& Lines) const
-    -> void
+    ComputeCategorySummary(const FCk_FrameAnalysisResult& Result,
+                           const FTimerNameMap& TimerNames) const
+    -> TArray<FCk_CategorySummaryEntry>
 {
     // Accumulate exclusive time per category
     TMap<FString, double> CategoryExclMs;
@@ -597,45 +796,90 @@ auto
         Total += ExclMs;
     }
 
-    // Sort: known categories by exclusive time, then "Other" at end
-    struct FCatEntry
-    {
-        FString Name;
-        double ExclMs;
-        int32 Priority;
-    };
-    TArray<FCatEntry> SortedCats;
+    const double FrameMs = Result.FrameDurationMs;
 
+    TArray<FCk_CategorySummaryEntry> Entries;
     for (const auto& [CatName, ExclMs] : CategoryExclMs)
     {
         if (ExclMs >= _Config.MinCategoryMs)
         {
-            SortedCats.Add(FCatEntry{
-                CatName, ExclMs, _Categorizer.GetCategoryPriority(CatName)
+            Entries.Add(FCk_CategorySummaryEntry{
+                CatName, ExclMs,
+                (FrameMs > 0.0) ? (ExclMs / FrameMs) * 100.0 : 0.0
             });
         }
     }
 
     // Sort by exclusive time descending (matching Python behavior)
-    ck::algo::Sort(SortedCats, [](const FCatEntry& A, const FCatEntry& B)
+    ck::algo::Sort(Entries, [](const FCk_CategorySummaryEntry& A, const FCk_CategorySummaryEntry& B)
     {
-        return A.ExclMs > B.ExclMs;
+        return A.ExclusiveMs > B.ExclusiveMs;
     });
+
+    return Entries;
+}
+
+auto
+    FCk_FrameReport::
+    ComputeTopTimers(const FCk_FrameAnalysisResult& Result,
+                     const FTimerNameMap& TimerNames,
+                     int32 MaxCount) const
+    -> TArray<FCk_TopTimerEntry>
+{
+    TArray<TPair<uint32, double>> Sorted;
+    for (const auto& [TimerIndex, ExclSec] : Result.TimerExclusive)
+    {
+        Sorted.Emplace(TimerIndex, ExclSec * 1000.0);
+    }
+    ck::algo::Sort(Sorted, [](const TPair<uint32, double>& A, const TPair<uint32, double>& B)
+    {
+        return A.Value > B.Value;
+    });
+
+    const double FrameMs = Result.FrameDurationMs;
+    const int32 Count = FMath::Min(Sorted.Num(), MaxCount);
+
+    TArray<FCk_TopTimerEntry> Entries;
+    Entries.Reserve(Count);
+
+    for (int32 i = 0; i < Count; ++i)
+    {
+        const uint32 TimerIndex = Sorted[i].Key;
+        const double ExclMs = Sorted[i].Value;
+
+        Entries.Add(FCk_TopTimerEntry{
+            FCk_TimerCategorizer::SimplifyName(GetTimerName(TimerNames, TimerIndex)),
+            ExclMs,
+            Result.GetInclusiveMs(TimerIndex),
+            Result.GetCount(TimerIndex),
+            (FrameMs > 0.0) ? (ExclMs / FrameMs) * 100.0 : 0.0
+        });
+    }
+
+    return Entries;
+}
+
+auto
+    FCk_FrameReport::
+    GenerateCategorySummary(const FCk_FrameAnalysisResult& Result,
+                           const FTimerNameMap& TimerNames,
+                           TArray<FString>& Lines) const
+    -> void
+{
+    const TArray<FCk_CategorySummaryEntry> SortedCats = ComputeCategorySummary(Result, TimerNames);
 
     if (SortedCats.Num() == 0) return;
 
     Lines.Add(FString::Printf(TEXT("\n%s"), *ck_frame_report::HRule));
     Lines.Add(TEXT("*Category Summary (exclusive time)*\n"));
 
-    const double FrameMs = Result.FrameDurationMs;
-    for (const FCatEntry& Cat : SortedCats)
+    for (const FCk_CategorySummaryEntry& Cat : SortedCats)
     {
-        const double Pct = (FrameMs > 0.0) ? (Cat.ExclMs / FrameMs) * 100.0 : 0.0;
-        const FString Icon = FCk_TimerCategorizer::SeverityIcon(Cat.ExclMs);
-        const FString FormattedMs = FCk_TimerCategorizer::FormatMs(Cat.ExclMs);
+        const FString Icon = FCk_TimerCategorizer::SeverityIcon(Cat.ExclusiveMs);
+        const FString FormattedMs = FCk_TimerCategorizer::FormatMs(Cat.ExclusiveMs);
 
         Lines.Add(FString::Printf(TEXT("%s *%8s*  %4.0f%%  %s"),
-            *Icon, *FormattedMs, Pct, *Cat.Name));
+            *Icon, *FormattedMs, Cat.PctOfFrame, *Cat.Name));
     }
 }
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
@@ -146,6 +146,57 @@ struct FCk_WorkerThreadSummary
 // --------------------------------------------------------------------------------------------------------------------
 
 /**
+ * One node of the structured hot-path tree — same wrapper unwrapping/collapsing
+ * and per-root dedup logic as the markdown report, exposed as data so Slate
+ * views (SCkInsightsAnalyzerTab) can render a real tree instead of text.
+ */
+struct CKINSIGHTSANALYZER_API FCk_HotPathNode
+{
+    /** Raw timer name (post wrapper-collapse). */
+    FString RawName;
+
+    /** Simplified display name (FCk_TimerCategorizer::SimplifyName). */
+    FString DisplayName;
+
+    /** Collapsed wrapper chain leading into this timer (raw names). */
+    TArray<FString> Breadcrumbs;
+
+    double InclusiveMs = 0.0;
+    double ExclusiveMs = 0.0;
+    uint32 Count = 0;
+
+    TArray<TSharedPtr<FCk_HotPathNode>> Children;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/** Per-category exclusive-time entry for structured display. */
+struct CKINSIGHTSANALYZER_API FCk_CategorySummaryEntry
+{
+    FString Name;
+    double ExclusiveMs = 0.0;
+    double PctOfFrame = 0.0;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/** Ranked timer entry (by exclusive time) for structured display. */
+struct CKINSIGHTSANALYZER_API FCk_TopTimerEntry
+{
+    /** Simplified display name. */
+    FString Name;
+
+    double ExclusiveMs = 0.0;
+    double InclusiveMs = 0.0;
+    uint32 Count = 0;
+
+    /** Exclusive time as a percentage of the frame duration. */
+    double PctOfFrame = 0.0;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/**
  * Generates Slack-friendly markdown reports from frame analysis results.
  *
  * Ports the full report generation pipeline from analyze_frame.py:
@@ -199,6 +250,33 @@ public:
 
     /** Get timer name, with fallback. */
     static auto GetTimerName(const FTimerNameMap& Names, uint32 TimerIndex) -> FString;
+
+    // ---- Structured data (for Slate views) ----
+    // NOTE: declared after FTimerNameMap — member alias must precede its use in
+    // parameter types.
+
+    /**
+     * Build the structured hot-path tree: roots sorted by inclusive time
+     * (capped at MaxRootTimers), same wrapper collapsing and per-root dedup
+     * as the markdown report. Acquires its own read scope.
+     */
+    auto BuildHotPathTree(const FCk_TraceSession& Session,
+                          const FCk_FrameAnalysisResult& Result) const
+        -> TArray<TSharedPtr<FCk_HotPathNode>>;
+
+    /**
+     * Per-category exclusive time, sorted descending, filtered by MinCategoryMs.
+     * Same data the markdown category summary renders.
+     */
+    auto ComputeCategorySummary(const FCk_FrameAnalysisResult& Result,
+                                const FTimerNameMap& TimerNames) const
+        -> TArray<FCk_CategorySummaryEntry>;
+
+    /** Top MaxCount timers by exclusive time, with simplified names. */
+    auto ComputeTopTimers(const FCk_FrameAnalysisResult& Result,
+                          const FTimerNameMap& TimerNames,
+                          int32 MaxCount) const
+        -> TArray<FCk_TopTimerEntry>;
 
 private:
 
@@ -284,6 +362,15 @@ private:
 
     /** Build tree-drawing prefix (e.g., "│  ├─ "). */
     static auto MakeTreePrefix(int32 Depth, const TMap<int32, bool>& IsLastAtDepth) -> FString;
+
+    /** Node-producing analog of BuildTreeLines (shared collapse/dedup rules). */
+    auto DoBuildTreeNode(uint32 TimerIndex, int32 Depth,
+                         double InclMs, double ExclMs, uint32 Count,
+                         const FCk_FrameAnalysisResult& Result,
+                         const FTimerNameMap& TimerNames,
+                         TSet<uint32>& ShownTimers,
+                         const TArray<FString>* PreBreadcrumbs = nullptr) const
+        -> TSharedPtr<FCk_HotPathNode>;
 
 private:
     FCk_FrameReportConfig _Config;

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkFrameBarChart.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkFrameBarChart.cpp
@@ -3,6 +3,8 @@
 #include "CkCore/Macros/CkMacros.h"
 #include "CkCore/Validation/CkIsValid.h"
 
+#include "CkEditorTools/Style/CkStyle.h"
+
 #include "Fonts/SlateFontInfo.h"
 #include "Framework/Application/SlateApplication.h"
 #include "Rendering/DrawElements.h"
@@ -26,17 +28,20 @@ namespace FrameBarChart
     // Fixed vertical ceiling — ensures threshold lines are always visible
     constexpr double MinDisplayMaxMs = 120.0;
 
-    const FLinearColor ColorGreen  = FLinearColor(0.2f, 0.8f, 0.2f, 0.9f);
-    const FLinearColor ColorYellow = FLinearColor(0.9f, 0.8f, 0.1f, 0.9f);
-    const FLinearColor ColorRed    = FLinearColor(0.9f, 0.15f, 0.15f, 0.9f);
-    const FLinearColor ColorHover  = FLinearColor(1.0f, 1.0f, 1.0f, 0.3f);
-    const FLinearColor ColorSelect = FLinearColor(0.3f, 0.5f, 1.0f, 0.25f);
-    const FLinearColor ColorThresholdGreen  = FLinearColor(0.2f, 0.6f, 0.2f, 0.4f);
-    const FLinearColor ColorThresholdYellow = FLinearColor(0.7f, 0.6f, 0.1f, 0.4f);
-    const FLinearColor ColorThresholdOrange = FLinearColor(0.8f, 0.5f, 0.1f, 0.4f);
-    const FLinearColor ColorThresholdRed    = FLinearColor(0.7f, 0.2f, 0.2f, 0.4f);
-    const FLinearColor ColorLabel  = FLinearColor(0.6f, 0.6f, 0.6f, 0.7f);
-    const FLinearColor ColorBackground = FLinearColor(0.02f, 0.02f, 0.02f, 1.0f);
+    // Style-token-backed colors, resolved lazily at paint time — CkStyle reads
+    // a settings CDO, so these must never be evaluated at static init.
+    auto ColorGreen()  -> FLinearColor { return CkStyle::OverlayOf(CkStyle::Ok(), 0.9f); }
+    auto ColorYellow() -> FLinearColor { return CkStyle::OverlayOf(CkStyle::Warn(), 0.9f); }
+    auto ColorRed()    -> FLinearColor { return CkStyle::OverlayOf(CkStyle::Err(), 0.9f); }
+    auto ColorHover()  -> FLinearColor { return CkStyle::OverlayOf(CkStyle::TextStrong(), 0.3f); }
+    auto ColorSelect() -> FLinearColor { return CkStyle::OverlayOf(CkStyle::Selection(), 0.25f); }
+    auto ColorThresholdGreen()  -> FLinearColor { return CkStyle::OverlayOf(CkStyle::Ok(), 0.4f); }
+    auto ColorThresholdYellow() -> FLinearColor { return CkStyle::OverlayOf(CkStyle::Warn(), 0.4f); }
+    auto ColorThresholdOrange() -> FLinearColor { return CkStyle::OverlayOf(FMath::Lerp(CkStyle::Warn(), CkStyle::Err(), 0.5f), 0.4f); }
+    auto ColorThresholdRed()    -> FLinearColor { return CkStyle::OverlayOf(CkStyle::Err(), 0.4f); }
+    auto ColorLabel()      -> FLinearColor { return CkStyle::OverlayOf(CkStyle::TextDim(), 0.7f); }
+    auto ColorBackground() -> FLinearColor { return CkStyle::BgRoot(); }
+    auto ColorGridLine()   -> FLinearColor { return CkStyle::OverlayOf(CkStyle::BorderStrong(), 0.25f); }
 
     /** Format an integer with comma separators (e.g. 4160 → "4,160"). */
     auto FormatWithCommas(int64 Value) -> FString
@@ -275,7 +280,7 @@ auto
         AllottedGeometry.ToPaintGeometry(),
         FAppStyle::GetBrush(TEXT("WhiteBrush")),
         ESlateDrawEffect::None,
-        FrameBarChart::ColorBackground);
+        FrameBarChart::ColorBackground());
 
     // Use P95-based display max so outlier frames don't squish normal bars.
     // Bars exceeding this value clamp to full height.
@@ -308,20 +313,20 @@ auto
                     FVector2D(FrameBarChart::LabelRightMargin, 14.0f),
                     FSlateLayoutTransform(FVector2D(BarAreaRight + 4.0f, Y - 7.0f))),
                 Label, LabelFont,
-                ESlateDrawEffect::None, FrameBarChart::ColorLabel);
+                ESlateDrawEffect::None, FrameBarChart::ColorLabel());
         }
     };
 
-    DrawThresholdLine(16.67,  FrameBarChart::ColorThresholdGreen,  TEXT("16.7 ms (60 fps)"));
-    DrawThresholdLine(33.33,  FrameBarChart::ColorThresholdYellow, TEXT("33.3 ms (30 fps)"));
-    DrawThresholdLine(50.0,   FrameBarChart::ColorThresholdOrange, TEXT("50 ms (20 fps)"));
-    DrawThresholdLine(66.67,  FrameBarChart::ColorThresholdRed,    TEXT("66.7 ms (15 fps)"));
-    DrawThresholdLine(100.0,  FrameBarChart::ColorThresholdRed,    TEXT("100 ms (10 fps)"));
+    DrawThresholdLine(16.67,  FrameBarChart::ColorThresholdGreen(),  TEXT("16.7 ms (60 fps)"));
+    DrawThresholdLine(33.33,  FrameBarChart::ColorThresholdYellow(), TEXT("33.3 ms (30 fps)"));
+    DrawThresholdLine(50.0,   FrameBarChart::ColorThresholdOrange(), TEXT("50 ms (20 fps)"));
+    DrawThresholdLine(66.67,  FrameBarChart::ColorThresholdRed(),    TEXT("66.7 ms (15 fps)"));
+    DrawThresholdLine(100.0,  FrameBarChart::ColorThresholdRed(),    TEXT("100 ms (10 fps)"));
 
     // Draw frame number axis along the top with vertical grid lines
     {
         const FSlateFontInfo AxisFont = FCoreStyle::GetDefaultFontStyle("Regular", 8);
-        const FLinearColor GridLineColor = FLinearColor(0.3f, 0.3f, 0.3f, 0.2f);
+        const FLinearColor GridLineColor = FrameBarChart::ColorGridLine();
 
         // Compute nice label interval so labels don't overlap (1-2-5 sequence)
         constexpr float MinLabelSpacing = 80.0f;
@@ -367,7 +372,7 @@ auto
                 FrameBarChart::FormatWithCommas(i),
                 AxisFont,
                 ESlateDrawEffect::None,
-                FrameBarChart::ColorLabel);
+                FrameBarChart::ColorLabel());
         }
     }
 
@@ -413,7 +418,7 @@ auto
                     FVector2D(ClampedX2 - ClampedX1, Height),
                     FSlateLayoutTransform(FVector2D(ClampedX1, 0.0f))),
                 FAppStyle::GetBrush(TEXT("WhiteBrush")),
-                ESlateDrawEffect::None, FrameBarChart::ColorSelect);
+                ESlateDrawEffect::None, FrameBarChart::ColorSelect());
         }
     }
 
@@ -429,7 +434,7 @@ auto
                     FVector2D(BarW, Height),
                     FSlateLayoutTransform(FVector2D(HoverX, 0.0f))),
                 FAppStyle::GetBrush(TEXT("WhiteBrush")),
-                ESlateDrawEffect::None, FrameBarChart::ColorHover);
+                ESlateDrawEffect::None, FrameBarChart::ColorHover());
         }
     }
 
@@ -648,13 +653,13 @@ auto
 {
     if (DurationMs > _TargetFrameMs * 2.0)
     {
-        return FrameBarChart::ColorRed;
+        return FrameBarChart::ColorRed();
     }
     if (DurationMs > _TargetFrameMs)
     {
-        return FrameBarChart::ColorYellow;
+        return FrameBarChart::ColorYellow();
     }
-    return FrameBarChart::ColorGreen;
+    return FrameBarChart::ColorGreen();
 }
 
 auto

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
@@ -1,31 +1,382 @@
 #include "CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h"
 
 #include "CkInsightsAnalyzer/Core/CkFrameAnalyzer.h"
-#include "CkInsightsAnalyzer/Report/CkFrameReport.h"
-#include "CkInsightsAnalyzer/Report/CkMultiFrameReport.h"
+#include "CkInsightsAnalyzer/Core/CkTimerCategorizer.h"
 #include "CkInsightsAnalyzer_Log.h"
 
 #include "CkCore/Macros/CkMacros.h"
 #include "CkCore/Validation/CkIsValid.h"
 
+#include "CkEditorTools/Style/CkStyle.h"
+
 #include <Async/Async.h>
 #include <DesktopPlatformModule.h>
 #include <HAL/PlatformApplicationMisc.h>
 #include <Styling/AppStyle.h>
+#include <Styling/CoreStyle.h>
+#include <Widgets/Images/SImage.h>
 #include <Widgets/Layout/SBorder.h>
 #include <Widgets/Layout/SBox.h>
-#include <Widgets/Layout/SSeparator.h>
+#include <Widgets/Layout/SExpandableArea.h>
 #include <Widgets/Layout/SScrollBox.h>
+#include <Widgets/Layout/SSplitter.h>
+#include <Widgets/SOverlay.h>
+#include <Widgets/Views/SExpanderArrow.h>
+#include <Widgets/Views/SHeaderRow.h>
+#include <Widgets/Views/STableRow.h>
 
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace InsightsAnalyzerTab_Constants
+namespace ck_insights_analyzer_tab
 {
     constexpr float PanelPadding = 8.0f;
-    constexpr float ButtonWidth = 160.0f;
     constexpr float SectionSpacing = 8.0f;
     constexpr float ChartHeight = 200.0f;
+    constexpr float SideBarWidth = 90.0f;    // proportion bar width in side panels
+    constexpr double TargetFrameMs = 16.67;
+    constexpr int32 TopTimerCount = 15;
+
+    // ---- Fonts (sizes read live from the style settings at construct time) ----
+
+    auto BodyFont()     -> FSlateFontInfo { return FCoreStyle::GetDefaultFontStyle("Regular", CkStyle::FontSizeBody()); }
+    auto BodyBoldFont() -> FSlateFontInfo { return FCoreStyle::GetDefaultFontStyle("Bold", CkStyle::FontSizeBody()); }
+    auto SmallFont()    -> FSlateFontInfo { return FCoreStyle::GetDefaultFontStyle("Regular", CkStyle::FontSizeSmall()); }
+    auto ItalicFont()   -> FSlateFontInfo { return FCoreStyle::GetDefaultFontStyle("Italic", CkStyle::FontSizeSmall()); }
+    auto MicroFont()    -> FSlateFontInfo { return FCoreStyle::GetDefaultFontStyle("Regular", CkStyle::FontSizeMicro()); }
+    auto TileFont()     -> FSlateFontInfo { return FCoreStyle::GetDefaultFontStyle("Bold", CkStyle::FontSizeH2()); }
+
+    // ---- Colors ----
+
+    // Same thresholds as FCk_TimerCategorizer::SeverityIcon so text and icons agree.
+    auto SeverityColor(double InMs) -> FLinearColor
+    {
+        if (InMs >= 5.0) { return CkStyle::Err(); }
+        if (InMs >= 2.0) { return CkStyle::Warn(); }
+        if (InMs >= 1.0) { return CkStyle::Info(); }
+        return CkStyle::TextDim();
+    }
+
+    auto FrameBudgetColor(double InFrameMs) -> FLinearColor
+    {
+        if (InFrameMs > TargetFrameMs * 2.0) { return CkStyle::Err(); }
+        if (InFrameMs > TargetFrameMs)       { return CkStyle::Warn(); }
+        return CkStyle::Ok();
+    }
+
+    auto FrameBudgetTone(double InFrameMs) -> ECk_Tone
+    {
+        if (InFrameMs > TargetFrameMs * 2.0) { return ECk_Tone::Err; }
+        if (InFrameMs > TargetFrameMs)       { return ECk_Tone::Warn; }
+        return ECk_Tone::Ok;
+    }
+
+    // Stable per-category accent (hash into a small style-derived palette).
+    auto CategoryColor(const FString& InName) -> FLinearColor
+    {
+        switch (GetTypeHash(InName) % 8u)
+        {
+            case 0:  return CkStyle::Info();
+            case 1:  return CkStyle::Ok();
+            case 2:  return CkStyle::Value_Tag();
+            case 3:  return CkStyle::Accent();
+            case 4:  return CkStyle::Value_Handle();
+            case 5:  return CkStyle::Relationship();
+            case 6:  return CkStyle::Value_String();
+            default: return CkStyle::Value_Numeric();
+        }
+    }
+
+    // ---- Small widget builders ----
+
+    auto MakeHeading(const FString& InText) -> TSharedRef<SWidget>
+    {
+        return SNew(STextBlock)
+            .Text(FText::FromString(InText.ToUpper()))
+            .Font(FCoreStyle::GetDefaultFontStyle("Bold", CkStyle::PaneHeadingFontSize()))
+            .ColorAndOpacity(CkStyle::PaneHeadingColor());
+    }
+
+    auto MakeDot(const FLinearColor& InColor, float InSize = 7.0f) -> TSharedRef<SWidget>
+    {
+        return SNew(SBox)
+            .WidthOverride(InSize)
+            .HeightOverride(InSize)
+            [
+                SNew(SImage)
+                .Image(CkStyle::GetFilledBrush())
+                .ColorAndOpacity(InColor)
+            ];
+    }
+
+    auto MakeProportionBar(double InPct, const FLinearColor& InFillColor, float InWidth) -> TSharedRef<SWidget>
+    {
+        const float Frac = FMath::Clamp(static_cast<float>(InPct) / 100.0f, 0.0f, 1.0f);
+        return SNew(SBox)
+            .WidthOverride(InWidth)
+            .HeightOverride(6.0f)
+            .VAlign(VAlign_Fill)
+            [
+                SNew(SOverlay)
+                + SOverlay::Slot()
+                [
+                    SNew(SImage)
+                    .Image(CkStyle::GetFilledBrush())
+                    .ColorAndOpacity(CkStyle::Bg3())
+                ]
+                + SOverlay::Slot()
+                .HAlign(HAlign_Left)
+                [
+                    SNew(SBox)
+                    .WidthOverride(FMath::Max(1.0f, InWidth * Frac))
+                    [
+                        SNew(SImage)
+                        .Image(CkStyle::GetFilledBrush())
+                        .ColorAndOpacity(InFillColor)
+                    ]
+                ]
+            ];
+    }
+
+    auto MakeStatTile(const FString& InLabel, const FString& InValue, const FLinearColor& InValueColor) -> TSharedRef<SWidget>
+    {
+        return SNew(SBorder)
+            .BorderImage(CkStyle::GetFilledBrush())
+            .BorderBackgroundColor(CkStyle::Bg2())
+            .Padding(FMargin(CkStyle::SpaceL, CkStyle::SpaceS))
+            [
+                SNew(SVerticalBox)
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(InLabel.ToUpper()))
+                    .Font(MicroFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                ]
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                .Padding(0.0f, 1.0f, 0.0f, 0.0f)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(InValue))
+                    .Font(TileFont())
+                    .ColorAndOpacity(InValueColor)
+                ]
+            ];
+    }
+
+    auto MakePanel(const FString& InHeading, const TSharedRef<SWidget>& InContent) -> TSharedRef<SWidget>
+    {
+        return SNew(SBorder)
+            .BorderImage(CkStyle::GetFilledBrush())
+            .BorderBackgroundColor(CkStyle::Bg1())
+            .Padding(CkStyle::SpaceM)
+            [
+                SNew(SVerticalBox)
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                .Padding(0.0f, 0.0f, 0.0f, CkStyle::SpaceS)
+                [
+                    MakeHeading(InHeading)
+                ]
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                [
+                    InContent
+                ]
+            ];
+    }
+
+    /** Format an integer with comma separators (e.g. 4160 → "4,160"). */
+    auto FormatWithCommas(uint64 Value) -> FString
+    {
+        FString Raw = FString::Printf(TEXT("%llu"), Value);
+        FString Result;
+        const int32 Len = Raw.Len();
+        for (int32 i = 0; i < Len; ++i)
+        {
+            if (i > 0 && (Len - i) % 3 == 0)
+            {
+                Result.AppendChar(TEXT(','));
+            }
+            Result.AppendChar(Raw[i]);
+        }
+        return Result;
+    }
 }
+
+// --------------------------------------------------------------------------------------------------------------------
+// Hot-path tree row
+// --------------------------------------------------------------------------------------------------------------------
+
+class SCkInsights_HotPathRow : public SMultiColumnTableRow<TSharedPtr<FCk_HotPathNode>>
+{
+public:
+    SLATE_BEGIN_ARGS(SCkInsights_HotPathRow)
+        : _FrameDurationMs(0.0)
+    {}
+        SLATE_ARGUMENT(TSharedPtr<FCk_HotPathNode>, Node)
+        SLATE_ARGUMENT(double, FrameDurationMs)
+    SLATE_END_ARGS()
+
+    auto Construct(const FArguments& InArgs, const TSharedRef<STableViewBase>& InOwnerTable) -> void
+    {
+        _Node = InArgs._Node;
+        _FrameDurationMs = InArgs._FrameDurationMs;
+
+        SMultiColumnTableRow<TSharedPtr<FCk_HotPathNode>>::Construct(
+            FSuperRowType::FArguments()
+                .Padding(FMargin(0.0f, 1.0f))
+                .ShowSelection(true),
+            InOwnerTable);
+    }
+
+    virtual auto GenerateWidgetForColumn(const FName& InColumnName) -> TSharedRef<SWidget> override
+    {
+        using namespace ck_insights_analyzer_tab;
+
+        if (ck::Is_NOT_Valid(_Node))
+        {
+            return SNullWidget::NullWidget;
+        }
+
+        if (InColumnName == TEXT("Timer"))
+        {
+            const TSharedRef<SHorizontalBox> Row = SNew(SHorizontalBox);
+
+            Row->AddSlot()
+               .AutoWidth()
+               [
+                   SNew(SExpanderArrow, SharedThis(this))
+                   .IndentAmount(12.0f)
+               ];
+
+            Row->AddSlot()
+               .AutoWidth()
+               .VAlign(VAlign_Center)
+               .Padding(0.0f, 0.0f, CkStyle::SpaceS, 0.0f)
+               [
+                   MakeDot(SeverityColor(_Node->InclusiveMs))
+               ];
+
+            Row->AddSlot()
+               .AutoWidth()
+               .VAlign(VAlign_Center)
+               [
+                   SNew(STextBlock)
+                   .Text(FText::FromString(_Node->DisplayName))
+                   .Font(BodyFont())
+                   .ColorAndOpacity(CkStyle::Text())
+                   .ToolTipText(FText::FromString(_Node->RawName))
+               ];
+
+            const FString Breadcrumb = DoBuildBreadcrumbSuffix();
+            if (NOT Breadcrumb.IsEmpty())
+            {
+                Row->AddSlot()
+                   .AutoWidth()
+                   .VAlign(VAlign_Center)
+                   [
+                       SNew(STextBlock)
+                       .Text(FText::FromString(Breadcrumb))
+                       .Font(ItalicFont())
+                       .ColorAndOpacity(CkStyle::TextMute())
+                   ];
+            }
+
+            return Row;
+        }
+
+        if (InColumnName == TEXT("Incl"))
+        {
+            return DoMakeCell(
+                FCk_TimerCategorizer::FormatMs(_Node->InclusiveMs),
+                BodyBoldFont(), SeverityColor(_Node->InclusiveMs));
+        }
+
+        if (InColumnName == TEXT("Self"))
+        {
+            const bool ShowSelf = _Node->ExclusiveMs > 0.05;
+            return DoMakeCell(
+                ShowSelf ? FCk_TimerCategorizer::FormatMs(_Node->ExclusiveMs) : FString(),
+                BodyFont(), CkStyle::TextDim());
+        }
+
+        if (InColumnName == TEXT("Count"))
+        {
+            return DoMakeCell(
+                (_Node->Count > 1) ? FCk_TimerCategorizer::FormatCount(_Node->Count) : FString(),
+                BodyFont(), CkStyle::TextMute());
+        }
+
+        if (InColumnName == TEXT("Pct"))
+        {
+            const double Pct = (_FrameDurationMs > 0.0)
+                ? (_Node->InclusiveMs / _FrameDurationMs) * 100.0
+                : 0.0;
+
+            return SNew(SHorizontalBox)
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .VAlign(VAlign_Center)
+                .Padding(CkStyle::SpaceS, 0.0f)
+                [
+                    MakeProportionBar(Pct, CkStyle::OverlayOf(SeverityColor(_Node->InclusiveMs), 0.85f), 60.0f)
+                ]
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .VAlign(VAlign_Center)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("%.0f%%"), Pct)))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextDim())
+                ];
+        }
+
+        return SNullWidget::NullWidget;
+    }
+
+private:
+    auto DoBuildBreadcrumbSuffix() const -> FString
+    {
+        // Show at most the last two collapsed wrappers, like the markdown report
+        FString Breadcrumb;
+        const int32 Start = FMath::Max(0, _Node->Breadcrumbs.Num() - 2);
+        for (int32 i = Start; i < _Node->Breadcrumbs.Num(); ++i)
+        {
+            const FString Simplified = FCk_TimerCategorizer::SimplifyName(_Node->Breadcrumbs[i]);
+            if (Simplified.Len() > 30)
+            {
+                continue;
+            }
+            if (NOT Breadcrumb.IsEmpty())
+            {
+                Breadcrumb += TEXT(" → ");
+            }
+            Breadcrumb += Simplified;
+        }
+        return Breadcrumb.IsEmpty() ? Breadcrumb : FString::Printf(TEXT("  (%s)"), *Breadcrumb);
+    }
+
+    auto DoMakeCell(const FString& InText, const FSlateFontInfo& InFont, const FLinearColor& InColor) const -> TSharedRef<SWidget>
+    {
+        return SNew(SBox)
+            .Padding(FMargin(ck_insights_analyzer_tab::SectionSpacing * 0.5f, 0.0f))
+            .VAlign(VAlign_Center)
+            .HAlign(HAlign_Right)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(InText))
+                .Font(InFont)
+                .ColorAndOpacity(InColor)
+            ];
+    }
+
+private:
+    TSharedPtr<FCk_HotPathNode> _Node;
+    double _FrameDurationMs = 0.0;
+};
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -34,6 +385,8 @@ auto
     Construct(const FArguments& InArgs)
     -> void
 {
+    using namespace ck_insights_analyzer_tab;
+
     _DepthOptions.Add(MakeShared<FString>(TEXT("Full")));
     _DepthOptions.Add(MakeShared<FString>(TEXT("Standard")));
     _DepthOptions.Add(MakeShared<FString>(TEXT("Concise")));
@@ -42,60 +395,63 @@ auto
     ChildSlot
     [
         SNew(SBorder)
-        .BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
-        .Padding(InsightsAnalyzerTab_Constants::PanelPadding)
+        .BorderImage(CkStyle::GetFilledBrush())
+        .BorderBackgroundColor(CkStyle::BgRoot())
+        .Padding(PanelPadding)
         [
             SNew(SVerticalBox)
 
             // Toolbar
             + SVerticalBox::Slot()
             .AutoHeight()
-            .Padding(0, 0, 0, InsightsAnalyzerTab_Constants::SectionSpacing)
+            .Padding(0.0f, 0.0f, 0.0f, SectionSpacing)
             [
                 DoCreateToolbar()
             ]
 
-            // Separator
+            // Summary strip (stat tiles; hidden until a trace is loaded)
             + SVerticalBox::Slot()
             .AutoHeight()
-            .Padding(0, 0, 0, InsightsAnalyzerTab_Constants::SectionSpacing)
+            .Padding(0.0f, 0.0f, 0.0f, SectionSpacing)
             [
-                SNew(SSeparator)
+                DoCreateSummaryStrip()
             ]
 
             // Frame bar chart
             + SVerticalBox::Slot()
             .AutoHeight()
-            .Padding(0, 0, 0, InsightsAnalyzerTab_Constants::SectionSpacing)
+            .Padding(0.0f, 0.0f, 0.0f, SectionSpacing)
             [
                 SNew(SBox)
-                .HeightOverride(InsightsAnalyzerTab_Constants::ChartHeight)
+                .HeightOverride(ChartHeight)
                 [
                     SAssignNew(_FrameBarChart, SCkFrameBarChart)
-                    .TargetFrameMs(16.67)
+                    .TargetFrameMs(TargetFrameMs)
                     .OnFrameSelectionChanged(
                         FOnFrameSelectionChanged::CreateSP(this, &SCkInsightsAnalyzerTab::DoOnFrameSelectionChanged))
                 ]
             ]
 
-            // Separator
-            + SVerticalBox::Slot()
-            .AutoHeight()
-            .Padding(0, 0, 0, InsightsAnalyzerTab_Constants::SectionSpacing)
-            [
-                SNew(SSeparator)
-            ]
-
-            // Results panel
+            // Results (tree + side panels)
             + SVerticalBox::Slot()
             .FillHeight(1.0f)
+            .Padding(0.0f, 0.0f, 0.0f, SectionSpacing)
             [
-                DoCreateResultsPanel()
+                DoCreateResultsArea()
+            ]
+
+            // Raw markdown report (collapsed)
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            [
+                DoCreateRawReportArea()
             ]
         ]
     ];
 }
 
+// --------------------------------------------------------------------------------------------------------------------
+// UI Construction
 // --------------------------------------------------------------------------------------------------------------------
 
 auto
@@ -103,38 +459,38 @@ auto
     DoCreateToolbar()
     -> TSharedRef<SWidget>
 {
+    using namespace ck_insights_analyzer_tab;
+
     return SNew(SHorizontalBox)
 
         // Open .utrace button
         + SHorizontalBox::Slot()
         .AutoWidth()
-        .Padding(0, 0, InsightsAnalyzerTab_Constants::SectionSpacing, 0)
+        .Padding(0.0f, 0.0f, SectionSpacing, 0.0f)
         [
-            SNew(SBox)
-            .WidthOverride(InsightsAnalyzerTab_Constants::ButtonWidth)
-            [
-                SNew(SButton)
-                .Text(FText::FromString(TEXT("Open .utrace...")))
-                .ToolTipText(FText::FromString(TEXT("Open an Unreal Insights trace file for analysis")))
-                .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnOpenTraceClicked)
-                .HAlign(HAlign_Center)
-            ]
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Open .utrace...")))
+            .ToolTipText(FText::FromString(TEXT("Open an Unreal Insights trace file for analysis")))
+            .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnOpenTraceClicked)
+            .HAlign(HAlign_Center)
         ]
 
         // Depth dropdown
         + SHorizontalBox::Slot()
         .AutoWidth()
         .VAlign(VAlign_Center)
-        .Padding(0, 0, InsightsAnalyzerTab_Constants::SectionSpacing, 0)
+        .Padding(0.0f, 0.0f, SectionSpacing, 0.0f)
         [
             SNew(SHorizontalBox)
             + SHorizontalBox::Slot()
             .AutoWidth()
             .VAlign(VAlign_Center)
-            .Padding(0, 0, 4, 0)
+            .Padding(0.0f, 0.0f, CkStyle::SpaceS, 0.0f)
             [
                 SNew(STextBlock)
                 .Text(FText::FromString(TEXT("Depth:")))
+                .Font(BodyFont())
+                .ColorAndOpacity(CkStyle::TextDim())
             ]
             + SHorizontalBox::Slot()
             .AutoWidth()
@@ -153,65 +509,636 @@ auto
         // Analyze Worst 10
         + SHorizontalBox::Slot()
         .AutoWidth()
-        .Padding(0, 0, InsightsAnalyzerTab_Constants::SectionSpacing, 0)
+        .Padding(0.0f, 0.0f, SectionSpacing, 0.0f)
         [
-            SNew(SBox)
-            .WidthOverride(InsightsAnalyzerTab_Constants::ButtonWidth)
-            [
-                SNew(SButton)
-                .Text(FText::FromString(TEXT("Analyze Worst 10")))
-                .ToolTipText(FText::FromString(TEXT("Find and analyze the 10 worst frames in the trace")))
-                .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnAnalyzeWorstClicked)
-                .HAlign(HAlign_Center)
-            ]
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Analyze Worst 10")))
+            .ToolTipText(FText::FromString(TEXT("Find and analyze the 10 worst frames in the trace")))
+            .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnAnalyzeWorstClicked)
+            .HAlign(HAlign_Center)
         ]
 
-        // Copy to Clipboard
+        // Copy Report
         + SHorizontalBox::Slot()
         .AutoWidth()
-        .Padding(0, 0, InsightsAnalyzerTab_Constants::SectionSpacing, 0)
+        .Padding(0.0f, 0.0f, SectionSpacing, 0.0f)
         [
-            SNew(SBox)
-            .WidthOverride(InsightsAnalyzerTab_Constants::ButtonWidth)
-            [
-                SNew(SButton)
-                .Text(FText::FromString(TEXT("Copy to Clipboard")))
-                .ToolTipText(FText::FromString(TEXT("Copy the current report to the system clipboard")))
-                .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnCopyToClipboardClicked)
-                .HAlign(HAlign_Center)
-            ]
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Copy Report")))
+            .ToolTipText(FText::FromString(TEXT("Copy the current markdown report to the system clipboard")))
+            .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnCopyToClipboardClicked)
+            .HAlign(HAlign_Center)
         ]
 
-        // Status text (fills remaining space)
+        // Status pill (fills remaining space)
         + SHorizontalBox::Slot()
         .FillWidth(1.0f)
         .VAlign(VAlign_Center)
-        .Padding(InsightsAnalyzerTab_Constants::SectionSpacing, 0, 0, 0)
+        .Padding(SectionSpacing, 0.0f, 0.0f, 0.0f)
         [
-            SAssignNew(_StatusText, STextBlock)
-            .Text(FText::FromString(TEXT("No trace loaded. Click \"Open .utrace...\" to begin.")))
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            .Padding(0.0f, 0.0f, CkStyle::SpaceS, 0.0f)
+            [
+                SNew(SBox)
+                .WidthOverride(8.0f)
+                .HeightOverride(8.0f)
+                [
+                    SNew(SImage)
+                    .Image(CkStyle::GetFilledBrush())
+                    .ColorAndOpacity_Lambda([this]() -> FSlateColor
+                    {
+                        return CkStyle::GetToneColor(_StatusTone);
+                    })
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .FillWidth(1.0f)
+            .VAlign(VAlign_Center)
+            [
+                SAssignNew(_StatusText, STextBlock)
+                .Text(FText::FromString(TEXT("No trace loaded. Click \"Open .utrace...\" to begin.")))
+                .Font(BodyFont())
+                .ColorAndOpacity(CkStyle::TextDim())
+            ]
         ];
 }
 
 auto
     SCkInsightsAnalyzerTab::
-    DoCreateResultsPanel()
+    DoCreateSummaryStrip()
     -> TSharedRef<SWidget>
 {
-    return SNew(SBorder)
-        .BorderImage(FAppStyle::GetBrush("ToolPanel.DarkGroupBorder"))
-        .Padding(4.0f)
+    SAssignNew(_SummaryBox, SHorizontalBox);
+
+    return SNew(SBox)
+        .Visibility_Lambda([this]() -> EVisibility
+        {
+            return (ck::IsValid(_SummaryBox) && _SummaryBox->NumSlots() > 0)
+                ? EVisibility::Visible
+                : EVisibility::Collapsed;
+        })
         [
-            SNew(SScrollBox)
-            .ConsumeMouseWheel(EConsumeMouseWheel::WhenScrollingPossible)
-            + SScrollBox::Slot()
+            _SummaryBox.ToSharedRef()
+        ];
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoCreateResultsArea()
+    -> TSharedRef<SWidget>
+{
+    return SNew(SSplitter)
+        .Orientation(Orient_Horizontal)
+        .PhysicalSplitterHandleSize(2.0f)
+
+        + SSplitter::Slot()
+        .Value(0.62f)
+        [
+            DoCreateHotPathPanel()
+        ]
+
+        + SSplitter::Slot()
+        .Value(0.38f)
+        [
+            DoCreateSidePanels()
+        ];
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoCreateHotPathPanel()
+    -> TSharedRef<SWidget>
+{
+    using namespace ck_insights_analyzer_tab;
+
+    SAssignNew(_HotPathTree, STreeView<TSharedPtr<FCk_HotPathNode>>)
+        .TreeItemsSource(&_HotPathRoots)
+        .SelectionMode(ESelectionMode::Single)
+        .OnGenerateRow(this, &SCkInsightsAnalyzerTab::DoGenerateHotPathRow)
+        .OnGetChildren_Lambda([](TSharedPtr<FCk_HotPathNode> InNode, TArray<TSharedPtr<FCk_HotPathNode>>& OutChildren)
+        {
+            if (InNode.IsValid())
+            {
+                OutChildren = InNode->Children;
+            }
+        })
+        .HeaderRow
+        (
+            SNew(SHeaderRow)
+            + SHeaderRow::Column(TEXT("Timer"))
+              .DefaultLabel(FText::FromString(TEXT("Timer")))
+              .FillWidth(1.0f)
+            + SHeaderRow::Column(TEXT("Incl"))
+              .DefaultLabel(FText::FromString(TEXT("Incl")))
+              .FixedWidth(76.0f)
+              .HAlignHeader(HAlign_Right)
+            + SHeaderRow::Column(TEXT("Self"))
+              .DefaultLabel(FText::FromString(TEXT("Self")))
+              .FixedWidth(76.0f)
+              .HAlignHeader(HAlign_Right)
+            + SHeaderRow::Column(TEXT("Count"))
+              .DefaultLabel(FText::FromString(TEXT("Count")))
+              .FixedWidth(64.0f)
+              .HAlignHeader(HAlign_Right)
+            + SHeaderRow::Column(TEXT("Pct"))
+              .DefaultLabel(FText::FromString(TEXT("% Frame")))
+              .FixedWidth(120.0f)
+        );
+
+    return SNew(SBorder)
+        .BorderImage(CkStyle::GetFilledBrush())
+        .BorderBackgroundColor(CkStyle::Bg1())
+        .Padding(CkStyle::SpaceM)
+        [
+            SNew(SVerticalBox)
+            + SVerticalBox::Slot()
+            .AutoHeight()
+            .Padding(0.0f, 0.0f, 0.0f, CkStyle::SpaceS)
             [
-                SAssignNew(_ReportText, SMultiLineEditableText)
-                .IsReadOnly(true)
-                .AutoWrapText(false)
-                .Text(FText::GetEmpty())
+                MakeHeading(TEXT("Game Thread Hot Paths"))
+            ]
+            + SVerticalBox::Slot()
+            .FillHeight(1.0f)
+            [
+                SNew(SOverlay)
+                + SOverlay::Slot()
+                [
+                    _HotPathTree.ToSharedRef()
+                ]
+                + SOverlay::Slot()
+                .HAlign(HAlign_Center)
+                .VAlign(VAlign_Center)
+                [
+                    SNew(STextBlock)
+                    .Font(BodyFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                    .Visibility_Lambda([this]() -> EVisibility
+                    {
+                        return (_HotPathRoots.Num() == 0)
+                            ? EVisibility::HitTestInvisible
+                            : EVisibility::Collapsed;
+                    })
+                    .Text_Lambda([this]() -> FText
+                    {
+                        switch (_ResultsMode)
+                        {
+                            case EResultsMode::MultiFrame:
+                                return FText::FromString(TEXT("Range analyzed — click a Worst Frame row or a single chart bar to see its hot paths."));
+                            case EResultsMode::SingleFrame:
+                                return FText::FromString(TEXT("No hot paths found for this frame."));
+                            default:
+                                return FText::FromString(TEXT("Open a .utrace, then click a frame bar (or drag a range) in the chart."));
+                        }
+                    })
+                ]
             ]
         ];
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoCreateSidePanels()
+    -> TSharedRef<SWidget>
+{
+    using namespace ck_insights_analyzer_tab;
+
+    SAssignNew(_CategoryRowsBox, SVerticalBox);
+    SAssignNew(_TopTimerRowsBox, SVerticalBox);
+    SAssignNew(_WorstFrameRowsBox, SVerticalBox);
+    SAssignNew(_CategoryAvgRowsBox, SVerticalBox);
+
+    const auto MakeGatedPanel =
+        [this](const FString& InHeading, const TSharedRef<SWidget>& InRowsBox, TFunction<bool()> InHasData) -> TSharedRef<SWidget>
+    {
+        return SNew(SBox)
+            .Visibility_Lambda([InHasData = MoveTemp(InHasData)]() -> EVisibility
+            {
+                return InHasData() ? EVisibility::Visible : EVisibility::Collapsed;
+            })
+            .Padding(FMargin(SectionSpacing, 0.0f, 0.0f, SectionSpacing))
+            [
+                MakePanel(InHeading, InRowsBox)
+            ];
+    };
+
+    return SNew(SScrollBox)
+        .ConsumeMouseWheel(EConsumeMouseWheel::WhenScrollingPossible)
+
+        + SScrollBox::Slot()
+        [
+            MakeGatedPanel(TEXT("Worst Frames"), _WorstFrameRowsBox.ToSharedRef(),
+                [this]() { return _WorstFrames.Num() > 0; })
+        ]
+
+        + SScrollBox::Slot()
+        [
+            MakeGatedPanel(TEXT("Category Averages"), _CategoryAvgRowsBox.ToSharedRef(),
+                [this]() { return _CategoryAverages.Num() > 0; })
+        ]
+
+        + SScrollBox::Slot()
+        [
+            MakeGatedPanel(TEXT("Categories (exclusive time)"), _CategoryRowsBox.ToSharedRef(),
+                [this]() { return _Categories.Num() > 0; })
+        ]
+
+        + SScrollBox::Slot()
+        [
+            MakeGatedPanel(TEXT("Top Timers (exclusive time)"), _TopTimerRowsBox.ToSharedRef(),
+                [this]() { return _TopTimers.Num() > 0; })
+        ];
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoCreateRawReportArea()
+    -> TSharedRef<SWidget>
+{
+    using namespace ck_insights_analyzer_tab;
+
+    return SNew(SBox)
+        .Visibility_Lambda([this]() -> EVisibility
+        {
+            return _CurrentReport.IsEmpty() ? EVisibility::Collapsed : EVisibility::Visible;
+        })
+        [
+            SNew(SExpandableArea)
+            .InitiallyCollapsed(true)
+            .HeaderContent()
+            [
+                MakeHeading(TEXT("Raw Markdown Report"))
+            ]
+            .BodyContent()
+            [
+                SNew(SBox)
+                .MaxDesiredHeight(260.0f)
+                [
+                    SNew(SBorder)
+                    .BorderImage(CkStyle::GetFilledBrush())
+                    .BorderBackgroundColor(CkStyle::Bg1())
+                    .Padding(CkStyle::SpaceS)
+                    [
+                        SNew(SScrollBox)
+                        .ConsumeMouseWheel(EConsumeMouseWheel::WhenScrollingPossible)
+                        + SScrollBox::Slot()
+                        [
+                            SAssignNew(_ReportText, SMultiLineEditableText)
+                            .IsReadOnly(true)
+                            .AutoWrapText(false)
+                            .Text(FText::GetEmpty())
+                        ]
+                    ]
+                ]
+            ]
+        ];
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Hot-path tree
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoGenerateHotPathRow(TSharedPtr<FCk_HotPathNode> InNode,
+                         const TSharedRef<STableViewBase>& InOwnerTable)
+    -> TSharedRef<ITableRow>
+{
+    return SNew(SCkInsights_HotPathRow, InOwnerTable)
+        .Node(InNode)
+        .FrameDurationMs(_AnalyzedFrameMs);
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoExpandHotPathDefaults()
+    -> void
+{
+    if (ck::Is_NOT_Valid(_HotPathTree))
+    {
+        return;
+    }
+
+    // Expand roots and their direct children so the interesting depth is visible immediately
+    for (const auto& Root : _HotPathRoots)
+    {
+        _HotPathTree->SetItemExpansion(Root, true);
+        for (const auto& Child : Root->Children)
+        {
+            _HotPathTree->SetItemExpansion(Child, true);
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Side panel row rebuilds
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildCategoryRows()
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (ck::Is_NOT_Valid(_CategoryRowsBox))
+    {
+        return;
+    }
+    _CategoryRowsBox->ClearChildren();
+
+    for (const FCk_CategorySummaryEntry& Cat : _Categories)
+    {
+        _CategoryRowsBox->AddSlot()
+        .AutoHeight()
+        .Padding(0.0f, 1.0f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            .Padding(0.0f, 0.0f, CkStyle::SpaceS, 0.0f)
+            [
+                MakeDot(CategoryColor(Cat.Name))
+            ]
+            + SHorizontalBox::Slot()
+            .FillWidth(1.0f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(Cat.Name))
+                .Font(BodyFont())
+                .ColorAndOpacity(CkStyle::Text())
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            .Padding(CkStyle::SpaceS, 0.0f)
+            [
+                MakeProportionBar(Cat.PctOfFrame, CkStyle::OverlayOf(CategoryColor(Cat.Name), 0.85f), SideBarWidth)
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(60.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FCk_TimerCategorizer::FormatMs(Cat.ExclusiveMs)))
+                    .Font(BodyBoldFont())
+                    .ColorAndOpacity(SeverityColor(Cat.ExclusiveMs))
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(44.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("%.0f%%"), Cat.PctOfFrame)))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                ]
+            ]
+        ];
+    }
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildTopTimerRows()
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (ck::Is_NOT_Valid(_TopTimerRowsBox))
+    {
+        return;
+    }
+    _TopTimerRowsBox->ClearChildren();
+
+    int32 Rank = 0;
+    for (const FCk_TopTimerEntry& Timer : _TopTimers)
+    {
+        ++Rank;
+
+        _TopTimerRowsBox->AddSlot()
+        .AutoHeight()
+        .Padding(0.0f, 1.0f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            .Padding(0.0f, 0.0f, CkStyle::SpaceS, 0.0f)
+            [
+                SNew(SBox)
+                .WidthOverride(22.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("%d."), Rank)))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .FillWidth(1.0f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(Timer.Name))
+                .Font(BodyFont())
+                .ColorAndOpacity(CkStyle::Text())
+                .OverflowPolicy(ETextOverflowPolicy::Ellipsis)
+                .ToolTipText(FText::FromString(FString::Printf(
+                    TEXT("%s\nExclusive: %s   Inclusive: %s   Count: %s"),
+                    *Timer.Name,
+                    *FCk_TimerCategorizer::FormatMs(Timer.ExclusiveMs),
+                    *FCk_TimerCategorizer::FormatMs(Timer.InclusiveMs),
+                    *FCk_TimerCategorizer::FormatCount(Timer.Count))))
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(60.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FCk_TimerCategorizer::FormatMs(Timer.ExclusiveMs)))
+                    .Font(BodyBoldFont())
+                    .ColorAndOpacity(SeverityColor(Timer.ExclusiveMs))
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(52.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString((Timer.Count > 1) ? FCk_TimerCategorizer::FormatCount(Timer.Count) : FString()))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                ]
+            ]
+        ];
+    }
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildWorstFrameRows()
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (ck::Is_NOT_Valid(_WorstFrameRowsBox))
+    {
+        return;
+    }
+    _WorstFrameRowsBox->ClearChildren();
+
+    for (const FCk_FrameSummary& Frame : _WorstFrames)
+    {
+        _WorstFrameRowsBox->AddSlot()
+        .AutoHeight()
+        .Padding(0.0f, 1.0f)
+        [
+            SNew(SButton)
+            .ButtonStyle(FAppStyle::Get(), "SimpleButton")
+            .ContentPadding(FMargin(CkStyle::SpaceS, 2.0f))
+            .ToolTipText(FText::FromString(TEXT("Analyze this frame (selects it in the chart)")))
+            .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnWorstFrameClicked, Frame.FrameIndex)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .VAlign(VAlign_Center)
+                [
+                    SNew(SBox)
+                    .WidthOverride(76.0f)
+                    [
+                        SNew(STextBlock)
+                        .Text(FText::FromString(FString::Printf(TEXT("#%s"), *FormatWithCommas(Frame.FrameIndex))))
+                        .Font(BodyBoldFont())
+                        .ColorAndOpacity(CkStyle::Accent())
+                    ]
+                ]
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .VAlign(VAlign_Center)
+                [
+                    SNew(SBox)
+                    .WidthOverride(64.0f)
+                    .HAlign(HAlign_Right)
+                    [
+                        SNew(STextBlock)
+                        .Text(FText::FromString(FCk_TimerCategorizer::FormatMs(Frame.DurationMs)))
+                        .Font(BodyBoldFont())
+                        .ColorAndOpacity(FrameBudgetColor(Frame.DurationMs))
+                    ]
+                ]
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .VAlign(VAlign_Center)
+                .Padding(CkStyle::SpaceM, 0.0f, 0.0f, 0.0f)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(Frame.DominantCost))
+                    .Font(ItalicFont())
+                    .ColorAndOpacity(CkStyle::TextDim())
+                    .OverflowPolicy(ETextOverflowPolicy::Ellipsis)
+                ]
+            ]
+        ];
+    }
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildCategoryAvgRows()
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (ck::Is_NOT_Valid(_CategoryAvgRowsBox))
+    {
+        return;
+    }
+    _CategoryAvgRowsBox->ClearChildren();
+
+    for (const FCk_MultiFrameStats::FCategoryStats& Cat : _CategoryAverages)
+    {
+        _CategoryAvgRowsBox->AddSlot()
+        .AutoHeight()
+        .Padding(0.0f, 1.0f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            .Padding(0.0f, 0.0f, CkStyle::SpaceS, 0.0f)
+            [
+                MakeDot(CategoryColor(Cat.Name))
+            ]
+            + SHorizontalBox::Slot()
+            .FillWidth(1.0f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(Cat.Name))
+                .Font(BodyFont())
+                .ColorAndOpacity(CkStyle::Text())
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            .Padding(CkStyle::SpaceS, 0.0f)
+            [
+                MakeProportionBar(Cat.TotalPct, CkStyle::OverlayOf(CategoryColor(Cat.Name), 0.85f), SideBarWidth)
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(64.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("%s avg"), *FCk_TimerCategorizer::FormatMs(Cat.AvgExclMs))))
+                    .Font(BodyBoldFont())
+                    .ColorAndOpacity(SeverityColor(Cat.AvgExclMs))
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(64.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("%s p95"), *FCk_TimerCategorizer::FormatMs(Cat.P95ExclMs))))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                ]
+            ]
+        ];
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -225,14 +1152,14 @@ auto
 {
     if (DoIsLoading())
     {
-        DoSetStatus(TEXT("Loading in progress..."));
+        DoSetStatus(TEXT("Loading in progress..."), ECk_Tone::Warn);
         return FReply::Handled();
     }
 
     const auto DesktopPlatform = FDesktopPlatformModule::Get();
     if (ck::Is_NOT_Valid(DesktopPlatform, ck::IsValid_Policy_NullptrOnly{}))
     {
-        DoSetStatus(TEXT("Desktop platform not available."));
+        DoSetStatus(TEXT("Desktop platform not available."), ECk_Tone::Err);
         return FReply::Handled();
     }
 
@@ -254,7 +1181,7 @@ auto
     // Close any existing session
     _Session.Close();
     _FrameBarChart->ClearFrameData();
-    DoSetReport(TEXT(""));
+    DoClearResults();
 
     DoStartAsyncOpen(OutFiles[0]);
     return FReply::Handled();
@@ -265,26 +1192,27 @@ auto
     DoOnAnalyzeWorstClicked()
     -> FReply
 {
+    using namespace ck_insights_analyzer_tab;
+
     if (NOT _Session.IsOpen() || DoIsLoading())
     {
-        DoSetStatus(TEXT("No trace loaded. Open a .utrace file first."));
+        DoSetStatus(TEXT("No trace loaded. Open a .utrace file first."), ECk_Tone::Warn);
         return FReply::Handled();
     }
 
-    DoSetStatus(TEXT("Analyzing worst 10 frames..."));
+    DoSetStatus(TEXT("Analyzing worst 10 frames..."), ECk_Tone::Info);
 
     FCk_MultiFrameReportConfig Config;
-    Config.TargetFrameMs = 16.67;
-    Config.WorstFrameCount = 10;
+    Config.TargetFrameMs = TargetFrameMs;
     Config.Depth = _ReportDepth;
     Config.ApplyDepth();
     Config.WorstFrameCount = 10; // Override depth's default worst count
 
     FCk_MultiFrameReport MultiReport(Config);
-    const FString Report = MultiReport.AnalyzeWorstFrames(_Session, 10);
+    DoSetReport(MultiReport.AnalyzeWorstFrames(_Session, 10));
+    DoPopulateMultiFrame(MultiReport.GetStats());
 
-    DoSetReport(Report);
-    DoSetStatus(TEXT("Worst 10 frames analysis complete."));
+    DoSetStatus(TEXT("Worst 10 frames analysis complete. Click a Worst Frame row to drill in."), ECk_Tone::Ok);
 
     return FReply::Handled();
 }
@@ -296,12 +1224,31 @@ auto
 {
     if (_CurrentReport.IsEmpty())
     {
-        DoSetStatus(TEXT("No report to copy."));
+        DoSetStatus(TEXT("No report to copy."), ECk_Tone::Warn);
         return FReply::Handled();
     }
 
     FPlatformApplicationMisc::ClipboardCopy(*_CurrentReport);
-    DoSetStatus(TEXT("Report copied to clipboard."));
+    DoSetStatus(TEXT("Report copied to clipboard."), ECk_Tone::Ok);
+
+    return FReply::Handled();
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoOnWorstFrameClicked(uint64 FrameIndex)
+    -> FReply
+{
+    if (NOT _Session.IsOpen() || DoIsLoading())
+    {
+        return FReply::Handled();
+    }
+
+    if (ck::IsValid(_FrameBarChart))
+    {
+        _FrameBarChart->SetSelection(FrameIndex, FrameIndex);
+    }
+    DoAnalyzeSingleFrame(FrameIndex);
 
     return FReply::Handled();
 }
@@ -321,14 +1268,9 @@ auto
     else if (*NewValue == TEXT("Standard"))  _ReportDepth = ECkReportDepth::Standard;
     else if (*NewValue == TEXT("Concise"))   _ReportDepth = ECkReportDepth::Concise;
     else                                    _ReportDepth = ECkReportDepth::HotPathsOnly;
-}
 
-auto
-    SCkInsightsAnalyzerTab::
-    DoGetReportDepth() const
-    -> ECkReportDepth
-{
-    return _ReportDepth;
+    // Re-run the current selection so the depth change is immediately visible
+    DoRerunCurrentSelection();
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -360,9 +1302,10 @@ auto
 
 auto
     SCkInsightsAnalyzerTab::
-    DoSetStatus(const FString& Text)
+    DoSetStatus(const FString& Text, ECk_Tone InTone)
     -> void
 {
+    _StatusTone = InTone;
     if (ck::IsValid(_StatusText))
     {
         _StatusText->SetText(FText::FromString(Text));
@@ -383,29 +1326,83 @@ auto
 
 auto
     SCkInsightsAnalyzerTab::
+    DoClearResults()
+    -> void
+{
+    DoSetReport(TEXT(""));
+
+    _ResultsMode = EResultsMode::None;
+    _AnalyzedFrameMs = 0.0;
+
+    _HotPathRoots.Reset();
+    _Categories.Reset();
+    _TopTimers.Reset();
+    _WorstFrames.Reset();
+    _CategoryAverages.Reset();
+
+    if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
+    DoRebuildCategoryRows();
+    DoRebuildTopTimerRows();
+    DoRebuildWorstFrameRows();
+    DoRebuildCategoryAvgRows();
+
+    if (ck::IsValid(_SummaryBox)) { _SummaryBox->ClearChildren(); }
+}
+
+auto
+    SCkInsightsAnalyzerTab::
     DoAnalyzeSingleFrame(uint64 FrameIndex)
     -> void
 {
-    DoSetStatus(FString::Printf(TEXT("Analyzing frame %llu..."), FrameIndex));
+    using namespace ck_insights_analyzer_tab;
+
+    DoSetStatus(FString::Printf(TEXT("Analyzing frame %llu..."), FrameIndex), ECk_Tone::Info);
 
     FCk_FrameAnalysisResult Result = FCk_FrameAnalyzer::AnalyzeFrame(_Session, FrameIndex);
     if (NOT Result.IsValid())
     {
-        DoSetStatus(FString::Printf(TEXT("Frame %llu produced no analysis data."), FrameIndex));
+        DoSetStatus(FString::Printf(TEXT("Frame %llu produced no analysis data."), FrameIndex), ECk_Tone::Warn);
+
+        _ResultsMode = EResultsMode::None;
+        _AnalyzedFrameMs = 0.0;
+        _HotPathRoots.Reset();
+        _Categories.Reset();
+        _TopTimers.Reset();
+        if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
+        DoRebuildCategoryRows();
+        DoRebuildTopTimerRows();
         DoSetReport(TEXT(""));
         return;
     }
 
     FCk_FrameReportConfig Config;
-    Config.TargetFrameMs = 16.67;
+    Config.TargetFrameMs = TargetFrameMs;
     Config.Depth = _ReportDepth;
     Config.ApplyDepth();
 
     FCk_FrameReport FrameReport(Config);
-    const FString Report = FrameReport.Generate(_Session, Result);
+    DoSetReport(FrameReport.Generate(_Session, Result));
 
-    DoSetReport(Report);
-    DoSetStatus(FString::Printf(TEXT("Frame %llu: %.2fms"), FrameIndex, Result.FrameDurationMs));
+    // Structured views
+    _ResultsMode = EResultsMode::SingleFrame;
+    _AnalyzedFrameMs = Result.FrameDurationMs;
+    _HotPathRoots = FrameReport.BuildHotPathTree(_Session, Result);
+
+    {
+        TraceServices::FAnalysisSessionReadScope ReadScope = _Session.CreateReadScope();
+        const FCk_FrameReport::FTimerNameMap TimerNames = FCk_FrameReport::BuildTimerNameMap(_Session);
+        _Categories = FrameReport.ComputeCategorySummary(Result, TimerNames);
+        _TopTimers = FrameReport.ComputeTopTimers(Result, TimerNames, TopTimerCount);
+    }
+
+    if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
+    DoExpandHotPathDefaults();
+    DoRebuildCategoryRows();
+    DoRebuildTopTimerRows();
+    DoRebuildSummaryStrip_SingleFrame(Result);
+
+    DoSetStatus(FString::Printf(TEXT("Frame %llu: %.2fms"), FrameIndex, Result.FrameDurationMs),
+        FrameBudgetTone(Result.FrameDurationMs));
 }
 
 auto
@@ -413,20 +1410,143 @@ auto
     DoAnalyzeFrameRange(uint64 StartFrame, uint64 EndFrame)
     -> void
 {
+    using namespace ck_insights_analyzer_tab;
+
     const uint64 Count = EndFrame - StartFrame + 1;
-    DoSetStatus(FString::Printf(TEXT("Analyzing frames %llu-%llu (%llu frames)..."), StartFrame, EndFrame, Count));
+    DoSetStatus(FString::Printf(TEXT("Analyzing frames %llu-%llu (%llu frames)..."), StartFrame, EndFrame, Count),
+        ECk_Tone::Info);
 
     FCk_MultiFrameReportConfig Config;
-    Config.TargetFrameMs = 16.67;
+    Config.TargetFrameMs = TargetFrameMs;
     Config.Depth = _ReportDepth;
     Config.ApplyDepth();
 
     FCk_MultiFrameReport MultiReport(Config);
     // EndFrame is inclusive from the chart, but AnalyzeAndGenerate expects exclusive
-    const FString Report = MultiReport.AnalyzeAndGenerate(_Session, StartFrame, EndFrame + 1);
+    DoSetReport(MultiReport.AnalyzeAndGenerate(_Session, StartFrame, EndFrame + 1));
+    DoPopulateMultiFrame(MultiReport.GetStats());
 
-    DoSetReport(Report);
-    DoSetStatus(FString::Printf(TEXT("Analyzed frames %llu-%llu (%llu frames)"), StartFrame, EndFrame, Count));
+    DoSetStatus(FString::Printf(TEXT("Analyzed frames %llu-%llu (%llu frames)"), StartFrame, EndFrame, Count),
+        ECk_Tone::Ok);
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRerunCurrentSelection()
+    -> void
+{
+    if (NOT _Session.IsOpen() || DoIsLoading() ||
+        ck::Is_NOT_Valid(_FrameBarChart) || NOT _FrameBarChart->HasSelection())
+    {
+        return;
+    }
+
+    DoOnFrameSelectionChanged(_FrameBarChart->GetSelectionStart(), _FrameBarChart->GetSelectionEnd());
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoPopulateMultiFrame(const FCk_MultiFrameStats& Stats)
+    -> void
+{
+    _ResultsMode = EResultsMode::MultiFrame;
+    _AnalyzedFrameMs = 0.0;
+
+    // Multi-frame analysis has no single-frame tree/categories
+    _HotPathRoots.Reset();
+    _Categories.Reset();
+    _TopTimers.Reset();
+
+    _WorstFrames = Stats.WorstFrames;
+    _CategoryAverages = Stats.CategoryAverages;
+
+    if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
+    DoRebuildCategoryRows();
+    DoRebuildTopTimerRows();
+    DoRebuildWorstFrameRows();
+    DoRebuildCategoryAvgRows();
+    DoRebuildSummaryStrip_MultiFrame(Stats);
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Summary strip
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoAddSummaryTile(const FString& InLabel, const FString& InValue, const FLinearColor& InValueColor)
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (ck::Is_NOT_Valid(_SummaryBox))
+    {
+        return;
+    }
+
+    _SummaryBox->AddSlot()
+    .AutoWidth()
+    .Padding(0.0f, 0.0f, CkStyle::SpaceM, 0.0f)
+    [
+        MakeStatTile(InLabel, InValue, InValueColor)
+    ];
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildSummaryStrip_TraceInfo()
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (ck::Is_NOT_Valid(_SummaryBox))
+    {
+        return;
+    }
+    _SummaryBox->ClearChildren();
+
+    if (NOT _Session.IsOpen())
+    {
+        return;
+    }
+
+    DoAddSummaryTile(TEXT("Trace"), FPaths::GetCleanFilename(_Session.GetFilePath()), CkStyle::Text());
+    DoAddSummaryTile(TEXT("Frames"), FormatWithCommas(_Session.GetFrameCount()), CkStyle::Text());
+    DoAddSummaryTile(TEXT("Duration"), FString::Printf(TEXT("%.1fs"), _Session.GetDurationSeconds()), CkStyle::Text());
+    DoAddSummaryTile(TEXT("Budget"), FString::Printf(TEXT("%.1fms"), TargetFrameMs), CkStyle::TextDim());
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildSummaryStrip_SingleFrame(const FCk_FrameAnalysisResult& Result)
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    DoRebuildSummaryStrip_TraceInfo();
+
+    const double FrameMs = Result.FrameDurationMs;
+    const double OverBudget = FrameMs / TargetFrameMs;
+
+    DoAddSummaryTile(TEXT("Frame"), FString::Printf(TEXT("#%s"), *FormatWithCommas(Result.FrameIndex)), CkStyle::Accent());
+    DoAddSummaryTile(TEXT("Frame Time"), FString::Printf(TEXT("%.2fms"), FrameMs), FrameBudgetColor(FrameMs));
+    DoAddSummaryTile(TEXT("Vs Budget"), FString::Printf(TEXT("%.1fx"), OverBudget), FrameBudgetColor(FrameMs));
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildSummaryStrip_MultiFrame(const FCk_MultiFrameStats& Stats)
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    DoRebuildSummaryStrip_TraceInfo();
+
+    DoAddSummaryTile(TEXT("Analyzed"), FormatWithCommas(Stats.FrameCount), CkStyle::Accent());
+    DoAddSummaryTile(TEXT("Avg"), FString::Printf(TEXT("%.2fms"), Stats.AvgFrameMs), FrameBudgetColor(Stats.AvgFrameMs));
+    DoAddSummaryTile(TEXT("P95"), FString::Printf(TEXT("%.2fms"), Stats.P95FrameMs), FrameBudgetColor(Stats.P95FrameMs));
+    DoAddSummaryTile(TEXT("P99"), FString::Printf(TEXT("%.2fms"), Stats.P99FrameMs), FrameBudgetColor(Stats.P99FrameMs));
+    DoAddSummaryTile(TEXT("Max"), FString::Printf(TEXT("%.2fms"), Stats.MaxFrameMs), FrameBudgetColor(Stats.MaxFrameMs));
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -441,13 +1561,13 @@ auto
     _PendingTracePath = TracePath;
     _LoadingState = ELoadingState::Opening;
 
-    DoSetStatus(FString::Printf(TEXT("Opening: %s ..."), *FPaths::GetCleanFilename(TracePath)));
+    DoSetStatus(FString::Printf(TEXT("Opening: %s ..."), *FPaths::GetCleanFilename(TracePath)), ECk_Tone::Info);
 
     // Prepare analysis service on game thread (FModuleManager is not thread-safe)
     _PendingSession = MakeShared<FCk_TraceSession>();
     if (NOT _PendingSession->PrepareAnalysisService())
     {
-        DoSetStatus(TEXT("Failed to create analysis service."));
+        DoSetStatus(TEXT("Failed to create analysis service."), ECk_Tone::Err);
         _PendingSession.Reset();
         _LoadingState = ELoadingState::Idle;
         return;
@@ -487,7 +1607,7 @@ auto
         if (NOT Success)
         {
             DoSetStatus(FString::Printf(TEXT("Failed to open: %s"),
-                *FPaths::GetCleanFilename(_PendingTracePath)));
+                *FPaths::GetCleanFilename(_PendingTracePath)), ECk_Tone::Err);
             _PendingSession.Reset();
             _LoadingState = ELoadingState::Idle;
             return false; // stop ticking
@@ -512,7 +1632,7 @@ auto
         _LoadingState = ELoadingState::ReadingFrames;
 
         DoSetStatus(FString::Printf(
-            TEXT("Reading frames: 0 / %llu ..."), _TotalFrameCount));
+            TEXT("Reading frames: 0 / %llu ..."), _TotalFrameCount), ECk_Tone::Info);
 
         return true; // continue ticking for frame reading
     }
@@ -573,7 +1693,7 @@ auto
 
     DoSetStatus(FString::Printf(
         TEXT("Reading frames: %llu / %llu ..."),
-        _LoadedFrameCount, _TotalFrameCount));
+        _LoadedFrameCount, _TotalFrameCount), ECk_Tone::Info);
 
     return _LoadedFrameCount >= _TotalFrameCount;
 }
@@ -595,7 +1715,9 @@ auto
     const double DurationSec = _Session.GetDurationSeconds();
     DoSetStatus(FString::Printf(
         TEXT("Loaded: %s  |  %llu frames  |  %.1fs duration"),
-        *FPaths::GetCleanFilename(_PendingTracePath), _TotalFrameCount, DurationSec));
+        *FPaths::GetCleanFilename(_PendingTracePath), _TotalFrameCount, DurationSec), ECk_Tone::Ok);
+
+    DoRebuildSummaryStrip_TraceInfo();
 
     _LoadingState = ELoadingState::Idle;
     _LoadingTickerHandle.Reset();

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
@@ -2,6 +2,7 @@
 
 #include "CkInsightsAnalyzer/Core/CkFrameAnalyzer.h"
 #include "CkInsightsAnalyzer/Core/CkTimerCategorizer.h"
+#include "CkInsightsAnalyzer/Report/CkJsonReport.h"
 #include "CkInsightsAnalyzer_Log.h"
 
 #include "CkCore/Macros/CkMacros.h"
@@ -9,9 +10,9 @@
 
 #include "CkEditorTools/Style/CkStyle.h"
 
-#include <Async/Async.h>
 #include <DesktopPlatformModule.h>
 #include <HAL/PlatformApplicationMisc.h>
+#include <Misc/FileHelper.h>
 #include <Styling/AppStyle.h>
 #include <Styling/CoreStyle.h>
 #include <Widgets/Images/SImage.h>
@@ -527,6 +528,18 @@ auto
             .Text(FText::FromString(TEXT("Copy Report")))
             .ToolTipText(FText::FromString(TEXT("Copy the current markdown report to the system clipboard")))
             .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnCopyToClipboardClicked)
+            .HAlign(HAlign_Center)
+        ]
+
+        // Export JSON
+        + SHorizontalBox::Slot()
+        .AutoWidth()
+        .Padding(0.0f, 0.0f, SectionSpacing, 0.0f)
+        [
+            SNew(SButton)
+            .Text(FText::FromString(TEXT("Export JSON...")))
+            .ToolTipText(FText::FromString(TEXT("Save the current analysis as a machine-readable JSON report (same format as the commandlet's -json output)")))
+            .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnExportJsonClicked)
             .HAlign(HAlign_Center)
         ]
 
@@ -1236,6 +1249,79 @@ auto
 
 auto
     SCkInsightsAnalyzerTab::
+    DoOnExportJsonClicked()
+    -> FReply
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (NOT _Session.IsOpen() ||
+        (NOT _LastSingleResult.IsSet() && NOT _LastMultiStats.IsSet()))
+    {
+        DoSetStatus(TEXT("No analysis to export. Analyze a frame or range first."), ECk_Tone::Warn);
+        return FReply::Handled();
+    }
+
+    const auto DesktopPlatform = FDesktopPlatformModule::Get();
+    if (ck::Is_NOT_Valid(DesktopPlatform, ck::IsValid_Policy_NullptrOnly{}))
+    {
+        DoSetStatus(TEXT("Desktop platform not available."), ECk_Tone::Err);
+        return FReply::Handled();
+    }
+
+    const FString BaseName = FPaths::GetBaseFilename(_Session.GetFilePath());
+    const FString DefaultName = _LastSingleResult.IsSet()
+        ? FString::Printf(TEXT("%s_Frame%llu.json"), *BaseName, _LastSingleResult->FrameIndex)
+        : FString::Printf(TEXT("%s_Frames.json"), *BaseName);
+
+    TArray<FString> OutFiles;
+    const bool Saved = DesktopPlatform->SaveFileDialog(
+        FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+        TEXT("Export JSON Report"),
+        FPaths::ProjectSavedDir() / TEXT("TraceSessions"),
+        DefaultName,
+        TEXT("JSON files (*.json)|*.json"),
+        EFileDialogFlags::None,
+        OutFiles);
+
+    if (NOT Saved || OutFiles.Num() == 0)
+    {
+        return FReply::Handled();
+    }
+
+    FString Json;
+    if (_LastSingleResult.IsSet())
+    {
+        FCk_FrameReportConfig Config;
+        Config.TargetFrameMs = TargetFrameMs;
+        Config.Depth = _ReportDepth;
+        Config.ApplyDepth();
+
+        Json = FCk_JsonReport::GenerateSingleFrame(_Session, *_LastSingleResult, Config);
+    }
+    else
+    {
+        FCk_MultiFrameReportConfig Config;
+        Config.TargetFrameMs = TargetFrameMs;
+        Config.Depth = _ReportDepth;
+        Config.ApplyDepth();
+
+        Json = FCk_JsonReport::GenerateMultiFrame(_Session, *_LastMultiStats, Config);
+    }
+
+    if (FFileHelper::SaveStringToFile(Json, *OutFiles[0]))
+    {
+        DoSetStatus(FString::Printf(TEXT("Exported JSON: %s"), *FPaths::GetCleanFilename(OutFiles[0])), ECk_Tone::Ok);
+    }
+    else
+    {
+        DoSetStatus(FString::Printf(TEXT("Failed to write: %s"), *OutFiles[0]), ECk_Tone::Err);
+    }
+
+    return FReply::Handled();
+}
+
+auto
+    SCkInsightsAnalyzerTab::
     DoOnWorstFrameClicked(uint64 FrameIndex)
     -> FReply
 {
@@ -1339,6 +1425,8 @@ auto
     _TopTimers.Reset();
     _WorstFrames.Reset();
     _CategoryAverages.Reset();
+    _LastSingleResult.Reset();
+    _LastMultiStats.Reset();
 
     if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
     DoRebuildCategoryRows();
@@ -1368,6 +1456,7 @@ auto
         _HotPathRoots.Reset();
         _Categories.Reset();
         _TopTimers.Reset();
+        _LastSingleResult.Reset();
         if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
         DoRebuildCategoryRows();
         DoRebuildTopTimerRows();
@@ -1386,6 +1475,8 @@ auto
     // Structured views
     _ResultsMode = EResultsMode::SingleFrame;
     _AnalyzedFrameMs = Result.FrameDurationMs;
+    _LastSingleResult = Result;   // retained for Export JSON
+    _LastMultiStats.Reset();
     _HotPathRoots = FrameReport.BuildHotPathTree(_Session, Result);
 
     {
@@ -1456,6 +1547,8 @@ auto
     _HotPathRoots.Reset();
     _Categories.Reset();
     _TopTimers.Reset();
+    _LastSingleResult.Reset();
+    _LastMultiStats = Stats;      // retained for Export JSON
 
     _WorstFrames = Stats.WorstFrames;
     _CategoryAverages = Stats.CategoryAverages;
@@ -1573,15 +1666,18 @@ auto
         return;
     }
 
-    // Launch heavy Analyze() on background thread
-    TSharedPtr<FCk_TraceSession> SessionForAsync = _PendingSession;
-    FString PathCopy = TracePath;
-
-    _OpenFuture = Async(EAsyncExecution::ThreadPool,
-        [SessionForAsync, PathCopy]() -> bool
-        {
-            return SessionForAsync->AnalyzeFile(PathCopy);
-        });
+    // START analysis here on the game thread — registered trace modules (e.g.
+    // ChaosVD) ensure(IsInGameThread()) inside OnAnalysisBegin, which fires
+    // synchronously in StartAnalysis. The heavy processing runs on
+    // TraceServices' own analysis thread; the ticker below polls completion.
+    if (NOT _PendingSession->StartAnalysis(TracePath))
+    {
+        DoSetStatus(FString::Printf(TEXT("Failed to open: %s"),
+            *FPaths::GetCleanFilename(TracePath)), ECk_Tone::Err);
+        _PendingSession.Reset();
+        _LoadingState = ELoadingState::Idle;
+        return;
+    }
 
     // Start polling ticker
     _LoadingTickerHandle = FTSTicker::GetCoreTicker().AddTicker(
@@ -1598,22 +1694,18 @@ auto
     {
     case ELoadingState::Opening:
     {
-        if (NOT _OpenFuture.IsReady())
+        if (ck::Is_NOT_Valid(_PendingSession))
         {
-            return true; // keep ticking
-        }
-
-        const bool Success = _OpenFuture.Get();
-        if (NOT Success)
-        {
-            DoSetStatus(FString::Printf(TEXT("Failed to open: %s"),
-                *FPaths::GetCleanFilename(_PendingTracePath)), ECk_Tone::Err);
-            _PendingSession.Reset();
             _LoadingState = ELoadingState::Idle;
             return false; // stop ticking
         }
 
-        // Move session from background to member
+        if (NOT _PendingSession->IsAnalysisComplete())
+        {
+            return true; // keep ticking
+        }
+
+        // Take ownership of the analyzed session
         _Session = MoveTemp(*_PendingSession);
         _PendingSession.Reset();
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
@@ -9,7 +9,6 @@
 
 #include "CkEditorTools/Style/CkStyle.h"
 
-#include <Async/Future.h>
 #include <Containers/Ticker.h>
 #include <Widgets/SCompoundWidget.h>
 #include <Widgets/SBoxPanel.h>
@@ -83,6 +82,7 @@ private:
     auto DoOnOpenTraceClicked() -> FReply;
     auto DoOnAnalyzeWorstClicked() -> FReply;
     auto DoOnCopyToClipboardClicked() -> FReply;
+    auto DoOnExportJsonClicked() -> FReply;
     auto DoOnWorstFrameClicked(uint64 FrameIndex) -> FReply;
 
     // ---- Depth Selector ----
@@ -160,16 +160,21 @@ private:
     TArray<FCk_FrameSummary> _WorstFrames;          // persists across single-frame drills
     TArray<FCk_MultiFrameStats::FCategoryStats> _CategoryAverages;
 
+    // Last analysis, retained so Export JSON can regenerate without re-analyzing
+    TOptional<FCk_FrameAnalysisResult> _LastSingleResult;
+    TOptional<FCk_MultiFrameStats> _LastMultiStats;
+
     // Side panel row containers
     TSharedPtr<SVerticalBox> _CategoryRowsBox;
     TSharedPtr<SVerticalBox> _TopTimerRowsBox;
     TSharedPtr<SVerticalBox> _WorstFrameRowsBox;
     TSharedPtr<SVerticalBox> _CategoryAvgRowsBox;
 
-    // Async loading state
+    // Async loading state. Analysis is STARTED on the game thread (trace modules
+    // like ChaosVD ensure(IsInGameThread()) in OnAnalysisBegin) and processed on
+    // TraceServices' own analysis thread; the ticker polls for completion.
     ELoadingState _LoadingState = ELoadingState::Idle;
     FTSTicker::FDelegateHandle _LoadingTickerHandle;
-    TFuture<bool> _OpenFuture;
     FString _PendingTracePath;
     TSharedPtr<FCk_TraceSession> _PendingSession;
     uint64 _TotalFrameCount = 0;

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
@@ -4,15 +4,20 @@
 
 #include "CkInsightsAnalyzer/Core/CkTraceSession.h"
 #include "CkInsightsAnalyzer/Report/CkFrameReport.h"
+#include "CkInsightsAnalyzer/Report/CkMultiFrameReport.h"
 #include "CkInsightsAnalyzer/Tab/SCkFrameBarChart.h"
+
+#include "CkEditorTools/Style/CkStyle.h"
 
 #include <Async/Future.h>
 #include <Containers/Ticker.h>
 #include <Widgets/SCompoundWidget.h>
+#include <Widgets/SBoxPanel.h>
 #include <Widgets/Text/STextBlock.h>
 #include <Widgets/Text/SMultiLineEditableText.h>
 #include <Widgets/Input/SButton.h>
 #include <Widgets/Input/STextComboBox.h>
+#include <Widgets/Views/STreeView.h>
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -20,10 +25,17 @@
  * Main editor tab for the Insights Analyzer.
  *
  * Layout (top to bottom):
- *   1. Toolbar  — [Open .utrace...] [Depth ▾] [Analyze Worst 10] [Copy to Clipboard]  Status text
- *   2. Frame bar chart (SCkFrameBarChart, ~200px)
- *   3. Separator
- *   4. Results panel (SScrollBox with read-only multi-line text, fills remaining space)
+ *   1. Toolbar       — [Open .utrace...] [Depth ▾] [Analyze Worst 10] [Copy Report]  Status pill
+ *   2. Summary strip — stat tiles (trace info; frame/aggregate numbers after analysis)
+ *   3. Frame bar chart (SCkFrameBarChart, ~200px)
+ *   4. Results       — splitter: hot-path tree (left) | categories / top timers /
+ *                      worst frames / category averages (right)
+ *   5. Raw report    — collapsed expandable area with the markdown text (also what
+ *                      "Copy Report" puts on the clipboard)
+ *
+ * All colors/fonts route through CkStyle:: (CkEditorTools). Side panels are
+ * rebuild-on-analysis (not SListView) — they are small, and rebuilding avoids
+ * the listview-inside-scrollbox desired-size pitfalls.
  */
 class CKINSIGHTSANALYZER_API SCkInsightsAnalyzerTab : public SCompoundWidget
 {
@@ -35,21 +47,47 @@ public:
 
 private:
 
+    // ---- Results mode ----
+
+    enum class EResultsMode : uint8
+    {
+        None,
+        SingleFrame,
+        MultiFrame,
+    };
+
     // ---- UI Construction ----
 
     auto DoCreateToolbar() -> TSharedRef<SWidget>;
-    auto DoCreateResultsPanel() -> TSharedRef<SWidget>;
+    auto DoCreateSummaryStrip() -> TSharedRef<SWidget>;
+    auto DoCreateResultsArea() -> TSharedRef<SWidget>;
+    auto DoCreateHotPathPanel() -> TSharedRef<SWidget>;
+    auto DoCreateSidePanels() -> TSharedRef<SWidget>;
+    auto DoCreateRawReportArea() -> TSharedRef<SWidget>;
+
+    // ---- Hot-path tree ----
+
+    auto DoGenerateHotPathRow(TSharedPtr<FCk_HotPathNode> InNode,
+                              const TSharedRef<STableViewBase>& InOwnerTable) -> TSharedRef<ITableRow>;
+    auto DoExpandHotPathDefaults() -> void;
+
+    // ---- Side panel row rebuilds ----
+
+    auto DoRebuildCategoryRows() -> void;
+    auto DoRebuildTopTimerRows() -> void;
+    auto DoRebuildWorstFrameRows() -> void;
+    auto DoRebuildCategoryAvgRows() -> void;
 
     // ---- Button Handlers ----
 
     auto DoOnOpenTraceClicked() -> FReply;
     auto DoOnAnalyzeWorstClicked() -> FReply;
     auto DoOnCopyToClipboardClicked() -> FReply;
+    auto DoOnWorstFrameClicked(uint64 FrameIndex) -> FReply;
 
     // ---- Depth Selector ----
 
     auto DoOnDepthSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type SelectInfo) -> void;
-    auto DoGetReportDepth() const -> ECkReportDepth;
 
     // ---- Chart Delegate ----
 
@@ -57,10 +95,20 @@ private:
 
     // ---- Helpers ----
 
-    auto DoSetStatus(const FString& Text) -> void;
+    auto DoSetStatus(const FString& Text, ECk_Tone InTone = ECk_Tone::Neutral) -> void;
     auto DoSetReport(const FString& ReportText) -> void;
+    auto DoClearResults() -> void;
     auto DoAnalyzeSingleFrame(uint64 FrameIndex) -> void;
     auto DoAnalyzeFrameRange(uint64 StartFrame, uint64 EndFrame) -> void;
+    auto DoRerunCurrentSelection() -> void;
+    auto DoPopulateMultiFrame(const FCk_MultiFrameStats& Stats) -> void;
+
+    // ---- Summary strip ----
+
+    auto DoAddSummaryTile(const FString& InLabel, const FString& InValue, const FLinearColor& InValueColor) -> void;
+    auto DoRebuildSummaryStrip_TraceInfo() -> void;
+    auto DoRebuildSummaryStrip_SingleFrame(const FCk_FrameAnalysisResult& Result) -> void;
+    auto DoRebuildSummaryStrip_MultiFrame(const FCk_MultiFrameStats& Stats) -> void;
 
     // ---- Async Loading ----
 
@@ -85,12 +133,38 @@ private:
     TSharedPtr<STextBlock> _StatusText;
     TSharedPtr<SMultiLineEditableText> _ReportText;
 
+    // Status pill tone (drives the dot color next to the status text)
+    ECk_Tone _StatusTone = ECk_Tone::Neutral;
+
     // Depth dropdown
     TArray<TSharedPtr<FString>> _DepthOptions;
     TSharedPtr<STextComboBox> _DepthCombo;
     ECkReportDepth _ReportDepth = ECkReportDepth::Standard;
 
     FString _CurrentReport;
+
+    // Summary strip (rebuilt per analysis)
+    TSharedPtr<SHorizontalBox> _SummaryBox;
+
+    // Results state
+    EResultsMode _ResultsMode = EResultsMode::None;
+    double _AnalyzedFrameMs = 0.0; // frame duration backing the hot-path %-of-frame column
+
+    // Hot-path tree
+    TArray<TSharedPtr<FCk_HotPathNode>> _HotPathRoots;
+    TSharedPtr<STreeView<TSharedPtr<FCk_HotPathNode>>> _HotPathTree;
+
+    // Side panel data (rebuild-on-analysis)
+    TArray<FCk_CategorySummaryEntry> _Categories;
+    TArray<FCk_TopTimerEntry> _TopTimers;
+    TArray<FCk_FrameSummary> _WorstFrames;          // persists across single-frame drills
+    TArray<FCk_MultiFrameStats::FCategoryStats> _CategoryAverages;
+
+    // Side panel row containers
+    TSharedPtr<SVerticalBox> _CategoryRowsBox;
+    TSharedPtr<SVerticalBox> _TopTimerRowsBox;
+    TSharedPtr<SVerticalBox> _WorstFrameRowsBox;
+    TSharedPtr<SVerticalBox> _CategoryAvgRowsBox;
 
     // Async loading state
     ELoadingState _LoadingState = ELoadingState::Idle;


### PR DESCRIPTION
## Summary

Two related pieces:

**1. New `CkEditorTools` module — shared style tokens for Ck editor tooling**

Migrates the style system from CkGameplayDebugger's `CkDebuggerCommon` into CkFoundation so debugger UIs and CkFoundation editor tools share one look, with generic names:

- `CkDebugStyle::` → `CkStyle::` (`CkEditorTools/Style/CkStyle.h`)
- `ECkDebug_Tone` → `ECk_Tone` (moved next to the style tokens)
- `UCkDebuggerStyleSettings` → `UCk_Style_UserSettings_UE` (Editor Preferences → Ck → Style; identical tunables/defaults)

Module type is **Runtime** on purpose: the debugger plugin's Runtime modules (`CkDebuggerCommon`, `CkEntityDebugOverlay`) must be able to link it.

**2. Structured Slate GUI for the Insights Analyzer tab**

Replaces the markdown text dump with real views, styled entirely via `CkStyle::`:

- Summary strip of stat tiles (trace info + per-frame or aggregate avg/p95/p99/max)
- Hot-path `STreeView` (Incl / Self / Count / %-of-frame with severity coloring, breadcrumbs, raw-name tooltips)
- Categories + Top Timers side panels with proportion bars
- Worst Frames panel with click-to-drill (selects the frame in the chart and analyzes it)
- Frame bar chart colors now come from the shared style tokens
- Markdown retained for Copy Report + a collapsed raw view
- `FCk_FrameReport` gains structured APIs (`BuildHotPathTree`, `ComputeCategorySummary`, `ComputeTopTimers`) sharing the exact collapse/dedup rules with the markdown renderer
- Unnamed frame-root timers (`UNKNOWN_<id>`) are now unwrapped like frame wrappers so real roots (`UWorld_Tick`, `Slate::DrawWindows`) surface directly

## Companion PR

chainkemists/CkGameplayDebugger `feature/shared-editor-style` migrates the debugger plugin to consume this module — **merge this PR first**.

## Verification

- Development Editor build green (BusterBlock superproject)
- `Ck.DebugOverlay` automation specs 7/7 pass (exercise the shared style at editor boot)
- Tab manually verified against a real 8k-frame `.utrace` capture: load, single-frame drill, range analysis, Worst 10 + click-through, depth switching, copy report

🤖 Generated with [Claude Code](https://claude.com/claude-code)
