### PR TITLE
fix(iskm): drive socket-follower scene-node descendants in Finalize

### DIFF
--- a/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Processor.cpp
+++ b/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Processor.cpp
@@ -3,6 +3,8 @@
 #include "CkCore/Validation/CkIsValid.h"
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 #include "CkEcs/Scheduler/CkProcessorRegistration.h"
+#include "CkEcsExt/SceneNode/CkSceneNode_Fragment.h"
+#include "CkEcsExt/SceneNode/CkSceneNode_Utils.h"
 #include "CkEcsExt/Transform/CkTransform_Utils.h"
 
 #include "CkIskmRenderer/AnimCollection/CkIskmAnimCollection_Fragment_Data.h"
@@ -22,6 +24,7 @@
 
 DECLARE_CYCLE_STAT(TEXT("Iskm::UpdateTransform"),    STAT_CkIskm_UpdateTransform,    STATGROUP_CkIskmRenderer);
 DECLARE_CYCLE_STAT(TEXT("Iskm::SocketFollowerSync"), STAT_CkIskm_SocketFollowerSync, STATGROUP_CkIskmRenderer);
+DECLARE_CYCLE_STAT(TEXT("Iskm::SocketFollowerSyncDescendants"), STAT_CkIskm_SocketFollowerSyncDescendants, STATGROUP_CkIskmRenderer);
 DECLARE_CYCLE_STAT(TEXT("Iskm::EmitFinishedEvents"), STAT_CkIskm_EmitFinishedEvents, STATGROUP_CkIskmRenderer);
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -316,6 +319,72 @@ namespace ck
         {
             InHandle.AddOrGet<FTag_Transform_Updated>();
         }
+    }
+
+    auto
+        FProcessor_IskmProxy_SocketFollower_SyncDescendants::
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            const FFragment_Transform& InTransform,
+            const FFragment_IskmProxy_SocketFollower& InFollower) const
+        -> void
+    {
+        SCOPE_CYCLE_COUNTER(STAT_CkIskm_SocketFollowerSyncDescendants);
+
+        // FTag_Transform_Updated is deliberately NOT a view requirement: this body ADDS that tag to
+        // descendant (non-follower) entities, and mutating a pool the view iterates would invalidate
+        // iteration. Gate on the follower's own tag here instead — it is set by SyncTransform (same
+        // group, RunAfter) the frames the follower actually moved, and only descendants inherit motion.
+        if (NOT InHandle.Has<FTag_Transform_Updated>())
+        { return; }
+
+        DoSync_Descendants(InHandle, InTransform.Get_Transform());
+    }
+
+    auto
+        FProcessor_IskmProxy_SocketFollower_SyncDescendants::
+        DoSync_Descendants(
+            FCk_Handle_Transform InParent,
+            const FTransform& InParentWorld)
+        -> void
+    {
+        UCk_Utils_SceneNode_UE::ForEach_SceneNode(InParent, [&](FCk_Handle_SceneNode InChild)
+        {
+            if (InChild.Has<FFragment_SceneNode_UnrealAnchor>())
+            { return; }
+
+            // A descendant that is itself a socket follower drives its own pose (and subtree) via
+            // SyncTransform + this same SyncDescendants pass; recomputing it here as relative*parentWorld
+            // would contest that. Followers must be scene-node leaves w.r.t. another follower.
+            if (InChild.Has<FFragment_IskmProxy_SocketFollower>())
+            { return; }
+
+            // Same skip contract as TProcessor_SceneNode_Update: anchor-authoritative children
+            // (RootComponent/MeshSocket without ExternallyDriven) are driven by their anchors.
+            if (InChild.Has_Any<FFragment_Transform_MeshSocket, FFragment_Transform_RootComponent>() &&
+                NOT InChild.Has<FTag_Transform_ExternallyDriven>())
+            { return; }
+
+            const auto NewTransform = InChild.Get<FFragment_SceneNode_Current>().Get_RelativeTransform() * InParentWorld;
+
+            auto ChildAsTransform = UCk_Utils_Transform_UE::Cast(InChild);
+            // Guaranteed-present Get (scene nodes always carry FFragment_Transform, added by
+            // SceneNode Add/Create), so this never structurally inserts into a view-member pool
+            // mid-iteration. Descendants are assumed non-replicating (held presentation); a replicating
+            // node parented under a follower would need OR-merged _ComponentsModified vs the canonical pass.
+            auto& ChildTransform = ChildAsTransform.AddOrGet<FFragment_Transform>();
+
+            // Unchanged parent-derived pose means the whole subtree below is unchanged too.
+            if (ChildTransform.Get_Transform().Equals(NewTransform))
+            { return; }
+
+            auto& ChildPrevTransform = ChildAsTransform.AddOrGet<FFragment_Transform_Previous>();
+            UCk_Utils_Transform_UE::Apply_SetTransform_DirectWrite(ChildTransform, ChildPrevTransform, NewTransform);
+            ChildAsTransform.AddOrGet<FTag_Transform_Updated>();
+
+            DoSync_Descendants(ChildAsTransform, NewTransform);
+        });
     }
 
     auto
@@ -1090,5 +1159,6 @@ CK_REGISTER_PROCESSOR(ck::FProcessor_IskmProxy_Setup);
 CK_REGISTER_PROCESSOR(ck::FProcessor_IskmProxy_HandleRequests);
 CK_REGISTER_PROCESSOR(ck::FProcessor_IskmProxy_UpdateTransform);
 CK_REGISTER_PROCESSOR(ck::FProcessor_IskmProxy_SocketFollower_SyncTransform);
+CK_REGISTER_PROCESSOR(ck::FProcessor_IskmProxy_SocketFollower_SyncDescendants);
 CK_REGISTER_PROCESSOR(ck::FProcessor_IskmProxy_EmitFinishedEvents);
 CK_REGISTER_PROCESSOR(ck::FProcessor_IskmProxy_EndPlay);

--- a/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Processor.h
+++ b/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Processor.h
@@ -168,6 +168,42 @@ namespace ck
             const FFragment_IskmProxy_SocketFollower& InFollower) const -> void;
     };
 
+    // Companion to SyncTransform (above). That pass runs in Finalize so scene-node-driven LEADERS are
+    // fresh — but Finalize is after TProcessor_SceneNode_Update (FGroup_Transform), so scene-node
+    // CHILDREN parented under a follower's output (e.g. a held item under a hand attach-point, plus
+    // that item's own probe children) would read the follower's FTag_Transform_Updated one group too
+    // late: Transform_Cleanup wipes the tag before the next frame's gate check, so after their
+    // construct-time one-shot they freeze at the follower's equip-time pose. This pass recomputes the
+    // follower's scene-node descendant subtree in place (same composition + anchor-skip contract as
+    // TProcessor_SceneNode_Update) right after the follower writes, and runs before SyncToActor so
+    // the recomputed poses land on their actors the same frame.
+    class CKISKMRENDERER_API FProcessor_IskmProxy_SocketFollower_SyncDescendants : public ck_exp::TProcessor<
+        FProcessor_IskmProxy_SocketFollower_SyncDescendants,
+        FCk_Handle_Transform,
+        TReadOnly<FFragment_Transform>,
+        TReadOnly<FFragment_IskmProxy_SocketFollower>,
+        CK_IGNORE_PENDING_KILL>
+    {
+    public:
+        using Group = FGroup_Transform_Finalize;
+        using RunAfter = TDepList<FProcessor_IskmProxy_SocketFollower_SyncTransform>;
+        using RunBefore = TDepList<FProcessor_Transform_SyncToActor>;
+    public:
+        using TProcessor::TProcessor;
+        auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            const FFragment_Transform& InTransform,
+            const FFragment_IskmProxy_SocketFollower& InFollower) const -> void;
+
+    private:
+        static auto
+        DoSync_Descendants(
+            FCk_Handle_Transform InParent,
+            const FTransform& InParentWorld) -> void;
+    };
+
     class CKISKMRENDERER_API FProcessor_IskmProxy_EmitFinishedEvents : public ck_exp::TProcessor<
         FProcessor_IskmProxy_EmitFinishedEvents,
         FCk_Handle_IskmProxy,


### PR DESCRIPTION
## Problem

Held items stopped following the hand. A held weapon parented under the player's
RightHand attach point (an IskM socket follower) froze in world space at its equip
pose; its hitbox probe (a scene-node child of the weapon) froze with it, so it only
damaged an NPC when the stationary weapon was adjacent.

## Root cause

Regression from `d3407146c` ("fix(iskm-lod): order SocketFollower after full
Transform group"). That commit moved `FProcessor_IskmProxy_SocketFollower_SyncTransform`
from `FGroup_Transform` to `FGroup_Transform_Finalize` so a follower reads a
scene-node-*driven leader* fresh — a genuine fix. But the follower's output feeds
scene-node *children*, whose `TProcessor_SceneNode_Update` runs in the earlier
`FGroup_Transform`, gated on the parent carrying `FTag_Transform_Updated`. The
follower now sets that tag one group too late (Finalize), and
`FProcessor_Transform_Cleanup` wipes it each frame, so children recompute once
(their construct-time one-shot) and then freeze.

It's a cross-group producer/consumer inversion: the follower must run *after* its
leader (which may itself be a scene-node child) yet *before* its own scene-node
children. One group placement can't satisfy both.

## Fix

Leave `SyncTransform` in `FGroup_Transform_Finalize` (byte-identical — the cosmetic
fix is preserved) and add a companion `FProcessor_IskmProxy_SocketFollower_SyncDescendants`
in the same group, `RunAfter` the follower and `RunBefore` `FProcessor_Transform_SyncToActor`.
For each follower that moved this frame it DFS-recomputes the follower's scene-node
descendant subtree (`world = relative * parentWorld`, mirroring `TProcessor_SceneNode_Update`'s
composition and anchor-skip), stamping `FTag_Transform_Updated` so `SyncToActor`
pushes actor-backed descendants the same frame. Purely additive (+106/−0).

## Notes for review

- **Serial processor**, so the immediate `AddOrGet` on descendants is the sanctioned
  form (parallel processors defer; this isn't one). Precedent for a processor
  mutating foreign entities in its body: `FProcessor_2dGridOccupancy_StampCells`.
- The view intentionally excludes `FTag_Transform_Updated` (gated in the body) so
  the descendant tag-adds never mutate a pool the view iterates.
- Guards nested followers (must be scene-node leaves) and documents the
  non-replicating-descendant assumption.

## Verification

- Adversarial 3-pass audit (EnTT-safety, CkF idiom, fidelity to
  `TProcessor_SceneNode_Update`): SOUND, no must-fix.
- PIE: held weapon + hitbox track the hand; NPC cosmetics stay locked (no return
  of the `d3407146c` trail).
- Full IskM autotest suite green; new regression test
  `Ck_AutoTest_IskmRenderer_SocketFollowerDrivesChild` red→green (companion CkTests PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
