### PR TITLE
feat(CkAngelscriptGenerator): read-only boots can decline regen ownership (-CkAsDeclineRegenOwnership)

### DIFF
--- a/Source/CkAngelscriptGenerator/CkAngelscriptGenerator_RegenOwnership.cpp
+++ b/Source/CkAngelscriptGenerator/CkAngelscriptGenerator_RegenOwnership.cpp
@@ -9,6 +9,7 @@
 #include <HAL/PlatformFileManager.h>
 #include <HAL/PlatformProcess.h>
 #include <Misc/CommandLine.h>
+#include <Misc/Parse.h>
 #include <Misc/Paths.h>
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -20,6 +21,7 @@ namespace ck_angelscript_generator_regen_ownership
     TUniquePtr<IFileHandle> sLockHandle;
     bool sWarnedSecondaryOnce = false;
     bool sWasSecondary        = false;
+    bool sWarnedDeclineOnce   = false;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -33,6 +35,28 @@ auto
     CK_ENSURE_IF_NOT(IsInGameThread(),
         TEXT("RegenOwnership gate [{}] called off the game thread"), FString{InGateSite})
     { return false; }
+
+    // Read-only boots (the toolbox's `Automation List; Quit` inline-discovery editor) pass
+    // -CkAsDeclineRegenOwnership: they only enumerate tests, so they must NEVER take the regen
+    // lock. If they did, a REAL test editor booting concurrently (the `--build --test`
+    // inline-discovery race) loses the lock, runs as SECONDARY with self-heal DISABLED, and can
+    // silently run stale bytecode ("Keeping all old script code") — the toolbox false-green.
+    // Declining here leaves the lock free for the test editor to own and self-heal as PRIMARY.
+    static const auto DeclineRegenOwnership =
+        FParse::Param(FCommandLine::Get(), TEXT("CkAsDeclineRegenOwnership"));
+    if (DeclineRegenOwnership)
+    {
+        if (NOT ck_angelscript_generator_regen_ownership::sWarnedDeclineOnce)
+        {
+            ck_angelscript_generator_regen_ownership::sWarnedDeclineOnce = true;
+            ck::angelscriptgenerator::Log(
+                TEXT("[RegenOwnership] -CkAsDeclineRegenOwnership set — this read-only boot declines ")
+                TEXT("Script/Generated ownership at every gate (first: [{}]); the lock is left free ")
+                TEXT("for a concurrent test editor. Generator writes + self-heal are inert here."),
+                FString{InGateSite});
+        }
+        return false;
+    }
 
     if (ck_angelscript_generator_regen_ownership::sLockHandle.IsValid())
     { return true; }


### PR DESCRIPTION
## What

Adds a `-CkAsDeclineRegenOwnership` CLI flag. When present, `FCkAngelscriptGenerator_RegenOwnership::Try_AcquireOrGet_IsOwner` returns `false` without opening the lock — the boot declines regen ownership at every gate.

## Why

The UnrealToolbox `--build --test` flow spawns a concurrent inline-discovery editor (`Automation List; Quit`) alongside the real test editor. Both race for the `RegenOwner` lock. When the read-only list boot wins, the **test** editor runs as SECONDARY with self-heal disabled → it can compile stale AngelScript (`Keeping all old script code`) and silently run the OLD tests — a false-green.

This flag lets the toolbox mark its read-only discovery boot so it never competes: the test editor always owns regen and self-heals as PRIMARY. Removes the race at its source.

- Scoped to the **inline** discovery boot only (the toolbox does not pass it to the dedicated `--discover-fresh` boot, which can be the sole editor and may legitimately need to self-heal).
- Orthogonal to the existing `-NoCkAsRegen` (which only skips self-heal hook *registration*, not lock acquisition).

## Verification

Proven end-to-end via `--build --test` on a BusterBlock project: the discovery editor logged the decline at `Module.StartupModule`, zero `runs as SECONDARY` in the run's logs, tests 9/9 exit 0. Paired with the toolbox change that passes the flag (UnrealToolbox v1.18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)