### PR TITLE
fix(CkEcs): pump-limit advisory emits as one log entry, not N+1

### DIFF
--- a/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorScheduler.cpp
+++ b/Source/CkEcs/Public/CkEcs/Scheduler/CkProcessorScheduler.cpp
@@ -370,13 +370,23 @@ auto
     _LastPumpWarningTime = InNow;
     _LastWarnedStillDirtyNames = StillDirtyNames;
 
-    ck::ecs::Warning(TEXT("Pump limit [{}] reached. Still dirty: [{}]"),
-        _MaxPumpIterations, StillDirtyNames.Num());
-
+    // The per-processor breakdown rides INSIDE the header's message rather than as N
+    // follow-up Warnings. Consumers that suppress this advisory (CkTests' AutoTest runner
+    // default-suppression list) match one Contains pattern against a whole log entry — a
+    // separate "  - [Name]" line is its own entry, slips the pattern, and fails otherwise-
+    // passing tests. One entry also collapses N+1 trips through the log pipeline into one.
+    auto Breakdown = FString{};
+    constexpr auto ApproxCharsPerEntry = 48;
+    Breakdown.Reserve(StillDirtyNames.Num() * ApproxCharsPerEntry);
     for (const auto& Name : StillDirtyNames)
     {
-        ck::ecs::Warning(TEXT("  - [{}]"), Name);
+        Breakdown += TEXT("\n  - [");
+        Breakdown += Name.ToString();
+        Breakdown += TEXT("]");
     }
+
+    ck::ecs::Warning(TEXT("Pump limit [{}] reached. Still dirty: [{}]{}"),
+        _MaxPumpIterations, StillDirtyNames.Num(), Breakdown);
 }
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`FProcessorScheduler::DoLogPumpLimitReached` emits its still-dirty breakdown as N separate `ck::ecs::Warning` calls:

```cpp
ck::ecs::Warning(TEXT("Pump limit [{}] reached. Still dirty: [{}]"), ...);
for (const auto& Name : StillDirtyNames)
{ ck::ecs::Warning(TEXT("  - [{}]"), Name); }
```

Expected-error suppression matches `Contains` **per log entry**, so a continuation line is its own entry. CkTests' AutoTest runner has carried `TEXT("Pump limit [")` in `GDefaultPlainPatterns` since `249daf4` ("don't fail autotests on CkEcs pump-saturation perf advisories"), but that pattern can only ever match the header — the `"  - [Name]"` lines slip through and reach the harness as unsuppressed warnings.

This shape predates the suppression by ten weeks (`22e5e5a2f`, 2026-04-06), so the suppression was incomplete from the day it was written. It was worked around locally twice in BusterBlock's DeliveryTruck tests rather than fixed here.

## Impact

Three BusterBlock `CheckoutCounter` AutoTests failed while passing **every one of their own assertions** — the harness failed them purely on the leaked detail lines. Because the advisory is throttled to 5s and the scheduler's throttle state is shared across sequentially-run tests in one PIE world, which test gets hit is order-dependent, making it intermittent and hard to attribute.

## Fix

Fold the breakdown into the header's message. One entry, one `Contains` match, indented layout unchanged:

```
CkEcs: Warning: Pump limit [30] reached. Still dirty: [41]
  - [class ck::FProcessor_EntityTag_HandleRequests]
  - [class ck::FProcessor_Timer_Setup]
  ...
```

No suppression-list change needed anywhere — the existing single pattern now covers the whole advisory.

## Verification

- Worst case observed in a full-suite run: **167 processors, all 167 detail lines rendered, no truncation**, block terminating cleanly into the next entry.
- Log entries per burst drop from 167 to 1 (N+1 → 1 trips through the log pipeline).
- BusterBlock full AutoTest suite on this build: **1154/1156**, the 2 failures inherited and byte-identical to a pre-change baseline (`CharacterCustomizer_RandomizedAppearance`, `SideHustleLeveling_LevelByVerb`).
- The three affected CheckoutCounter tests now pass; so do both DeliveryTruck tests with their local workarounds removed.

## Notes for review

- Uses plain `FString` concatenation rather than `ck::Format_UE` — that TU includes only `CkEcsLog.h` / `CkEcs_Settings.h` / `CkStats.h`, and the format header isn't obviously reachable.
- Trade-off: detail lines no longer carry a per-line `[timestamp][frame]CkEcs: Warning:` prefix. Every field in it was byte-identical to the header (same call, same millisecond), so no information is lost — but a **line**-oriented category filter will show those rows as uncategorised. Worth a look if the team's log viewer filters that way.
- Separately worth someone's attention: the saturation itself is real — 41–167 processors still dirty after 30 pump passes. This PR only stops it failing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
