### PR TITLE
feat(CkCrowd): Request_SetMaxSpeed — runtime gait override on crowd agents

### DIFF
--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment.h
@@ -34,7 +34,8 @@ namespace ck
         using MoveToRequestType       = FCk_Request_CrowdAgent_MoveTo;
         using FollowTargetRequestType = FCk_Request_CrowdAgent_FollowTarget;
         using StopRequestType         = FCk_Request_CrowdAgent_Stop;
-        using RequestType             = std::variant<MoveToRequestType, FollowTargetRequestType, StopRequestType>;
+        using SetMaxSpeedRequestType  = FCk_Request_CrowdAgent_SetMaxSpeed;
+        using RequestType             = std::variant<MoveToRequestType, FollowTargetRequestType, StopRequestType, SetMaxSpeedRequestType>;
 
     private:
         TArray<RequestType> _Requests;

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment_Data.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment_Data.h
@@ -97,6 +97,7 @@ struct CKCROWD_API FCk_Fragment_CrowdAgent_ParamsData
     friend class ck::FProcessor_CrowdAgent_Steering;
     friend class ck::FProcessor_CrowdAgent_NeighborSync;
     friend class ck::FProcessor_CrowdAgent_Separation;
+    friend class ck::FProcessor_CrowdAgent_HandleRequests;
 
 private:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(AllowPrivateAccess=true, ClampMin="1.0"))
@@ -464,6 +465,32 @@ struct CKCROWD_API FCk_Request_CrowdAgent_Stop : public FCk_Request_Base
     CK_REQUEST_DEFINE_DEBUG_NAME(FCk_Request_CrowdAgent_Stop);
 
     friend class ck::FProcessor_CrowdAgent_HandleRequests;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// Public request — override the agent's max speed at runtime (sprint/flee gaits). Writes the
+// params fragment's _MaxSpeed, which every steering-chain processor reads per frame, so the new
+// speed applies from the next tick and persists until the next SetMaxSpeed. Does not disturb the
+// active path or goal.
+USTRUCT(BlueprintType)
+struct CKCROWD_API FCk_Request_CrowdAgent_SetMaxSpeed : public FCk_Request_Base
+{
+    GENERATED_BODY()
+    CK_GENERATED_BODY(FCk_Request_CrowdAgent_SetMaxSpeed);
+    CK_REQUEST_DEFINE_DEBUG_NAME(FCk_Request_CrowdAgent_SetMaxSpeed);
+
+    friend class ck::FProcessor_CrowdAgent_HandleRequests;
+
+private:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, meta=(AllowPrivateAccess=true, ClampMin="1.0"))
+    float _MaxSpeed = 240.0f;
+
+public:
+    CK_PROPERTY_GET(_MaxSpeed);
+
+public:
+    CK_DEFINE_CONSTRUCTORS(FCk_Request_CrowdAgent_SetMaxSpeed, _MaxSpeed);
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_HandleRequests_Processor.cpp
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_HandleRequests_Processor.cpp
@@ -33,7 +33,7 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
-            const FFragment_CrowdAgent_Params& InParams,
+            FFragment_CrowdAgent_Params& InParams,
             FFragment_CrowdAgent_PathFollow& InPathFollow,
             FFragment_CrowdAgent_DesiredVelocity& InDesired,
             FFragment_CrowdAgent_MoveRequests& InRequests) const
@@ -252,6 +252,23 @@ namespace ck
         BlockDetect._SampleAccumulatorSec = 0.0f;
         BlockDetect._RecheckAccumulatorSec = 0.0f;
         BlockDetect._BlockedSignalSent = false;
+    }
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    auto
+        FProcessor_CrowdAgent_HandleRequests::
+        DoHandleRequest(
+            HandleType InHandle,
+            FFragment_CrowdAgent_Params& InParams,
+            FFragment_CrowdAgent_PathFollow& InPathFollow,
+            FFragment_CrowdAgent_DesiredVelocity& InDesired,
+            const FCk_Request_CrowdAgent_SetMaxSpeed& InRequest)
+        -> void
+    {
+        InParams._MaxSpeed = InRequest.Get_MaxSpeed();
+
+        ck::crowd::Verbose(TEXT("CrowdAgent [{}] SetMaxSpeed {}"), InHandle, InRequest.Get_MaxSpeed());
     }
 }
 

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_HandleRequests_Processor.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_HandleRequests_Processor.h
@@ -19,13 +19,15 @@ namespace ck
     //   CkNavigation lands the FFragment_Nav_PathResult.
     // - Stop: zero _DesiredVelocity, transition Walking/PathPending → Idle. Steering's view filter
     //   (which also requires Walking) stops firing; bridge writes zero velocity → agent halts.
+    // - SetMaxSpeed: write the params fragment's _MaxSpeed (read per-frame by the steering chain),
+    //   so gait changes (sprint/flee) apply from the next tick without disturbing the active path.
     //
     // Group: FGroup_Gameplay (early in the frame so the path request is enqueued before
     // FProcessor_Nav_HandleRequests runs in FGroup_Gameplay's downstream group).
     class CKCROWD_API FProcessor_CrowdAgent_HandleRequests : public ck_exp::TProcessor<
             FProcessor_CrowdAgent_HandleRequests,
             FCk_Handle_CrowdAgent,
-            ck::TReadOnly<FFragment_CrowdAgent_Params>,
+            ck::TReadWrite<FFragment_CrowdAgent_Params>,
             ck::TReadWrite<FFragment_CrowdAgent_PathFollow>,
             ck::TReadWrite<FFragment_CrowdAgent_DesiredVelocity>,
             ck::TReadWrite<FFragment_CrowdAgent_MoveRequests>,
@@ -43,7 +45,7 @@ namespace ck
         ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
-            const FFragment_CrowdAgent_Params& InParams,
+            FFragment_CrowdAgent_Params& InParams,
             FFragment_CrowdAgent_PathFollow& InPathFollow,
             FFragment_CrowdAgent_DesiredVelocity& InDesired,
             FFragment_CrowdAgent_MoveRequests& InRequests) const -> void;
@@ -79,6 +81,14 @@ namespace ck
         static auto
         DoClearBlockedState(
             FCk_Handle_CrowdAgent& InAgent) -> void;
+
+        static auto
+        DoHandleRequest(
+            HandleType InHandle,
+            FFragment_CrowdAgent_Params& InParams,
+            FFragment_CrowdAgent_PathFollow& InPathFollow,
+            FFragment_CrowdAgent_DesiredVelocity& InDesired,
+            const FCk_Request_CrowdAgent_SetMaxSpeed& InRequest) -> void;
     };
 }
 

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.cpp
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.cpp
@@ -183,6 +183,49 @@ auto
 
 auto
     UCk_Utils_CrowdAgent_UE::
+    Request_SetMaxSpeed(
+        FCk_Handle_CrowdAgent& InAgent,
+        float InMaxSpeed)
+    -> FCk_Handle_CrowdAgent
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InAgent),
+        TEXT("Invalid CrowdAgent handle [{}] passed to Request_SetMaxSpeed"), InAgent)
+    { return InAgent; }
+
+    CK_ENSURE_IF_NOT(UCk_Utils_Net_UE::Get_HasAuthority(InAgent),
+        TEXT("Request_SetMaxSpeed on CrowdAgent [{}] dropped — caller does not have authority. "
+             "Steering is server-only."), InAgent)
+    { return InAgent; }
+
+    CK_ENSURE_IF_NOT(InMaxSpeed >= 1.0f,
+        TEXT("Request_SetMaxSpeed on CrowdAgent [{}] dropped — MaxSpeed [{}] must be >= 1"),
+        InAgent, InMaxSpeed)
+    { return InAgent; }
+
+    InAgent.AddOrGet<ck::FFragment_CrowdAgent_MoveRequests>()._Requests.Emplace(
+        FCk_Request_CrowdAgent_SetMaxSpeed{InMaxSpeed});
+    return InAgent;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_CrowdAgent_UE::
+    Get_MaxSpeed(
+        const FCk_Handle_CrowdAgent& InAgent)
+    -> float
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InAgent),
+        TEXT("Invalid CrowdAgent handle [{}] passed to Get_MaxSpeed"), InAgent)
+    { return 0.0f; }
+
+    return InAgent.Get<ck::FFragment_CrowdAgent_Params>().Get_MaxSpeed();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_CrowdAgent_UE::
     BindTo_OnGoalReached(
         FCk_Handle_CrowdAgent& InAgent,
         const FCk_Delegate_CrowdAgent_OnGoalReached& InDelegate,

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.h
@@ -121,6 +121,24 @@ public:
     Request_Stop(
         UPARAM(ref) FCk_Handle_CrowdAgent& InAgent);
 
+    // Override the agent's max speed at runtime (sprint/flee gaits). Applies from the next tick
+    // and persists until the next SetMaxSpeed; does not disturb the active path or goal.
+    UFUNCTION(BlueprintCallable,
+              Category = "Ck|Utils|CrowdAgent",
+              DisplayName="[Ck][CrowdAgent] Request Set Max Speed")
+    static FCk_Handle_CrowdAgent
+    Request_SetMaxSpeed(
+        UPARAM(ref) FCk_Handle_CrowdAgent& InAgent,
+        float InMaxSpeed);
+
+    // The params fragment's current max speed (post any runtime SetMaxSpeed override).
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|CrowdAgent",
+              DisplayName="[Ck][CrowdAgent] Get Max Speed")
+    static float
+    Get_MaxSpeed(
+        const FCk_Handle_CrowdAgent& InAgent);
+
     UFUNCTION(BlueprintCallable,
               Category = "Ck|Utils|CrowdAgent",
               DisplayName="[Ck][CrowdAgent] Bind To OnGoalReached")


### PR DESCRIPTION
## What
Adds `Request_SetMaxSpeed` (+ `Get_MaxSpeed`) to `CkCrowd` — a runtime max-speed override on a crowd agent, dispatched through the agent's existing move-request variant. The handler writes the params fragment's `_MaxSpeed` (read per-frame by the whole steering chain), so a gait change applies from the next tick without disturbing the active path or goal.

## Why
Crowd agents had **no runtime speed mutation point** — `_MaxSpeed` was a setup-time param, friend-gated to the steering processors with no utils surface. So an NPC could never sprint to close on, or flee from, a faster player. Consumer: BusterBlock NPC retaliation combat (chase 450 / flee 900 vs the 240 default).

## Shape
Additive only — the request rides the same variant queue `MoveTo`/`Stop` already drain; `HandleRequests` takes `Params` read-write for this (behaviour-neutral otherwise). No existing behaviour changed.

## Verified
Exercised at runtime via the BusterBlock NpcCombat AutoTests + the `NpcRetaliatesWhenHit` Gauntlet run (the AS binding is hit on a real chase). Rebased onto current `dev` (`a7fa87a9c`).
