### PR TITLE
InsightsAnalyzer: trace-overview tiles, recent-traces dropdown, wait/stall breakdown

### DIFF
--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTimerCategorizer.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTimerCategorizer.cpp
@@ -179,6 +179,33 @@ auto
     return FString::Printf(TEXT("%ux"), Count);
 }
 
+auto
+    FCk_TimerCategorizer::
+    IsWaitTimer(const FString& TimerName)
+    -> bool
+{
+    // Names observed in real captures plus the "Waiting/Blocking" category keywords.
+    // "WaitForTask" (singular) also covers WaitForTasks and GameThreadWaitForTask.
+    static const TArray<FString> WaitKeywords = {
+        TEXT("WaitForTask"),
+        TEXT("FTaskBase::Wait"),
+        TEXT("Game thread idle time"),
+        TEXT("FAsyncTask::SyncCompletion"),
+        TEXT("TaskWorkerIsLookingForWork"),
+        TEXT("WaitUntilTasksComplete"),
+        TEXT("ParallelFor.Wait"),
+    };
+
+    for (const FString& Keyword : WaitKeywords)
+    {
+        if (TimerName.Contains(Keyword, ESearchCase::IgnoreCase))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 // Category Initialization (ported from Python CATEGORY_KEYWORDS)
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTimerCategorizer.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTimerCategorizer.h
@@ -66,6 +66,13 @@ public:
     /** Format call count with separator for large numbers (e.g., "1,234x"). */
     static auto FormatCount(uint32 Count) -> FString;
 
+    /**
+     * Whether a timer name is a wait/stall scope (task waits, idle time, sync completions).
+     * Broader than the "Waiting/Blocking" category keywords — also matches wait scopes that
+     * other categories claim first (e.g. WaitUntilTasksComplete under Tick Overhead).
+     */
+    static auto IsWaitTimer(const FString& TimerName) -> bool;
+
 private:
     auto InitializeCategories() -> void;
     auto InitializeNameReplacements() -> void;

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.cpp
@@ -364,6 +364,18 @@ auto
 
 auto
     FCk_TraceSession::
+    GetRenderFrameCount() const
+    -> uint64
+{
+    if (NOT IsOpen()) return 0;
+
+    TraceServices::FAnalysisSessionReadScope ReadScope(*_Session.Get());
+    const TraceServices::IFrameProvider* FrameProvider = GetFrameProvider();
+    return FrameProvider ? FrameProvider->GetFrameCount(ETraceFrameType::TraceFrameType_Rendering) : 0;
+}
+
+auto
+    FCk_TraceSession::
     GetFrame(uint64 Index) const
     -> const TraceServices::FFrame*
 {

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Core/CkTraceSession.h
@@ -110,6 +110,9 @@ public:
     /** Get total number of game frames in the trace. */
     auto GetFrameCount() const -> uint64;
 
+    /** Get total number of render frames in the trace. 0 when the capture has no rendering frames (e.g. -nullrhi). */
+    auto GetRenderFrameCount() const -> uint64;
+
     /** Get a specific game frame by index. Returns nullptr if index is invalid. */
     auto GetFrame(uint64 Index) const -> const TraceServices::FFrame*;
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
@@ -97,11 +97,15 @@ auto
         return TEXT("(No analysis data)");
     }
 
-    TraceServices::FAnalysisSessionReadScope ReadScope = Session.CreateReadScope();
-    const FTimerNameMap TimerNames = BuildTimerNameMap(Session);
-
     TArray<FString> Lines;
     Lines.Reserve(128);
+
+    // The overview accessors each take their own read scope — emit before the
+    // scope below so the session read lock is never acquired recursively.
+    GenerateTraceOverview(Session, Lines);
+
+    TraceServices::FAnalysisSessionReadScope ReadScope = Session.CreateReadScope();
+    const FTimerNameMap TimerNames = BuildTimerNameMap(Session);
 
     GenerateHeader(Result, Lines);
     GenerateHotPaths(Result, TimerNames, Lines);
@@ -127,6 +131,25 @@ auto
 // --------------------------------------------------------------------------------------------------------------------
 // Header
 // --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_FrameReport::
+    GenerateTraceOverview(const FCk_TraceSession& Session,
+                          TArray<FString>& Lines)
+    -> void
+{
+    const uint64 RenderFrames = Session.GetRenderFrameCount();
+    const FString RenderFramesStr = RenderFrames > 0
+        ? FString::Printf(TEXT(", %llu render frames"), RenderFrames)
+        : FString{};
+
+    Lines.Add(FString::Printf(TEXT("_Trace: %s \u2014 %.1fs, %llu game frames%s, %d threads_"),
+        *FPaths::GetCleanFilename(Session.GetFilePath()),
+        Session.GetDurationSeconds(),
+        Session.GetFrameCount(),
+        *RenderFramesStr,
+        Session.GetThreadInfos().Num()));
+}
 
 auto
     FCk_FrameReport::

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.cpp
@@ -115,6 +115,11 @@ auto
         GenerateCategorySummary(Result, TimerNames, Lines);
     }
 
+    if (_Config.ShowWaitBreakdown)
+    {
+        GenerateWaitBreakdown(Session, Result, Lines);
+    }
+
     if (_Config.ShowWorkerThreads)
     {
         GenerateWorkerThreads(Session, Result, Lines);
@@ -1117,6 +1122,169 @@ auto
                 *FCk_TimerCategorizer::FormatMs(Top.ExclusiveMs),
                 *FCk_TimerCategorizer::FormatCount(Top.Count),
                 *ShortName));
+        }
+    }
+    Lines.Add(TEXT(""));
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Wait/Stall Breakdown
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_FrameReport::
+    ComputeWaitSummaries(const FCk_TraceSession& Session,
+                         const FCk_FrameAnalysisResult& GameThreadResult,
+                         double MinWaitMs)
+    -> TArray<FCk_WaitThreadSummary>
+{
+    const FTimerNameMap TimerNames = BuildTimerNameMap(Session);
+    const uint32 GameThreadId = GameThreadResult.ThreadId;
+
+    // Aggregates a thread's wait scopes (exclusive time, so nested waits never double count)
+    auto MakeSummary = [&TimerNames, MinWaitMs](
+        const FCk_FrameAnalysisResult& ThreadResult, uint32 ThreadId, const FString& ThreadName,
+        bool bIsGameThread, double WallMs)
+        -> TOptional<FCk_WaitThreadSummary>
+    {
+        TArray<TPair<uint32, double>> WaitTimers;
+        double WaitMs = 0.0;
+        for (const auto& [TimerIndex, ExclSec] : ThreadResult.TimerExclusive)
+        {
+            if (NOT FCk_TimerCategorizer::IsWaitTimer(GetTimerName(TimerNames, TimerIndex)))
+            {
+                continue;
+            }
+            WaitMs += ExclSec * 1000.0;
+            WaitTimers.Emplace(TimerIndex, ExclSec * 1000.0);
+        }
+
+        if (WaitMs < MinWaitMs)
+        {
+            return {};
+        }
+
+        ck::algo::Sort(WaitTimers, [](const TPair<uint32, double>& A, const TPair<uint32, double>& B)
+        {
+            return A.Value > B.Value;
+        });
+
+        FCk_WaitThreadSummary Summary;
+        Summary.ThreadId = ThreadId;
+        Summary.ThreadName = ThreadName;
+        Summary.bIsGameThread = bIsGameThread;
+        Summary.WaitMs = WaitMs;
+        Summary.WallMs = WallMs;
+
+        for (int32 Index = 0; Index < FMath::Min(WaitTimers.Num(), 3); ++Index)
+        {
+            Summary.TopWaits.Add(FCk_WaitThreadSummary::FWaitScope{
+                FCk_TimerCategorizer::SimplifyName(GetTimerName(TimerNames, WaitTimers[Index].Key)),
+                WaitTimers[Index].Value,
+                ThreadResult.GetCount(WaitTimers[Index].Key)});
+        }
+
+        return Summary;
+    };
+
+    TArray<FCk_WaitThreadSummary> Waits;
+
+    for (const TraceServices::FThreadInfo& Info : Session.GetThreadInfos())
+    {
+        const FString ThreadName = Info.Name
+            ? FString(Info.Name)
+            : FString::Printf(TEXT("Thread %u"), Info.Id);
+
+        if (Info.Id == GameThreadId)
+        {
+            constexpr auto IsGameThread = true;
+            if (auto Summary = MakeSummary(GameThreadResult, Info.Id, ThreadName,
+                    IsGameThread, GameThreadResult.FrameDurationMs))
+            {
+                Waits.Add(MoveTemp(*Summary));
+            }
+            continue;
+        }
+
+        const FCk_FrameAnalysisResult ThreadResult = FCk_FrameAnalyzer::AnalyzeTimeRange(
+            Session, Info.Id,
+            GameThreadResult.FrameStartTime, GameThreadResult.FrameEndTime);
+
+        if (NOT ThreadResult.IsValid())
+        {
+            continue;
+        }
+
+        // Wall time from depth-0 events (same computation as ComputeWorkerThreadSummaries)
+        uint32 MinDepth = MAX_uint32;
+        for (const FCk_TimingEvent& Evt : ThreadResult.Events)
+        {
+            MinDepth = FMath::Min(MinDepth, Evt.Depth);
+        }
+        double WallMs = 0.0;
+        for (const FCk_TimingEvent& Evt : ThreadResult.Events)
+        {
+            if (Evt.Depth == MinDepth)
+            {
+                WallMs += (Evt.EndTime - Evt.StartTime) * 1000.0;
+            }
+        }
+
+        constexpr auto IsGameThread = false;
+        if (auto Summary = MakeSummary(ThreadResult, Info.Id, ThreadName, IsGameThread, WallMs))
+        {
+            Waits.Add(MoveTemp(*Summary));
+        }
+    }
+
+    // Game thread pinned first, then by wait time descending
+    ck::algo::Sort(Waits, [](const FCk_WaitThreadSummary& A, const FCk_WaitThreadSummary& B)
+    {
+        if (A.bIsGameThread != B.bIsGameThread)
+        {
+            return A.bIsGameThread;
+        }
+        return A.WaitMs > B.WaitMs;
+    });
+
+    return Waits;
+}
+
+auto
+    FCk_FrameReport::
+    GenerateWaitBreakdown(const FCk_TraceSession& Session,
+                          const FCk_FrameAnalysisResult& GameThreadResult,
+                          TArray<FString>& Lines) const
+    -> void
+{
+    const TArray<FCk_WaitThreadSummary> Waits = ComputeWaitSummaries(
+        Session, GameThreadResult, _Config.MinWaitMs);
+
+    if (Waits.Num() == 0) return;
+
+    Lines.Add(FString::Printf(TEXT("\n%s"), *ck_frame_report::HRule));
+    Lines.Add(FString::Printf(TEXT("*Wait/Stall Breakdown (>%.0fms)*\n"), _Config.MinWaitMs));
+
+    for (const FCk_WaitThreadSummary& W : Waits)
+    {
+        const double PctOfWall = W.WallMs > 0.0 ? (W.WaitMs / W.WallMs) * 100.0 : 0.0;
+
+        Lines.Add(FString::Printf(TEXT("*%s* %s *%s* waiting  _(%.0f%% of %s wall)_"),
+            *W.ThreadName,
+            *FCk_TimerCategorizer::SeverityIcon(W.WaitMs),
+            *FCk_TimerCategorizer::FormatMs(W.WaitMs),
+            PctOfWall,
+            *FCk_TimerCategorizer::FormatMs(W.WallMs)));
+
+        for (const auto& Top : W.TopWaits)
+        {
+            if (Top.ExclusiveMs < 0.5) break;
+
+            Lines.Add(FString::Printf(TEXT("    %s *%s*  %s  `%s`"),
+                *FCk_TimerCategorizer::SeverityIcon(Top.ExclusiveMs),
+                *FCk_TimerCategorizer::FormatMs(Top.ExclusiveMs),
+                *FCk_TimerCategorizer::FormatCount(Top.Count),
+                *Top.Name));
         }
     }
     Lines.Add(TEXT(""));

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
@@ -250,6 +250,13 @@ public:
                   const FCk_FrameAnalysisResult& Result) const -> FString;
 
     /**
+     * One-line trace overview (file, duration, game/render frame counts, thread count).
+     * Shared by the single-frame and multi-frame markdown reports.
+     */
+    static auto GenerateTraceOverview(const FCk_TraceSession& Session,
+                                      TArray<FString>& Lines) -> void;
+
+    /**
      * Analyze all non-game threads within the frame's time window and summarize them.
      * Returns summaries sorted by wall time descending, filtered to >= MinWorkerThreadMs.
      * Shared by the markdown and JSON renderers.

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkFrameReport.h
@@ -87,6 +87,12 @@ struct CKINSIGHTSANALYZER_API FCk_FrameReportConfig
     /** Whether to include category summary. */
     bool ShowCategorySummary = true;
 
+    /** Whether to include the per-thread wait/stall breakdown. */
+    bool ShowWaitBreakdown = true;
+
+    /** Minimum aggregated wait time (ms) for a thread to appear in the wait breakdown. */
+    double MinWaitMs = 1.0;
+
     /** Set all individual fields from Depth. */
     auto ApplyDepth() -> void
     {
@@ -103,6 +109,7 @@ struct CKINSIGHTSANALYZER_API FCk_FrameReportConfig
             RawTimerCount = 50;
             ShowWorkerThreads = true;
             ShowCategorySummary = true;
+            ShowWaitBreakdown = true;
             break;
         case ECkReportDepth::Standard:
             MaxTreeDepth = 5;
@@ -114,6 +121,7 @@ struct CKINSIGHTSANALYZER_API FCk_FrameReportConfig
             ShowRawTimerList = false;
             ShowWorkerThreads = true;
             ShowCategorySummary = true;
+            ShowWaitBreakdown = true;
             break;
         case ECkReportDepth::Concise:
             MaxTreeDepth = 3;
@@ -123,6 +131,7 @@ struct CKINSIGHTSANALYZER_API FCk_FrameReportConfig
             ShowRawTimerList = false;
             ShowWorkerThreads = false;
             ShowCategorySummary = true;
+            ShowWaitBreakdown = false;
             break;
         case ECkReportDepth::HotPathsOnly:
             MaxTreeDepth = 4;
@@ -131,6 +140,7 @@ struct CKINSIGHTSANALYZER_API FCk_FrameReportConfig
             ShowRawTimerList = false;
             ShowWorkerThreads = false;
             ShowCategorySummary = false;
+            ShowWaitBreakdown = false;
             break;
         }
     }
@@ -189,6 +199,34 @@ struct CKINSIGHTSANALYZER_API FCk_HotPathNode
     bool bIsAggregate = false;
 
     TArray<TSharedPtr<FCk_HotPathNode>> Children;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Per-thread wait/stall summary for a single frame window — how much of the thread's
+ * time went to task waits, idle time, and sync completions (FCk_TimerCategorizer::IsWaitTimer).
+ */
+struct CKINSIGHTSANALYZER_API FCk_WaitThreadSummary
+{
+    uint32 ThreadId = 0;
+    FString ThreadName;
+    bool bIsGameThread = false;
+
+    /** Aggregated exclusive time (ms) of wait scopes on this thread within the frame window. */
+    double WaitMs = 0.0;
+
+    /** Thread wall time (ms) within the frame window (frame duration for the game thread). */
+    double WallMs = 0.0;
+
+    /** Top wait scopes by exclusive time: (SimplifiedName, ExclusiveMs, Count). */
+    struct FWaitScope
+    {
+        FString Name;
+        double ExclusiveMs = 0.0;
+        uint32 Count = 0;
+    };
+    TArray<FWaitScope> TopWaits;
 };
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -266,6 +304,17 @@ public:
                                              double MinWorkerThreadMs)
         -> TArray<FCk_WorkerThreadSummary>;
 
+    /**
+     * Aggregate wait/stall time per thread (game thread first, then workers) within the
+     * frame's time window. Sums EXCLUSIVE time of wait scopes so nested waits never double
+     * count. Returns threads with >= MinWaitMs of wait, sorted by wait time descending
+     * (game thread pinned first). Shared by the markdown, JSON, and Slate renderers.
+     */
+    static auto ComputeWaitSummaries(const FCk_TraceSession& Session,
+                                     const FCk_FrameAnalysisResult& GameThreadResult,
+                                     double MinWaitMs)
+        -> TArray<FCk_WaitThreadSummary>;
+
     /** Get/set the report configuration. */
     auto GetConfig() const -> const FCk_FrameReportConfig& { return _Config; }
     auto SetConfig(const FCk_FrameReportConfig& Config) -> void { _Config = Config; }
@@ -324,6 +373,10 @@ private:
                                 TArray<FString>& Lines) const -> void;
 
     auto GenerateWorkerThreads(const FCk_TraceSession& Session,
+                               const FCk_FrameAnalysisResult& GameThreadResult,
+                               TArray<FString>& Lines) const -> void;
+
+    auto GenerateWaitBreakdown(const FCk_TraceSession& Session,
                                const FCk_FrameAnalysisResult& GameThreadResult,
                                TArray<FString>& Lines) const -> void;
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkJsonReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkJsonReport.cpp
@@ -50,17 +50,10 @@ auto
     Obj->SetNumberField(TEXT("durationSeconds"), Round3(Session.GetDurationSeconds()));
     Obj->SetNumberField(TEXT("gameFrameCount"), static_cast<double>(Session.GetFrameCount()));
 
-    // Render frame count has no convenience accessor — query the frame provider directly
+    if (const uint64 RenderFrames = Session.GetRenderFrameCount();
+        RenderFrames > 0)
     {
-        TraceServices::FAnalysisSessionReadScope ReadScope = Session.CreateReadScope();
-        if (const TraceServices::IFrameProvider* FrameProvider = Session.GetFrameProvider())
-        {
-            const uint64 RenderFrames = FrameProvider->GetFrameCount(ETraceFrameType::TraceFrameType_Rendering);
-            if (RenderFrames > 0)
-            {
-                Obj->SetNumberField(TEXT("renderFrameCount"), static_cast<double>(RenderFrames));
-            }
-        }
+        Obj->SetNumberField(TEXT("renderFrameCount"), static_cast<double>(RenderFrames));
     }
 
     TArray<TSharedPtr<FJsonValue>> ThreadValues;

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkJsonReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkJsonReport.cpp
@@ -363,6 +363,42 @@ auto
         Frame->SetArrayField(TEXT("workerThreads"), WorkerValues);
     }
 
+    // ---- Wait/stall breakdown ----
+
+    const TArray<FCk_WaitThreadSummary> Waits = FCk_FrameReport::ComputeWaitSummaries(
+        Session, Result, Config.MinWaitMs);
+
+    TArray<TSharedPtr<FJsonValue>> WaitValues;
+    for (const FCk_WaitThreadSummary& Wait : Waits)
+    {
+        TSharedPtr<FJsonObject> WaitObj = MakeShared<FJsonObject>();
+        WaitObj->SetNumberField(TEXT("id"), Wait.ThreadId);
+        WaitObj->SetStringField(TEXT("name"), Wait.ThreadName);
+        WaitObj->SetBoolField(TEXT("isGameThread"), Wait.bIsGameThread);
+        WaitObj->SetNumberField(TEXT("waitMs"), Round3(Wait.WaitMs));
+        WaitObj->SetNumberField(TEXT("wallMs"), Round3(Wait.WallMs));
+
+        TArray<TSharedPtr<FJsonValue>> TopValues;
+        for (const FCk_WaitThreadSummary::FWaitScope& Top : Wait.TopWaits)
+        {
+            TSharedPtr<FJsonObject> TopObj = MakeShared<FJsonObject>();
+            TopObj->SetStringField(TEXT("name"), Top.Name);
+            TopObj->SetNumberField(TEXT("exclusiveMs"), Round3(Top.ExclusiveMs));
+            TopObj->SetNumberField(TEXT("count"), Top.Count);
+            TopValues.Add(MakeShared<FJsonValueObject>(TopObj));
+        }
+        if (TopValues.Num() > 0)
+        {
+            WaitObj->SetArrayField(TEXT("topWaits"), TopValues);
+        }
+
+        WaitValues.Add(MakeShared<FJsonValueObject>(WaitObj));
+    }
+    if (WaitValues.Num() > 0)
+    {
+        Frame->SetArrayField(TEXT("waitBreakdown"), WaitValues);
+    }
+
     Root->SetObjectField(TEXT("singleFrame"), Frame);
     return ToJsonString(Root);
 }

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkMultiFrameReport.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkMultiFrameReport.cpp
@@ -252,7 +252,7 @@ auto
     {
         return TEXT("(No frame data to analyze)");
     }
-    return GenerateReport();
+    return GenerateReport(Session);
 }
 
 auto
@@ -267,7 +267,7 @@ auto
     {
         return TEXT("(No frame data to analyze)");
     }
-    return GenerateReport();
+    return GenerateReport(Session);
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -276,11 +276,13 @@ auto
 
 auto
     FCk_MultiFrameReport::
-    GenerateReport() const
+    GenerateReport(const FCk_TraceSession& Session) const
     -> FString
 {
     TArray<FString> Lines;
     Lines.Reserve(64);
+
+    FCk_FrameReport::GenerateTraceOverview(Session, Lines);
 
     const double OverBudget = _Stats.AvgFrameMs / _Config.TargetFrameMs;
     const FString Icon = FCk_TimerCategorizer::SeverityIcon(_Stats.AvgFrameMs);

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkMultiFrameReport.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Report/CkMultiFrameReport.h
@@ -171,7 +171,7 @@ private:
         -> TPair<FString, double>;
 
     /** Generate the markdown report from populated _Stats. */
-    auto GenerateReport() const -> FString;
+    auto GenerateReport(const FCk_TraceSession& Session) const -> FString;
 
     /** Compute percentile from a sorted array. */
     static auto Percentile(const TArray<double>& SortedValues, double P) -> double;

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
@@ -766,6 +766,7 @@ auto
     SAssignNew(_TopTimerRowsBox, SVerticalBox);
     SAssignNew(_WorstFrameRowsBox, SVerticalBox);
     SAssignNew(_CategoryAvgRowsBox, SVerticalBox);
+    SAssignNew(_WaitRowsBox, SVerticalBox);
 
     const auto MakeGatedPanel =
         [this](const FString& InHeading, const TSharedRef<SWidget>& InRowsBox, TFunction<bool()> InHasData) -> TSharedRef<SWidget>
@@ -800,6 +801,12 @@ auto
         [
             MakeGatedPanel(TEXT("Categories (exclusive time)"), _CategoryRowsBox.ToSharedRef(),
                 [this]() { return _Categories.Num() > 0; })
+        ]
+
+        + SScrollBox::Slot()
+        [
+            MakeGatedPanel(TEXT("Waits/Stalls (per thread)"), _WaitRowsBox.ToSharedRef(),
+                [this]() { return _WaitRows.Num() > 0; })
         ]
 
         + SScrollBox::Slot()
@@ -965,6 +972,107 @@ auto
                 ]
             ]
         ];
+    }
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoRebuildWaitRows()
+    -> void
+{
+    using namespace ck_insights_analyzer_tab;
+
+    if (ck::Is_NOT_Valid(_WaitRowsBox))
+    {
+        return;
+    }
+    _WaitRowsBox->ClearChildren();
+
+    for (const FCk_WaitThreadSummary& Wait : _WaitRows)
+    {
+        const double PctOfWall = Wait.WallMs > 0.0 ? (Wait.WaitMs / Wait.WallMs) * 100.0 : 0.0;
+
+        _WaitRowsBox->AddSlot()
+        .AutoHeight()
+        .Padding(0.0f, 1.0f)
+        [
+            SNew(SHorizontalBox)
+            + SHorizontalBox::Slot()
+            .FillWidth(1.0f)
+            .VAlign(VAlign_Center)
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(Wait.ThreadName))
+                .Font(Wait.bIsGameThread ? BodyBoldFont() : BodyFont())
+                .ColorAndOpacity(CkStyle::Text())
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            .Padding(CkStyle::SpaceS, 0.0f)
+            [
+                MakeProportionBar(PctOfWall, CkStyle::OverlayOf(SeverityColor(Wait.WaitMs), 0.85f), SideBarWidth)
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(60.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FCk_TimerCategorizer::FormatMs(Wait.WaitMs)))
+                    .Font(BodyBoldFont())
+                    .ColorAndOpacity(SeverityColor(Wait.WaitMs))
+                ]
+            ]
+            + SHorizontalBox::Slot()
+            .AutoWidth()
+            .VAlign(VAlign_Center)
+            [
+                SNew(SBox)
+                .WidthOverride(44.0f)
+                .HAlign(HAlign_Right)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("%.0f%%"), PctOfWall)))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                ]
+            ]
+        ];
+
+        for (const FCk_WaitThreadSummary::FWaitScope& Top : Wait.TopWaits)
+        {
+            _WaitRowsBox->AddSlot()
+            .AutoHeight()
+            .Padding(CkStyle::SpaceM, 0.0f, 0.0f, 1.0f)
+            [
+                SNew(SHorizontalBox)
+                + SHorizontalBox::Slot()
+                .FillWidth(1.0f)
+                .VAlign(VAlign_Center)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(Top.Name))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextDim())
+                ]
+                + SHorizontalBox::Slot()
+                .AutoWidth()
+                .VAlign(VAlign_Center)
+                .Padding(CkStyle::SpaceS, 0.0f, 0.0f, 0.0f)
+                [
+                    SNew(STextBlock)
+                    .Text(FText::FromString(FString::Printf(TEXT("%s  %s"),
+                        *FCk_TimerCategorizer::FormatMs(Top.ExclusiveMs),
+                        *FCk_TimerCategorizer::FormatCount(Top.Count))))
+                    .Font(SmallFont())
+                    .ColorAndOpacity(CkStyle::TextMute())
+                ]
+            ];
+        }
     }
 }
 
@@ -1574,6 +1682,7 @@ auto
     _TopTimers.Reset();
     _WorstFrames.Reset();
     _CategoryAverages.Reset();
+    _WaitRows.Reset();
     _LastSingleResult.Reset();
     _LastMultiStats.Reset();
 
@@ -1582,6 +1691,7 @@ auto
     DoRebuildTopTimerRows();
     DoRebuildWorstFrameRows();
     DoRebuildCategoryAvgRows();
+    DoRebuildWaitRows();
 
     if (ck::IsValid(_SummaryBox)) { _SummaryBox->ClearChildren(); }
 }
@@ -1605,10 +1715,12 @@ auto
         _HotPathRoots.Reset();
         _Categories.Reset();
         _TopTimers.Reset();
+        _WaitRows.Reset();
         _LastSingleResult.Reset();
         if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
         DoRebuildCategoryRows();
         DoRebuildTopTimerRows();
+        DoRebuildWaitRows();
         DoSetReport(TEXT(""));
         return;
     }
@@ -1634,12 +1746,16 @@ auto
         const FCk_FrameReport::FTimerNameMap TimerNames = FCk_FrameReport::BuildTimerNameMap(_Session);
         _Categories = FrameReport.ComputeCategorySummary(Result, TimerNames);
         _TopTimers = FrameReport.ComputeTopTimers(Result, TimerNames, TopTimerCount);
+
+        // ComputeWaitSummaries reads timer names internally — needs the scope above
+        _WaitRows = FCk_FrameReport::ComputeWaitSummaries(_Session, Result, Config.MinWaitMs);
     }
 
     if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
     DoExpandHotPathDefaults();
     DoRebuildCategoryRows();
     DoRebuildTopTimerRows();
+    DoRebuildWaitRows();
     DoRebuildSummaryStrip_SingleFrame(Result);
 
     DoSetStatus(FString::Printf(TEXT("Frame %llu: %.2fms"), FrameIndex, Result.FrameDurationMs),
@@ -1697,6 +1813,7 @@ auto
     _HotPathRoots.Reset();
     _Categories.Reset();
     _TopTimers.Reset();
+    _WaitRows.Reset();
     _LastSingleResult.Reset();
     _LastMultiStats = Stats;      // retained for Export JSON
 
@@ -1706,6 +1823,7 @@ auto
     if (ck::IsValid(_HotPathTree)) { _HotPathTree->RequestTreeRefresh(); }
     DoRebuildCategoryRows();
     DoRebuildTopTimerRows();
+    DoRebuildWaitRows();
     DoRebuildWorstFrameRows();
     DoRebuildCategoryAvgRows();
     DoRebuildSummaryStrip_MultiFrame(Stats);

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
@@ -5,18 +5,21 @@
 #include "CkInsightsAnalyzer/Report/CkJsonReport.h"
 #include "CkInsightsAnalyzer_Log.h"
 
+#include "CkCore/Algorithms/CkAlgorithms.h"
 #include "CkCore/Macros/CkMacros.h"
 #include "CkCore/Validation/CkIsValid.h"
 
 #include "CkEditorTools/Style/CkStyle.h"
 
 #include <DesktopPlatformModule.h>
+#include <Framework/MultiBox/MultiBoxBuilder.h>
 #include <HAL/PlatformApplicationMisc.h>
 #include <Misc/FileHelper.h>
 #include <Styling/AppStyle.h>
 #include <Styling/CoreStyle.h>
 #include <Widgets/Images/SImage.h>
 #include <Widgets/Input/SCheckBox.h>
+#include <Widgets/Input/SComboButton.h>
 #include <Widgets/Layout/SBorder.h>
 #include <Widgets/Layout/SBox.h>
 #include <Widgets/Layout/SExpandableArea.h>
@@ -478,6 +481,23 @@ auto
             .ToolTipText(FText::FromString(TEXT("Open an Unreal Insights trace file for analysis")))
             .OnClicked(this, &SCkInsightsAnalyzerTab::DoOnOpenTraceClicked)
             .HAlign(HAlign_Center)
+        ]
+
+        // Recent traces dropdown
+        + SHorizontalBox::Slot()
+        .AutoWidth()
+        .Padding(0.0f, 0.0f, SectionSpacing, 0.0f)
+        [
+            SNew(SComboButton)
+            .ToolTipText(FText::FromString(TEXT(
+                "Open a recent trace from Saved/Profiling or the local Unreal Trace Server store")))
+            .OnGetMenuContent(this, &SCkInsightsAnalyzerTab::DoMakeRecentTracesMenu)
+            .ButtonContent()
+            [
+                SNew(STextBlock)
+                .Text(FText::FromString(TEXT("Recent")))
+                .Font(BodyFont())
+            ]
         ]
 
         // Depth dropdown
@@ -1204,7 +1224,7 @@ auto
     const bool Opened = DesktopPlatform->OpenFileDialog(
         FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
         TEXT("Open Unreal Insights Trace"),
-        FPaths::ProjectSavedDir() / TEXT("TraceSessions"),
+        FPaths::ProfilingDir(),
         TEXT(""),
         TEXT("Unreal Trace Files (*.utrace)|*.utrace"),
         EFileDialogFlags::None,
@@ -1215,13 +1235,98 @@ auto
         return FReply::Handled();
     }
 
+    DoOpenTracePath(OutFiles[0]);
+    return FReply::Handled();
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoOpenTracePath(FString TracePath)
+    -> void
+{
+    if (DoIsLoading())
+    {
+        DoSetStatus(TEXT("Loading in progress..."), ECk_Tone::Warn);
+        return;
+    }
+
     // Close any existing session
     _Session.Close();
     _FrameBarChart->ClearFrameData();
     DoClearResults();
 
-    DoStartAsyncOpen(OutFiles[0]);
-    return FReply::Handled();
+    DoStartAsyncOpen(TracePath);
+}
+
+auto
+    SCkInsightsAnalyzerTab::
+    DoMakeRecentTracesMenu()
+    -> TSharedRef<SWidget>
+{
+    // (Path, ModificationTime, SizeBytes) for every .utrace in a candidate directory
+    struct FTraceFileInfo
+    {
+        FString Path;
+        FDateTime MTime;
+        int64 SizeBytes = 0;
+    };
+
+    // The default landing dir for -tracefile / Trace.File captures, plus the
+    // local Unreal Trace Server store (where traces without -tracefile go).
+    const FString TraceStoreDir = FString{FPlatformProcess::UserSettingsDir()} /
+        TEXT("UnrealEngine/Common/UnrealTrace/Store/001");
+    const TArray<FString> SearchDirs = { FPaths::ProfilingDir(), TraceStoreDir };
+
+    TArray<FTraceFileInfo> TraceFiles;
+    for (const FString& Dir : SearchDirs)
+    {
+        TArray<FString> Found;
+        IFileManager::Get().FindFiles(Found, *(Dir / TEXT("*.utrace")), true, false);
+        for (const FString& FileName : Found)
+        {
+            const FString FullPath = Dir / FileName;
+            TraceFiles.Add(FTraceFileInfo{
+                FullPath,
+                IFileManager::Get().GetTimeStamp(*FullPath),
+                IFileManager::Get().FileSize(*FullPath)});
+        }
+    }
+
+    ck::algo::Sort(TraceFiles, [](const FTraceFileInfo& A, const FTraceFileInfo& B)
+    {
+        return A.MTime > B.MTime;
+    });
+
+    constexpr auto MaxRecentTraces = 15;
+    constexpr auto CloseAfterSelection = true;
+    FMenuBuilder MenuBuilder(CloseAfterSelection, nullptr);
+
+    if (TraceFiles.IsEmpty())
+    {
+        MenuBuilder.AddWidget(
+            SNew(STextBlock)
+                .Text(FText::FromString(TEXT("No .utrace files found")))
+                .ColorAndOpacity(CkStyle::TextDim()),
+            FText::GetEmpty());
+        return MenuBuilder.MakeWidget();
+    }
+
+    for (int32 Index = 0; Index < FMath::Min(TraceFiles.Num(), MaxRecentTraces); ++Index)
+    {
+        const FTraceFileInfo& Info = TraceFiles[Index];
+        const FString Label = FString::Printf(TEXT("%s    %s    %.1f MB"),
+            *FPaths::GetCleanFilename(Info.Path),
+            *Info.MTime.ToString(TEXT("%Y-%m-%d %H:%M")),
+            static_cast<double>(Info.SizeBytes) / (1024.0 * 1024.0));
+
+        MenuBuilder.AddMenuEntry(
+            FText::FromString(Label),
+            FText::FromString(Info.Path),
+            FSlateIcon(),
+            FUIAction(FExecuteAction::CreateSP(this, &SCkInsightsAnalyzerTab::DoOpenTracePath, Info.Path)));
+    }
+
+    return MenuBuilder.MakeWidget();
 }
 
 auto

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.cpp
@@ -1649,8 +1649,16 @@ auto
     }
 
     DoAddSummaryTile(TEXT("Trace"), FPaths::GetCleanFilename(_Session.GetFilePath()), CkStyle::Text());
-    DoAddSummaryTile(TEXT("Frames"), FormatWithCommas(_Session.GetFrameCount()), CkStyle::Text());
     DoAddSummaryTile(TEXT("Duration"), FString::Printf(TEXT("%.1fs"), _Session.GetDurationSeconds()), CkStyle::Text());
+    DoAddSummaryTile(TEXT("Game Frames"), FormatWithCommas(_Session.GetFrameCount()), CkStyle::Text());
+
+    if (const uint64 RenderFrames = _Session.GetRenderFrameCount();
+        RenderFrames > 0)
+    {
+        DoAddSummaryTile(TEXT("Render Frames"), FormatWithCommas(RenderFrames), CkStyle::Text());
+    }
+
+    DoAddSummaryTile(TEXT("Threads"), FormatWithCommas(_Session.GetThreadInfos().Num()), CkStyle::TextDim());
     DoAddSummaryTile(TEXT("Budget"), FString::Printf(TEXT("%.1fms"), TargetFrameMs), CkStyle::TextDim());
 }
 

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
@@ -25,10 +25,10 @@
  * Main editor tab for the Insights Analyzer.
  *
  * Layout (top to bottom):
- *   1. Toolbar       — [Open .utrace...] [Depth ▾] [Analyze Worst 10] [Copy Report]  Status pill
+ *   1. Toolbar       — [Open .utrace...] [Recent ▾] [Depth ▾] [Analyze Worst 10] [Copy Report]  Status pill
  *   2. Summary strip — stat tiles (trace info; frame/aggregate numbers after analysis)
  *   3. Frame bar chart (SCkFrameBarChart, ~200px)
- *   4. Results       — splitter: hot-path tree (left) | categories / top timers /
+ *   4. Results       — splitter: hot-path tree (left) | categories / waits / top timers /
  *                      worst frames / category averages (right)
  *   5. Raw report    — collapsed expandable area with the markdown text (also what
  *                      "Copy Report" puts on the clipboard)
@@ -77,10 +77,18 @@ private:
     auto DoRebuildTopTimerRows() -> void;
     auto DoRebuildWorstFrameRows() -> void;
     auto DoRebuildCategoryAvgRows() -> void;
+    auto DoRebuildWaitRows() -> void;
 
     // ---- Button Handlers ----
 
     auto DoOnOpenTraceClicked() -> FReply;
+
+    /** Build the "Recent" dropdown menu — newest-first .utrace files from Saved/Profiling and the local trace store. */
+    auto DoMakeRecentTracesMenu() -> TSharedRef<SWidget>;
+
+    /** Close the current session and start async-opening the given trace. Shared by the file dialog
+     *  and the Recent menu. By-value: bound as a delegate payload, which decays reference types. */
+    auto DoOpenTracePath(FString TracePath) -> void;
     auto DoOnAnalyzeWorstClicked() -> FReply;
     auto DoOnCopyToClipboardClicked() -> FReply;
     auto DoOnExportJsonClicked() -> FReply;

--- a/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
+++ b/Source/CkInsightsAnalyzer/Public/CkInsightsAnalyzer/Tab/SCkInsightsAnalyzerTab.h
@@ -173,6 +173,7 @@ private:
     TArray<FCk_TopTimerEntry> _TopTimers;
     TArray<FCk_FrameSummary> _WorstFrames;          // persists across single-frame drills
     TArray<FCk_MultiFrameStats::FCategoryStats> _CategoryAverages;
+    TArray<FCk_WaitThreadSummary> _WaitRows;        // single-frame only
 
     // Last analysis, retained so Export JSON can regenerate without re-analyzing
     TOptional<FCk_FrameAnalysisResult> _LastSingleResult;
@@ -183,6 +184,7 @@ private:
     TSharedPtr<SVerticalBox> _TopTimerRowsBox;
     TSharedPtr<SVerticalBox> _WorstFrameRowsBox;
     TSharedPtr<SVerticalBox> _CategoryAvgRowsBox;
+    TSharedPtr<SVerticalBox> _WaitRowsBox;
 
     // Async loading state. Analysis is STARTED on the game thread (trace modules
     // like ChaosVD ensure(IsInGameThread()) in OnAnalysisBegin) and processed on


### PR DESCRIPTION
Follow-up to #679 — the remaining items from the feature-gap comparison (GPU timers excluded; they need a gpu-channel capture and will come as their own PR).

## 1. Trace overview everywhere the JSON has it
The JSON report already emitted file / duration / game+render frame counts / threads; the Slate summary strip and both markdown reports did not.
- New `FCk_TraceSession::GetRenderFrameCount()` (the JSON renderer previously queried the frame provider by hand)
- Summary strip: **Duration / Game Frames / Render Frames / Threads** tiles (Render Frames omitted when the capture has none, same rule as the JSON)
- One-line `_Trace: <file> — <s>s, N game frames, N render frames, N threads_` header on both the single-frame and multi-frame markdown reports

## 2. Recent-traces dropdown
**Recent** combo next to *Open .utrace…* — newest 15 traces from `Saved/Profiling/` (where `-tracefile` / `Trace.File` captures actually land) plus the local Unreal Trace Server store, menu built lazily on click. The file dialog's default directory now also points at `Saved/Profiling/` (was the never-used `Saved/TraceSessions`).

## 3. Per-thread wait/stall breakdown
- `FCk_TimerCategorizer::IsWaitTimer()` — wait-scope match list verified against a real capture; deliberately broader than the *Waiting/Blocking* category (which loses e.g. `WaitUntilTasksComplete` to Tick Overhead's earlier priority)
- `FCk_FrameReport::ComputeWaitSummaries()` — per-thread wait ms within the frame window, summing **exclusive** time so nested waits never double count; game thread pinned first; top-3 wait scopes per thread
- Markdown *Wait/Stall Breakdown* section (Standard/Full depths), JSON `waitBreakdown` array, *Waits/Stalls* side panel in the tab (single-frame analyses)

## Verification
Commandlet runs against the 634s / 3326-frame BusterBlock capture (frame 2000 + `-worst=2` + `-json`):
- Overview line renders on both markdown reports; report body otherwise byte-identical to the pre-change baseline
- JSON `trace` object unchanged after the accessor refactor
- Wait section cross-checks the known frame-2000 numbers: RenderThread 46.4ms waiting (WaitForTasks 45.5ms · 32x), RHIThread 36.8ms (WaitForTasks 36.1ms · 27x); GameThread correctly absent (<1ms wait — it was the busy thread)

Human-verified in the editor (tiles, Recent dropdown, Waits/Stalls panel on a 263ms frame, Show-all toggle, panel hidden on multi-frame ranges). Rebased onto dev `05601412c`; analyzer diff byte-identical across the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)