### PR TITLE
feat(asset-exporter): freshness banner heads every summary txt

### DIFF
--- a/Source/CkAssetExporter/Claude.md
+++ b/Source/CkAssetExporter/Claude.md
@@ -25,7 +25,15 @@ commandlet command line. Components:
 - `ExportMeta/` — deterministic `_meta` (source .uasset MD5 + per-exporter version constant)
   stamped in every sibling `.json`; powers `-SkipFresh` (hash AND version must match). Bump the
   version constant whenever an exporter's output shape changes. NO timestamps in any export
-  output (write-if-changed sweeps + clean diffs depend on it).
+  output (write-if-changed sweeps + clean diffs depend on it). The json is the ONLY sibling
+  carrying `_meta` — `.txt`/`.csv`/WBP paste-artifact siblings carry none of their own, but all
+  siblings of an asset are written in the SAME export call, so the json's `_meta` verdict covers
+  every sibling. **Freshness banner (2026-07-19):** every human-readable summary `.txt` from the
+  seven exporters (DataAsset/Blueprint/BehaviorTree/EQS/StateTree/UserDefinedEnum/
+  UserDefinedStruct) now opens with a deterministic 3-line banner pointing at the sibling json's
+  `_meta` as the freshness oracle. Deliberately NO version bump for this change — the banner is
+  txt-only, txt was never freshness-gated (`-SkipFresh` only ever checked the json's `_meta`),
+  and the committed json corpus is byte-unchanged.
 - `Server/` — `FCk_AssetExporter_RequestProcessor` (shared core) + the `-ExportServer` loop:
   polls `Saved/CkAssetExporter/Requests/*.json` (`op: export | list | dumpGraph | quit`), writes
   `Results/<basename>.json`, advertises via `server.json` (pid, dirs, `busy`/`currentOp`/
@@ -42,7 +50,11 @@ commandlet command line. Components:
 - `BlueprintExporter/CkWidgetPasteArtifacts` — WBP exports also emit `<Base>.hierarchy.copy.txt`
   (byte-identical to the UMG Designer's Ctrl+C clipboard text — paste-ready into another WBP;
   format stable 5.5↔5.7) and per-animation `.t3d.txt` reference dumps (NOT pasteable — the
-  Designer has no paste-animation path).
+  Designer has no paste-animation path). Neither carries the freshness banner by design — byte
+  identity to the clipboard format forbids any prepended text; the sibling json's `_meta` is
+  their freshness oracle instead (same all-siblings-one-export-call rule as `ExportMeta/` above).
+  Committed under `Content/BusterBlock` in the legacy superproject (`BusterBlock_5-5`) as the WBP
+  porting source of truth; stay machine-local/gitignored in current-repo consumers.
 
 **Depends on:** `CkAi`, `CkCore`, `CkEcs`, `CkLog` (+ engine editor modules incl. UMGEditor).
 **Used by:** Agent/pipeline tooling; superprojects via `Export-CkAssets.ps1` + their

--- a/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.cpp
@@ -455,7 +455,7 @@ auto
         const UBehaviorTree* InBehaviorTree)
     -> FString
 {
-    auto Text = FString{};
+    auto Text = FCk_AssetExportMeta::Get_SummaryTextBanner(InBehaviorTree->GetName());
 
     Text += FString::Printf(TEXT("=== Behavior Tree: %s ===\n"), *InBehaviorTree->GetName());
     Text += FString::Printf(TEXT("Path: %s\n"), *InBehaviorTree->GetPathName());

--- a/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.cpp
@@ -1030,7 +1030,7 @@ auto
         const UBlueprint* InBlueprint)
     -> FString
 {
-    auto Text = FString{};
+    auto Text = FCk_AssetExportMeta::Get_SummaryTextBanner(InBlueprint->GetName());
 
     // Header
     Text += ck::Format_UE(TEXT("=== Blueprint: {} ===\n"), InBlueprint->GetName());

--- a/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.cpp
@@ -555,7 +555,7 @@ auto
         const UDataAsset* InDataAsset)
     -> FString
 {
-    auto Text = FString{};
+    auto Text = FCk_AssetExportMeta::Get_SummaryTextBanner(InDataAsset->GetName());
 
     Text += ck::Format_UE(TEXT("=== DataAsset: {} ===\n"), InDataAsset->GetName());
     Text += ck::Format_UE(TEXT("Path: {}\n"), InDataAsset->GetPathName());

--- a/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.cpp
@@ -305,7 +305,7 @@ auto
         const UEnvQuery* InQuery)
     -> FString
 {
-    auto Text = FString{};
+    auto Text = FCk_AssetExportMeta::Get_SummaryTextBanner(InQuery->GetName());
 
     Text += FString::Printf(TEXT("=== EQS Query: %s ===\n"), *InQuery->GetName());
     Text += FString::Printf(TEXT("Path: %s\n"), *InQuery->GetPathName());

--- a/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.cpp
@@ -141,3 +141,19 @@ auto
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_AssetExportMeta::
+    Get_SummaryTextBanner(
+        const FString& InAssetName)
+    -> FString
+{
+    return FString::Printf(
+        TEXT("// [CkAssetExporter] Human-readable companion - carries NO freshness metadata.\n")
+        TEXT("// Freshness oracle: sibling %s.json \"_meta\" (source-asset MD5 + exporter version);\n")
+        TEXT("// its verdict covers this file (all siblings are written in the same export call).\n")
+        TEXT("\n"),
+        *InAssetName);
+}
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h
@@ -68,6 +68,13 @@ public:
         const UObject* InAsset,
         const FString& InSiblingJsonPath,
         int32 InCurrentExporterVersion) -> bool;
+
+    // Header prepended to every human-readable summary .txt sibling. The txt carries no "_meta" of its own — this
+    // banner points readers at the sibling json, whose freshness verdict covers the txt because both are written in
+    // the same export call. Deterministic (no timestamp) like every other export output.
+    static auto
+    Get_SummaryTextBanner(
+        const FString& InAssetName) -> FString;
 };
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.cpp
@@ -390,7 +390,7 @@ auto
         const UStateTree* InStateTree)
     -> FString
 {
-    auto Text = FString{};
+    auto Text = FCk_AssetExportMeta::Get_SummaryTextBanner(InStateTree->GetName());
 
     Text += FString::Printf(TEXT("=== State Tree: %s ===\n"), *InStateTree->GetName());
     Text += FString::Printf(TEXT("Path: %s\n"), *InStateTree->GetPathName());

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.cpp
@@ -185,7 +185,7 @@ auto
 {
     using namespace ck_user_defined_enum_exporter_internal;
 
-    auto Text = FString{};
+    auto Text = FCk_AssetExportMeta::Get_SummaryTextBanner(InEnum->GetName());
 
     Text += ck::Format_UE(TEXT("=== UserDefinedEnum: {} ===\n"), InEnum->GetName());
     Text += ck::Format_UE(TEXT("Path: {}\n"), InEnum->GetPathName());

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.cpp
@@ -211,7 +211,7 @@ auto
 {
     using namespace ck_user_defined_struct_exporter_internal;
 
-    auto Text = FString{};
+    auto Text = FCk_AssetExportMeta::Get_SummaryTextBanner(InStruct->GetName());
 
     Text += ck::Format_UE(TEXT("=== UserDefinedStruct: {} ===\n"), InStruct->GetName());
     Text += ck::Format_UE(TEXT("Path: {}\n"), InStruct->GetPathName());

--- a/Source/CkAssetExporter/Tests/Test_AssetExporterDispatch.cpp
+++ b/Source/CkAssetExporter/Tests/Test_AssetExporterDispatch.cpp
@@ -148,6 +148,28 @@ bool FCk_AssetExporter_Dispatch_ExportMetaRoundTrip_Test::RunTest(const FString&
 }
 
 // --------------------------------------------------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCk_AssetExporter_Dispatch_SummaryTextBanner_Test,
+    "Ck.AssetExporter.Dispatch.SummaryTextBanner",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FCk_AssetExporter_Dispatch_SummaryTextBanner_Test::RunTest(const FString& InParameters)
+{
+    const auto Banner = FCk_AssetExportMeta::Get_SummaryTextBanner(TEXT("MyAsset"));
+
+    TestTrue(TEXT("banner opens with the module tag"), Banner.StartsWith(TEXT("// [CkAssetExporter]")));
+    TestTrue(TEXT("banner names the sibling json"), Banner.Contains(TEXT("MyAsset.json")));
+    TestTrue(TEXT("banner points at _meta"), Banner.Contains(TEXT("\"_meta\"")));
+    TestTrue(TEXT("banner ends with a blank separator line"), Banner.EndsWith(TEXT("\n\n")));
+
+    // Deterministic — same input, byte-identical output (no timestamps), like every other export output.
+    TestEqual(TEXT("banner is deterministic"), Banner, FCk_AssetExportMeta::Get_SummaryTextBanner(TEXT("MyAsset")));
+
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
 // Graph-dump shape check against a tiny real content dir. No env gating — MembershipBoard is small and always present.
 // --------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

The summary `.txt` sidecars carried no `_meta` — an agent grepping a machine-local txt got no staleness warning and no pointer to the json. The sibling `.json` is the corpus of record; its `_meta` (source MD5 + exporter version) is the freshness contract.

## What

- Every `DoSerializeToText` (DataAsset/Blueprint/BT/EQS/StateTree/Enum/Struct) now opens with a deterministic 3-line banner naming the sibling json as the freshness oracle — all siblings of an asset are written in the same export call, so the json verdict covers each of them.
- New shared helper `FCk_AssetExportMeta::Get_SummaryTextBanner` + shape test (`Ck.AssetExporter.Dispatch.SummaryTextBanner`).
- Module doc: all-siblings freshness rule, banner, no-version-bump rationale; WBP paste-artifact bullet notes they carry no banner by design (clipboard byte-identity) and are committed in the legacy superproject as the porting source.

**Deliberately NO exporter version bumps** — banner is txt-only, txt was never freshness-gated (`-SkipFresh` reads only json `_meta`), committed json corpus is byte-identical.

## Gate

- `/build-test` Development: 6/6 `Ck.AssetExporter` tests (incl. new banner test).
- Commandlet run over BP/WBP/DataTable/DataAsset: banners present; WBP `hierarchy.copy.txt` banner-free clipboard-native; `LastRun.json` schema unchanged (csv still rides the `txt` column for DataTables); `git status` — zero committed-json diffs after regen; `-SkipFresh` rerun all-skipped.
- Same change synced to legacy `feature/5.5-temporary` (built + commandlet-verified there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)