### PR TITLE
feat(CkEcs+CkInsightsAnalyzer): per-processor/per-batch trace breakdown under the ECS world actor

### DIFF
--- a/Source/CkDynamic/Public/CkDynamic/CkDynamic_ScriptProcessor_Host.cpp
+++ b/Source/CkDynamic/Public/CkDynamic/CkDynamic_ScriptProcessor_Host.cpp
@@ -3,6 +3,7 @@
 #include "CkDynamic_Utils.h"
 #include "CkDynamic_ScriptQueryProcessor.h"
 
+#include "CkCore/Format/CkFormat.h"
 #include "CkCore/Validation/CkIsValid.h"
 
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
@@ -104,6 +105,11 @@ namespace ck
             -> void
         {
             OutDescriptor._Name = FName{*InDevClass->GetPathName()};
+
+            // Short identity for the per-processor trace scope — mirrors the `script::<DevClass>` stat
+            // row the hosted wrapper registers. _Name stays the full path so RunAfter references resolve.
+            OutDescriptor._DisplayName = FName{*ck::Format_UE(TEXT("script::{}"), InDevClass->GetName())};
+
             OutDescriptor._GroupName = DoResolveGroupName(InCDO->Get_Group());
 
             for (const auto& RunAfterName : InCDO->Get_RunAfter())

--- a/Source/CkEcs/Public/CkEcs/Processor/CkParallelProcessor.h
+++ b/Source/CkEcs/Public/CkEcs/Processor/CkParallelProcessor.h
@@ -151,10 +151,15 @@ namespace ck
                         Registry.template Get<T_ComponentsOnly>(Entity))...);
             };
 
+            // Named per processor so the worker-thread task scopes in Unreal Insights are attributable
+            // (the unnamed overload labels every task "ParallelFor Task"). Reuses the ` [ForEachEntity]`
+            // phase stat identity; one FString conversion per template instantiation.
+            static const auto TaskDebugName = FString{FStat_STAT_ForEachEntity::GetStatName()};
+
             if constexpr (detail::THasMinBatchSize<DerivedType>::value)
             {
                 ParallelForWithTaskContext(
-                    TEXT("TParallelProcessor"),
+                    *TaskDebugName,
                     TaskCommandBuffers,
                     _CachedEntities.Num(),
                     DerivedType::MinBatchSize,
@@ -163,10 +168,15 @@ namespace ck
             }
             else
             {
+                // Matches the unnamed overload's implicit minimum batch size.
+                constexpr auto MinBatchSize = 1;
                 ParallelForWithTaskContext(
+                    *TaskDebugName,
                     TaskCommandBuffers,
                     _CachedEntities.Num(),
-                    ParallelBody);
+                    MinBatchSize,
+                    ParallelBody,
+                    EParallelForFlags::None);
             }
 
 #if !UE_BUILD_SHIPPING

--- a/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorDescriptor.h
+++ b/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorDescriptor.h
@@ -98,6 +98,11 @@ namespace ck
 
         FName _Name;
 
+        // Optional short identity for human-facing surfaces (per-processor Insights trace scopes).
+        // _Name stays the canonical registry key (C++ type name / script class path name) that
+        // RunAfter/RunBefore references resolve against; surfaces fall back to _Name when this is unset.
+        FName _DisplayName;
+
         FProcessorFactory _Factory;
 
         FName _GroupName;

--- a/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorGraph.cpp
+++ b/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorGraph.cpp
@@ -68,6 +68,23 @@ namespace ck::detail
         }
     }
 
+    // Trace-scope display name for a node: descriptor _DisplayName when set, else the canonical
+    // _Name with entt::type_name's "struct "/"class " prefix stripped — so per-processor trace rows
+    // read the same as the cleantype-derived `stat CkProcessors` rows.
+    static auto
+    Get_NodeTraceName(
+        const FProcessorDescriptor& InDescriptor) -> FName
+    {
+        if (NOT InDescriptor._DisplayName.IsNone())
+        { return InDescriptor._DisplayName; }
+
+        auto NameStr = InDescriptor._Name.ToString();
+        if (NameStr.RemoveFromStart(TEXT("struct ")) || NameStr.RemoveFromStart(TEXT("class ")))
+        { return FName{*NameStr}; }
+
+        return InDescriptor._Name;
+    }
+
     static auto
     ShouldCreateProcessorForWorldType(
         ECk_ProcessorWorldTypeRequirement InRequirement,
@@ -198,6 +215,7 @@ auto
             auto StartNode = FProcessorGraphNode{};
             StartNode._Index = _Nodes.Num();
             StartNode._ProcessorName = Descriptor._Name;
+            StartNode._TraceName = detail::Get_NodeTraceName(Descriptor);
             StartNode._HasDirtyMarker = Descriptor._HasDirtyMarker;
             StartNode._IsDirtyChecker = Descriptor._IsDirtyChecker;
             StartNode._DirtyMarkerHashes = Descriptor._DirtyMarkerHashes;
@@ -235,6 +253,7 @@ auto
             auto Node = FProcessorGraphNode{};
             Node._Index = _Nodes.Num();
             Node._ProcessorName = Descriptor._Name;
+            Node._TraceName = detail::Get_NodeTraceName(Descriptor);
             Node._HasDirtyMarker = Descriptor._HasDirtyMarker;
             Node._IsDirtyChecker = Descriptor._IsDirtyChecker;
             Node._DirtyMarkerHashes = Descriptor._DirtyMarkerHashes;

--- a/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorGraph.h
+++ b/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorGraph.h
@@ -30,6 +30,13 @@ namespace ck
         int32 _Index = INDEX_NONE;
         FName _ProcessorName;
 
+        // Name emitted as the per-processor Insights CPU scope by the scheduler's dispatch loop
+        // (descriptor _DisplayName when set, else _ProcessorName), plus the lazily-created trace
+        // event spec id it caches (0 = not traced yet; created on first dispatch with the `cpu`
+        // trace channel enabled).
+        FName _TraceName;
+        uint32 _TraceSpecId = 0;
+
         bool _HasDirtyMarker = false;
         FDirtyChecker _IsDirtyChecker;
         FProcessorFactory _Factory;

--- a/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorScheduler.cpp
+++ b/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorScheduler.cpp
@@ -6,6 +6,7 @@
 #include "CkProfile/Stats/CkStats.h"
 
 #include "HAL/PlatformTime.h"
+#include "ProfilingDebugging/CpuProfilerTrace.h"
 
 #if !UE_BUILD_SHIPPING
 #include "HAL/IConsoleManager.h"
@@ -122,7 +123,20 @@ auto
             }
 #endif
 
-            (*Node._Instance)->Tick(InDeltaTime);
+            {
+#if CPUPROFILERTRACE_ENABLED
+                // Per-processor Insights scope, named by the node (C++ canonical type name, or the
+                // script host's `script::<DevClass>` display name). This is what decomposes the ECS
+                // world actor's tick on the trace timeline — the stat system's per-processor cycle
+                // counters emit no trace events unless -statnamedevents is on. Near-free when the
+                // `cpu` trace channel is off (one branch); the event spec is created lazily on first
+                // traced dispatch and cached on the node.
+                constexpr auto TraceUnconditionally = true;
+                FCpuProfilerTrace::FEventScope ProcessorTraceScope{
+                    Node._TraceSpecId, Node._TraceName, TraceUnconditionally, __FILE__, __LINE__};
+#endif
+                (*Node._Instance)->Tick(InDeltaTime);
+            }
 
 #if !UE_BUILD_SHIPPING
             if (DebugTimingEnabled)
@@ -264,7 +278,17 @@ auto
             }
 #endif
 
-            const auto VisitedCount = (*Node._Instance)->Pump();
+            auto VisitedCount = int32{};
+            {
+#if CPUPROFILERTRACE_ENABLED
+                // Same per-processor scope as the main pass (shared spec id) — pump invocations show
+                // as additional instances of the processor's timer rather than a separate row.
+                constexpr auto TraceUnconditionally = true;
+                FCpuProfilerTrace::FEventScope ProcessorTraceScope{
+                    Node._TraceSpecId, Node._TraceName, TraceUnconditionally, __FILE__, __LINE__};
+#endif
+                VisitedCount = (*Node._Instance)->Pump();
+            }
 
             // A pump that provably visited zero entities cannot have produced new work — letting it
             // count as "ticked" would schedule a full extra pump pass for nothing (this is what a

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Commandlet/CkInsightsAnalyzerCommandlet.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Commandlet/CkInsightsAnalyzerCommandlet.cpp
@@ -75,6 +75,7 @@ int32
     const bool AllFrames = Switches.Contains(TEXT("all"));
     const bool Raw = Switches.Contains(TEXT("raw"));
     const bool Json = Switches.Contains(TEXT("json"));
+    const bool ShowAll = Switches.Contains(TEXT("showall"));
 
     const auto OutputPath = ParsedParams.Find(TEXT("output"));
 
@@ -143,6 +144,7 @@ int32
         ReportConfig.TargetFrameMs = Budget;
         ReportConfig.ShowRawTimerList = Raw;
         ReportConfig.RawTimerCount = RawTop;
+        ReportConfig.ShowAllChildren = ShowAll;
 
         if (Json)
         {

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Commandlet/CkInsightsAnalyzerCommandlet.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Commandlet/CkInsightsAnalyzerCommandlet.cpp
@@ -11,6 +11,7 @@
 
 #include "HAL/PlatformApplicationMisc.h"
 #include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -275,16 +276,22 @@ int32
         ck::insights_analyzer::Display(TEXT("{}"), Line);
     }
 
-    // Write to file if requested
+    // Write to file if requested. Relative paths resolve against the project dir — the process
+    // CWD is Binaries/Win64 by the time a commandlet runs, which is where a raw relative path
+    // would otherwise silently land.
     if (OutputPath && NOT OutputPath->IsEmpty())
     {
-        if (FFileHelper::SaveStringToFile(Report, **OutputPath, FFileHelper::EEncodingOptions::ForceUTF8))
+        const auto ResolvedOutputPath = FPaths::IsRelative(**OutputPath)
+            ? FPaths::Combine(FPaths::ProjectDir(), **OutputPath)
+            : *OutputPath;
+
+        if (FFileHelper::SaveStringToFile(Report, *ResolvedOutputPath, FFileHelper::EEncodingOptions::ForceUTF8))
         {
-            ck::insights_analyzer::Display(TEXT("Report written to: {}"), *OutputPath);
+            ck::insights_analyzer::Display(TEXT("Report written to: {}"), ResolvedOutputPath);
         }
         else
         {
-            ck::insights_analyzer::Error(TEXT("Failed to write report to: {}"), *OutputPath);
+            ck::insights_analyzer::Error(TEXT("Failed to write report to: {}"), ResolvedOutputPath);
         }
     }
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTimerCategorizer.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTimerCategorizer.cpp
@@ -274,6 +274,7 @@ auto
     AddCategory(TEXT("ECS (CK)"), {
         TEXT("ck::"), TEXT("Ck_"), TEXT("CkFoundation"),
         TEXT("AC_Fragment"), TEXT("ObjectReplicator"), TEXT("EcsWorld"),
+        TEXT("script::"),   // scheduler-emitted script-processor scopes (see CkProcessorScheduler.cpp)
     });
 
     AddCategory(TEXT("Networking"), {

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
@@ -266,6 +266,15 @@ auto
 
     for (int32 Iter = 0; Iter < 10; ++Iter) // max collapse depth
     {
+        // Never collapse a script-processor scope into its dispatch child: `script::<Class>` IS
+        // the attribution the tree exists to show. Without this guard, every script processor
+        // (near-zero self-time, one dominant VM child) collapses into the same anonymous
+        // "ForEachBatch" timer and dedup merges them all into one unattributable row.
+        if (GetTimerName(TimerNames, CurrentIndex).StartsWith(TEXT("script::")))
+        {
+            break;
+        }
+
         // If this timer does significant self-work, stop collapsing
         if (CurrentExcl > CurrentIncl * 0.05 && CurrentExcl > 0.3)
         {
@@ -465,7 +474,10 @@ auto
         // Use global stats for display consistency
         const double GlobalIncl = FMath::Min(
             Result.GetInclusiveMs(CC.TimerIndex), Collapsed.InclusiveMs);
-        const double GlobalExcl = Result.GetExclusiveMs(CC.TimerIndex);
+        // Clamped to the (already parent-clamped) inclusive — global exclusive can exceed this
+        // parent's slice when the timer also runs under other parents, and "6.8ms self" inside a
+        // "5.4ms incl" row reads as nonsense.
+        const double GlobalExcl = FMath::Min(Result.GetExclusiveMs(CC.TimerIndex), GlobalIncl);
         const uint32 GlobalCount = Result.GetCount(CC.TimerIndex);
 
         const auto Existing = Seen.Find(CC.TimerIndex);
@@ -499,10 +511,25 @@ auto
         Visible.Add(MoveTemp(Deduped[i]));
     }
 
+    // Reconciliation row (mirrors DoBuildTreeNode): children dropped by the threshold, the 8-child
+    // cap, or dedup otherwise read as a silent gap under the parent. Computed before the recursion
+    // so the last real child keeps a "├" glyph when the synthetic row takes the "└".
+    double ShownChildrenMs = 0.0;
+    for (const FDedupedChild& Child : Visible)
+    {
+        ShownChildrenMs += Child.InclusiveMs;
+    }
+
+    const auto ChildMap = Result.ChildrenOf.Find(Collapsed.TimerIndex);
+    const double HiddenMs = Collapsed.InclusiveMs - Collapsed.ExclusiveMs - ShownChildrenMs;
+    const int32 HiddenChildCount = ChildMap ? ChildMap->Num() - Visible.Num() : 0;
+    const bool EmitHiddenRow = HiddenChildCount > 0
+                            && HiddenMs >= FMath::Max(0.1, Collapsed.InclusiveMs * 0.02);
+
     for (int32 i = 0; i < Visible.Num(); ++i)
     {
         TMap<int32, bool> ChildIsLast = IsLastAtDepth;
-        ChildIsLast.Add(Depth + 1, i == Visible.Num() - 1);
+        ChildIsLast.Add(Depth + 1, i == Visible.Num() - 1 && NOT EmitHiddenRow);
 
         TArray<FString> ChildLines = BuildTreeLines(
             Visible[i].TimerIndex, Depth + 1,
@@ -511,6 +538,16 @@ auto
             &Visible[i].Breadcrumbs);
 
         Lines.Append(MoveTemp(ChildLines));
+    }
+
+    if (EmitHiddenRow)
+    {
+        TMap<int32, bool> RowIsLast = IsLastAtDepth;
+        RowIsLast.Add(Depth + 1, true);
+
+        Lines.Add(FString::Printf(TEXT("%s(+%d below threshold)  *%s*"),
+            *MakeTreePrefix(Depth + 1, RowIsLast), HiddenChildCount,
+            *FCk_TimerCategorizer::FormatMs(HiddenMs)));
     }
 
     return Lines;
@@ -656,7 +693,10 @@ auto
         // Use global stats for display consistency
         const double GlobalIncl = FMath::Min(
             Result.GetInclusiveMs(CC.TimerIndex), Collapsed.InclusiveMs);
-        const double GlobalExcl = Result.GetExclusiveMs(CC.TimerIndex);
+        // Clamped to the (already parent-clamped) inclusive — global exclusive can exceed this
+        // parent's slice when the timer also runs under other parents, and "6.8ms self" inside a
+        // "5.4ms incl" row reads as nonsense.
+        const double GlobalExcl = FMath::Min(Result.GetExclusiveMs(CC.TimerIndex), GlobalIncl);
         const uint32 GlobalCount = Result.GetCount(CC.TimerIndex);
 
         const auto Existing = Seen.Find(CC.TimerIndex);
@@ -697,6 +737,37 @@ auto
         if (ChildNode.IsValid())
         {
             Node->Children.Add(MoveTemp(ChildNode));
+        }
+    }
+
+    // Reconciliation row — makes the sums visibly add up (self + shown children + this row ≈
+    // inclusive). Children are dropped by the 3%/0.3ms threshold, the 8-child cap, and the
+    // sibling-subtree dedup above; without this row the dropped mass reads as a mysterious gap
+    // under the parent. Deliberately also emitted when EVERY child was pruned (the node would
+    // otherwise render as a leaf whose self-time doesn't explain its inclusive time).
+    if (const auto ChildMap = Result.ChildrenOf.Find(Collapsed.TimerIndex))
+    {
+        double ShownChildrenMs = 0.0;
+        for (const TSharedPtr<FCk_HotPathNode>& Child : Node->Children)
+        {
+            ShownChildrenMs += Child->InclusiveMs;
+        }
+
+        // Displayed child values use global (frame-wide) stats, so this remainder can go slightly
+        // negative when a child also appears under another parent — clamp via the threshold below.
+        const double HiddenMs = Node->InclusiveMs - Node->ExclusiveMs - ShownChildrenMs;
+        const int32 HiddenChildCount = ChildMap->Num() - Node->Children.Num();
+
+        if (HiddenChildCount > 0 && HiddenMs >= FMath::Max(0.1, Node->InclusiveMs * 0.02))
+        {
+            auto HiddenNode = MakeShared<FCk_HotPathNode>();
+            HiddenNode->RawName = FString::Printf(TEXT("(+%d below threshold)"), HiddenChildCount);
+            HiddenNode->DisplayName = HiddenNode->RawName;
+            HiddenNode->InclusiveMs = HiddenMs;
+            HiddenNode->ExclusiveMs = 0.0;
+            HiddenNode->Count = static_cast<uint32>(HiddenChildCount);
+            HiddenNode->bIsAggregate = true;
+            Node->Children.Add(MoveTemp(HiddenNode));
         }
     }
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
@@ -449,8 +449,11 @@ auto
         return Lines;
     }
 
-    // Get children with adaptive threshold (3% of parent, min 0.3ms)
-    const double MinChildMs = FMath::Max(0.3, Collapsed.InclusiveMs * 0.03);
+    // Get children with adaptive threshold (config: pct of parent with an absolute floor);
+    // ShowAllChildren bypasses it entirely.
+    const double MinChildMs = _Config.ShowAllChildren
+        ? 0.0
+        : FMath::Max(_Config.MinChildMs, Collapsed.InclusiveMs * _Config.MinChildPctOfParent);
     TArray<FChildInfo> Children = GetSignificantChildren(
         Collapsed.TimerIndex, Result, MinChildMs);
 
@@ -500,12 +503,13 @@ auto
         return A.InclusiveMs > B.InclusiveMs;
     });
 
-    // Limit to 8 children, filter out self-references.
+    // Limit to the configured child cap, filter out self-references.
     // Don't filter by ShownTimers here — let each branch show its full subtree
     // even if the timer appeared in a sibling's subtree. The ShownTimers check
     // at the top of BuildTreeLines prevents infinite recursion.
+    const int32 MaxVisible = _Config.ShowAllChildren ? MAX_int32 : _Config.MaxVisibleChildren;
     TArray<FDedupedChild> Visible;
-    for (int32 i = 0; i < Deduped.Num() && Visible.Num() < 8; ++i)
+    for (int32 i = 0; i < Deduped.Num() && Visible.Num() < MaxVisible; ++i)
     {
         if (Deduped[i].TimerIndex == Collapsed.TimerIndex) continue;
         Visible.Add(MoveTemp(Deduped[i]));
@@ -668,8 +672,11 @@ auto
         return Node;
     }
 
-    // Get children with adaptive threshold (3% of parent, min 0.3ms)
-    const double MinChildMs = FMath::Max(0.3, Collapsed.InclusiveMs * 0.03);
+    // Get children with adaptive threshold (config: pct of parent with an absolute floor);
+    // ShowAllChildren bypasses it entirely.
+    const double MinChildMs = _Config.ShowAllChildren
+        ? 0.0
+        : FMath::Max(_Config.MinChildMs, Collapsed.InclusiveMs * _Config.MinChildPctOfParent);
     TArray<FChildInfo> Children = GetSignificantChildren(
         Collapsed.TimerIndex, Result, MinChildMs);
 
@@ -708,7 +715,7 @@ auto
         }
     }
 
-    // Sort deduped children by inclusive time, filter self-references, cap at 8
+    // Sort deduped children by inclusive time, filter self-references, cap at the configured limit
     TArray<FDedupedChild> Deduped;
     for (auto& [Key, Val] : Seen)
     {
@@ -719,8 +726,9 @@ auto
         return A.InclusiveMs > B.InclusiveMs;
     });
 
+    const int32 MaxVisible = _Config.ShowAllChildren ? MAX_int32 : _Config.MaxVisibleChildren;
     TArray<FDedupedChild> Visible;
-    for (int32 i = 0; i < Deduped.Num() && Visible.Num() < 8; ++i)
+    for (int32 i = 0; i < Deduped.Num() && Visible.Num() < MaxVisible; ++i)
     {
         if (Deduped[i].TimerIndex == Collapsed.TimerIndex) continue;
         Visible.Add(MoveTemp(Deduped[i]));

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
@@ -165,6 +165,13 @@ struct CKINSIGHTSANALYZER_API FCk_HotPathNode
     double ExclusiveMs = 0.0;
     uint32 Count = 0;
 
+    /**
+     * True for the synthetic "(+N below threshold)" reconciliation row appended after the visible
+     * children — it carries the inclusive mass of children dropped by the 3%/0.3ms threshold, the
+     * child cap, or sibling-subtree dedup, so self + children + this row ≈ the parent's inclusive.
+     */
+    bool bIsAggregate = false;
+
     TArray<TSharedPtr<FCk_HotPathNode>> Children;
 };
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
@@ -50,6 +50,22 @@ struct CKINSIGHTSANALYZER_API FCk_FrameReportConfig
     /** Minimum inclusive time (ms) for a timer to appear in the tree. */
     double MinInclusiveMs = 1.0;
 
+    /** Floor (ms) below which a child folds into the "(+N below threshold)" aggregate row. */
+    double MinChildMs = 0.3;
+
+    /** Fraction of the parent's inclusive time below which a child folds into the aggregate row. */
+    double MinChildPctOfParent = 0.03;
+
+    /** Maximum visible children per node; the remainder folds into the aggregate row. */
+    int32 MaxVisibleChildren = 8;
+
+    /**
+     * Bypass the child threshold and cap entirely — every child renders and no aggregate rows are
+     * emitted for threshold-folding (dedup-dropped mass can still produce one). Orthogonal to
+     * Depth (ApplyDepth never touches it); MaxTreeDepth still bounds recursion.
+     */
+    bool ShowAllChildren = false;
+
     /** Minimum exclusive time (ms) for a timer to appear in the category summary. */
     double MinCategoryMs = 0.3;
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
@@ -16,6 +16,7 @@
 #include <Styling/AppStyle.h>
 #include <Styling/CoreStyle.h>
 #include <Widgets/Images/SImage.h>
+#include <Widgets/Input/SCheckBox.h>
 #include <Widgets/Layout/SBorder.h>
 #include <Widgets/Layout/SBox.h>
 #include <Widgets/Layout/SExpandableArea.h>
@@ -507,6 +508,26 @@ auto
                     .InitiallySelectedItem(_DepthOptions[1]) // Standard
                     .OnSelectionChanged(this, &SCkInsightsAnalyzerTab::DoOnDepthSelectionChanged)
                 ]
+            ]
+        ]
+
+        // Show-all toggle — bypasses the hot-path tree's child threshold + cap
+        + SHorizontalBox::Slot()
+        .AutoWidth()
+        .VAlign(VAlign_Center)
+        .Padding(0.0f, 0.0f, SectionSpacing, 0.0f)
+        [
+            SNew(SCheckBox)
+            .IsChecked(this, &SCkInsightsAnalyzerTab::DoGet_ShowAllChildrenState)
+            .OnCheckStateChanged(this, &SCkInsightsAnalyzerTab::DoOnShowAllChildrenChanged)
+            .ToolTipText(FText::FromString(TEXT(
+                "Show every child in the hot-path tree instead of folding small ones into "
+                "'(+N below threshold)' rows. Tree depth still follows the Depth preset.")))
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(TEXT("Show all")))
+                .Font(BodyFont())
+                .ColorAndOpacity(CkStyle::TextDim())
             ]
         ]
 
@@ -1298,6 +1319,7 @@ auto
         Config.TargetFrameMs = TargetFrameMs;
         Config.Depth = _ReportDepth;
         Config.ApplyDepth();
+        Config.ShowAllChildren = _ShowAllChildren;
 
         Json = FCk_JsonReport::GenerateSingleFrame(_Session, *_LastSingleResult, Config);
     }
@@ -1359,6 +1381,25 @@ auto
     else                                    _ReportDepth = ECkReportDepth::HotPathsOnly;
 
     // Re-run the current selection so the depth change is immediately visible
+    DoRerunCurrentSelection();
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoGet_ShowAllChildrenState() const
+    -> ECheckBoxState
+{
+    return _ShowAllChildren ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoOnShowAllChildrenChanged(ECheckBoxState NewState)
+    -> void
+{
+    _ShowAllChildren = NewState == ECheckBoxState::Checked;
+
+    // Re-run the current selection so the toggle is immediately visible
     DoRerunCurrentSelection();
 }
 
@@ -1471,6 +1512,7 @@ auto
     Config.TargetFrameMs = TargetFrameMs;
     Config.Depth = _ReportDepth;
     Config.ApplyDepth();
+    Config.ShowAllChildren = _ShowAllChildren;
 
     FCk_FrameReport FrameReport(Config);
     DoSetReport(FrameReport.Generate(_Session, Result));

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
@@ -252,12 +252,14 @@ public:
                    .IndentAmount(12.0f)
                ];
 
+            // The synthetic "(+N below threshold)" reconciliation row renders muted — it is an
+            // aggregate of pruned children, not a timer of its own.
             Row->AddSlot()
                .AutoWidth()
                .VAlign(VAlign_Center)
                .Padding(0.0f, 0.0f, CkStyle::SpaceS, 0.0f)
                [
-                   MakeDot(SeverityColor(_Node->InclusiveMs))
+                   MakeDot(_Node->bIsAggregate ? CkStyle::TextMute() : SeverityColor(_Node->InclusiveMs))
                ];
 
             Row->AddSlot()
@@ -266,8 +268,8 @@ public:
                [
                    SNew(STextBlock)
                    .Text(FText::FromString(_Node->DisplayName))
-                   .Font(BodyFont())
-                   .ColorAndOpacity(CkStyle::Text())
+                   .Font(_Node->bIsAggregate ? ItalicFont() : BodyFont())
+                   .ColorAndOpacity(_Node->bIsAggregate ? CkStyle::TextDim() : CkStyle::Text())
                    .ToolTipText(FText::FromString(_Node->RawName))
                ];
 
@@ -292,7 +294,8 @@ public:
         {
             return DoMakeCell(
                 FCk_TimerCategorizer::FormatMs(_Node->InclusiveMs),
-                BodyBoldFont(), SeverityColor(_Node->InclusiveMs));
+                BodyBoldFont(),
+                _Node->bIsAggregate ? CkStyle::TextDim() : SeverityColor(_Node->InclusiveMs));
         }
 
         if (InColumnName == TEXT("Self"))

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
@@ -10,6 +10,7 @@
 #include "CkEditorTools/Style/CkStyle.h"
 
 #include <Containers/Ticker.h>
+#include <Styling/SlateTypes.h>
 #include <Widgets/SCompoundWidget.h>
 #include <Widgets/SBoxPanel.h>
 #include <Widgets/Text/STextBlock.h>
@@ -88,6 +89,8 @@ private:
     // ---- Depth Selector ----
 
     auto DoOnDepthSelectionChanged(TSharedPtr<FString> NewValue, ESelectInfo::Type SelectInfo) -> void;
+    auto DoGet_ShowAllChildrenState() const -> ECheckBoxState;
+    auto DoOnShowAllChildrenChanged(ECheckBoxState NewState) -> void;
 
     // ---- Chart Delegate ----
 
@@ -140,6 +143,9 @@ private:
     TArray<TSharedPtr<FString>> _DepthOptions;
     TSharedPtr<STextComboBox> _DepthCombo;
     ECkReportDepth _ReportDepth = ECkReportDepth::Standard;
+
+    // "Show all" toggle — bypasses the hot-path tree's child threshold/cap (FCk_FrameReportConfig::ShowAllChildren)
+    bool _ShowAllChildren = false;
 
     FString _CurrentReport;
 


### PR DESCRIPTION
## Summary

The maintainer's ask: *"let's see what the breakdown is for each batch"* — `Ck_EcsWorld_Actor_UE` showed ~5.6ms of unattributed self-time in traces because C++ processors and script-processor batch dispatches emitted no CPU-trace scopes.

### feat(CkEcs): per-processor Insights trace scopes
- The scheduler wraps both dispatch sites (main-pass `Tick`, pump `Pump`) in an `FCpuProfilerTrace::FEventScope` named per graph node (spec id cached on the node). One choke point covers C++ processors and both script hosts.
- New optional `FProcessorDescriptor::_DisplayName`: script hosts set `script::<DevClass>` (mirrors their stat row); `_Name` stays the RunAfter-resolvable path. C++ names strip `entt::type_name`'s `struct ` prefix so trace rows match `stat CkProcessors` rows.
- `TParallelProcessor` names its ParallelFor with the `[ForEachEntity]` stat identity so worker-thread tasks are attributable (behavior-preserving: the unnamed overload is the named one with `"ParallelFor Task"` + MinBatchSize 1).
- Cost with the `cpu` channel off: one branch per processor per frame.

### feat(CkInsightsAnalyzer): tree sums reconcile + per-batch attribution
- Synthetic `(+N below threshold)` row carries the pruned child mass (threshold + 8-cap + dedup), so self + children + row = parent — directly answers "that doesn't add up". Muted/italic in the GUI via `FCk_HotPathNode::bIsAggregate`.
- `CollapseWrappers` no longer folds `script::` scopes into their `ForEachBatch` child (the collapse re-merged all batches into one anonymous row).
- `script::` timers categorize as **ECS (CK)**; child self-time clamps to parent-scoped inclusive; commandlet relative `-output` resolves against the project dir instead of silently landing in `Binaries/Win64`.

## Verification

- Development editor build green; Economy AutoTest suite 5/5 (baseline: no known failures in that pattern).
- Verified against a real 634s PIE capture (3326 frames), frame 2000: `Ck_EcsWorld_Actor_UE` (24.2ms) decomposes into named rows — `script::Bb_Processor_NpcAI_POIPicker` 5.39ms, `ck::FProcessor_IsmProxy_TransformInstance` 1.15ms, `ck::FProcessor_SmTask_Tick` 0.956ms, … `(+565 below threshold) 12.6ms` — actor self-time now ~0, sums reconcile exactly.