### PR TITLE
fix(iskm): track world socket during ragdoll so cosmetics stay attached

### DIFF
--- a/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Fragment.h
+++ b/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Fragment.h
@@ -158,6 +158,13 @@ namespace ck
     // only moved at PostTransform — and the follower trails by one frame of
     // velocity. Component-space sampling keeps only the animation pose a frame
     // stale (sub-cm) while the root-motion term is always current.
+    //
+    // EXCEPTION — ragdoll: the entity-transform root is only valid while UpdateTransform
+    // keeps the SKMC at the entity transform. During ragdoll physics owns the SKMC and
+    // UpdateTransform is excluded (TExclude<FTag_IskmProxy_Ragdolling>), so the entity
+    // transform is frozen at the death pose. SyncTransform then reads the WORLD-space
+    // socket directly (no entity root, no _LocalLocationOffset) so the follower stays on
+    // the physics pose. See FProcessor_IskmProxy_SocketFollower_SyncTransform.
     struct CKISKMRENDERER_API FFragment_IskmProxy_SocketFollower
     {
     public:

--- a/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Processor.cpp
+++ b/Source/CkIskmRenderer/Public/CkIskmRenderer/Proxy/CkIskmProxy_Processor.cpp
@@ -291,20 +291,40 @@ namespace ck
         if (ck::Is_NOT_Valid(Leader))
         { return; }
 
-        // Component-space socket = pure animation pose (the SKMC's world placement
-        // is deliberately NOT consulted — it is one frame stale by construction);
-        // the root term comes from the leader's live entity transform instead.
-        const auto SocketComponentSpace = ::UCk_Utils_IskmProxy_UE::Get_SocketTransform(
-            Leader, InFollower.Get_Socket(), ECk_IskmProxy_TransformSpace::Component);
+        auto NewTransform = FTransform::Identity;
 
-        auto LeaderTransform = ::UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentTransform(Leader);
-        // Compose the leader's render offset into the root so followers track the *offset* body
-        // rather than the entity origin — must match FProcessor_IskmProxy_UpdateTransform's SKMC
-        // placement (line ~258), or cosmetics float by the offset (e.g. a Character's capsule half-height).
-        const auto LeaderOffset = Leader.Get<FFragment_IskmProxy_Current>().Get_LocalLocationOffset();
-        LeaderTransform.AddToTranslation(LeaderTransform.GetRotation().RotateVector(LeaderOffset));
+        if (Leader.Has<FTag_IskmProxy_Ragdolling>())
+        {
+            // Ragdoll breaks the component-space composition below. Physics now owns the SKMC world
+            // pose, and FProcessor_IskmProxy_UpdateTransform (TExclude<FTag_IskmProxy_Ragdolling>)
+            // stops pushing the entity transform onto it — so the leader's ENTITY transform is frozen
+            // at the death pose while the SKMC drifts. Re-anchoring the live component-space socket
+            // onto that stale root sends the follower off on its own (the hair-detach bug). Read the
+            // physics-authoritative WORLD socket instead: it is the exact pose the leader body renders
+            // from, so the follower stays glued to it. It already carries ComponentToWorld, so the
+            // entity-space _LocalLocationOffset must NOT be re-added here (that would double-count it).
+            const auto SocketWorldSpace = ::UCk_Utils_IskmProxy_UE::Get_SocketTransform(
+                Leader, InFollower.Get_Socket(), ECk_IskmProxy_TransformSpace::World);
 
-        const auto NewTransform = InFollower.Get_Offset() * SocketComponentSpace * LeaderTransform;
+            NewTransform = InFollower.Get_Offset() * SocketWorldSpace;
+        }
+        else
+        {
+            // Component-space socket = pure animation pose (the SKMC's world placement
+            // is deliberately NOT consulted — it is one frame stale by construction);
+            // the root term comes from the leader's live entity transform instead.
+            const auto SocketComponentSpace = ::UCk_Utils_IskmProxy_UE::Get_SocketTransform(
+                Leader, InFollower.Get_Socket(), ECk_IskmProxy_TransformSpace::Component);
+
+            auto LeaderTransform = ::UCk_Utils_Transform_TypeUnsafe_UE::Get_EntityCurrentTransform(Leader);
+            // Compose the leader's render offset into the root so followers track the *offset* body
+            // rather than the entity origin — must match FProcessor_IskmProxy_UpdateTransform's SKMC
+            // placement (line ~258), or cosmetics float by the offset (e.g. a Character's capsule half-height).
+            const auto LeaderOffset = Leader.Get<FFragment_IskmProxy_Current>().Get_LocalLocationOffset();
+            LeaderTransform.AddToTranslation(LeaderTransform.GetRotation().RotateVector(LeaderOffset));
+
+            NewTransform = InFollower.Get_Offset() * SocketComponentSpace * LeaderTransform;
+        }
 
         if (InTransform.Get_Transform().Equals(NewTransform))
         { return; }


### PR DESCRIPTION
## Summary

NPC hair — and any CharacterCustomizer cosmetic that socket-follows an IskM proxy — detaches and flies off when the wearer is ragdolled: it rides the ragdoll's bone motion but stays anchored at the frozen death-pose world root. This fixes the socket-follower's transform composition during ragdoll.

Long-standing: broken since the IskM socket-follower was introduced (nobody had ragdolled a cosmetic-wearing NPC). Independent of the recent held-item scene-node-follow fix (#682) — that was the Finalize-group ordering for scene-node *children*; this is the follower's own root during ragdoll.

## Root cause

`FProcessor_IskmProxy_SocketFollower_SyncTransform` composes the follower as:

```
Offset × Socket(Component) × LeaderEntityTransform
```

That entity-transform root is only valid while `FProcessor_IskmProxy_UpdateTransform` keeps the SKMC pinned to the leader's entity transform. During ragdoll:

- `BeginRagdoll` → `SetSimulatePhysics(true)`: **physics now owns the SKMC world pose.**
- `UpdateTransform` carries `TExclude<FTag_IskmProxy_Ragdolling>`: the entity→SKMC push **stops.**
- Nothing writes the physics pose back into the leader's `FFragment_Transform`: the **entity transform freezes at the death pose** while the SKMC drifts.

So the follower re-anchors the live component-space socket onto a stale root → it moves *with* the ragdoll but offset in the air ("a life of its own").

## Fix

Branch on the leader's ragdoll tag and read the physics-authoritative **world** socket directly:

```cpp
if (Leader.Has<FTag_IskmProxy_Ragdolling>())
    NewTransform = Offset × Socket(World);                          // the exact pose the body renders from
else
    NewTransform = Offset × Socket(Component) × LeaderEntityTransform;  // unchanged
```

`Socket(World)` already carries `ComponentToWorld`, so the `_LocalLocationOffset` term is **dropped** — re-adding it would double-count and shift the cosmetic down by a capsule half-height.

## Blast radius

The non-ragdoll path is byte-identical, so every follower whose leader never ragdolls (player held weapon/cosmetics, scooter, candy-dealer head) is unaffected. The only in-game ragdoll consumer is the NPC downed task, whose leader is the proxy the hair follows. `SyncDescendants` needs no change (it recomputes from the follower's now-correct transform).

## Verification (headless, UnrealToolbox)

Regression test `Ck_AutoTest_IskmRenderer_SocketFollowerTracksRagdoll` — CkTests chainkemists/CkTests#44:

| Build | Result |
|---|---|
| with fix | 33/33 ✅ (follower tracks the world socket) |
| ablated (else-branch forced) | 32/33 ❌ — **only** this test, follower delta **9999.8 cm** |
| fix restored | 33/33 ✅ |

Full IskmRenderer suite green, no regressions; AS compiled clean.

**[EDITOR-VERIFY]** PIE (agents can't PIE): kill a hair-wearing NPC → the hair should stay glued to the ragdolling head through the fall — not floating at the death spot, and not shifted down by a capsule half-height (which would mean the `_LocalLocationOffset` term was wrongly kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
