### PR TITLE
fix(CkCore): accept FCk_Entity in dynamic-fragment schema validation

### DIFF
--- a/Source/CkCore/Public/CkCore/Validation/CkUntracedStructSafety.cpp
+++ b/Source/CkCore/Public/CkCore/Validation/CkUntracedStructSafety.cpp
@@ -23,6 +23,19 @@ namespace ck_untraced_struct_safety
             InStruct->GetPropertiesSize() == 0;
     }
 
+    auto IsApprovedGcIndependentStruct(const UScriptStruct* InStruct) -> bool
+    {
+        // Allowlist of native structs certified to retain no untraced UObject reference, matched by reflected path so
+        // foundational CkCore need not link against the modules that declare them (same rationale as IsAngelScriptStruct).
+        //
+        // FCk_Entity holds only an entt::entity integer id; its int32 mirror fields exist solely for the editor debugger
+        // and are compiled out under WITH_EDITORONLY_DATA. A cooked build therefore sees zero reflected fields, so the
+        // field-less-struct heuristic below would otherwise reject every dynamic fragment / EntityScript spawn-param that
+        // embeds an FCk_Handle (its _Entity member is an FCk_Entity). The type is provably GC-independent, not opaque.
+        static const auto ApprovedPaths = TSet<FString>{TEXT("/Script/CkEcs.Ck_Entity")};
+        return InStruct != nullptr && ApprovedPaths.Contains(InStruct->GetPathName());
+    }
+
     auto Accept() -> FResult
     { return {.Safety = EResult::GcIndependent}; }
 
@@ -143,6 +156,9 @@ namespace ck_untraced_struct_safety
         if (NOT HasReflectedProperty)
         {
             if (IsAngelScriptStruct(InStruct))
+            { return Accept(); }
+
+            if (IsApprovedGcIndependentStruct(InStruct))
             { return Accept(); }
 
             return Reject(EResult::UnprovenOpaque, InPath,


### PR DESCRIPTION
## Summary

Fixes a **cooked-build-only** regression where every dynamic fragment / EntityScript spawn-param that embeds an `FCk_Handle` fails schema validation at entity construction, producing a storm of `Dynamic Fragment Add/AddOrGet rejected invalid input` AngelScript exceptions. Store systems never reach ready (game hangs on the loading screen) and the process eventually OOMs (~145 GiB virtual). **Editor/PIE never reproduces it.**

## Root cause

`Analyze_UntracedStructSafety` treats a native struct with no reflected `FProperty` fields as opaque/unproven and rejects it:

```
native/opaque struct [/Script/CkEcs.Ck_Entity] has no reflected fields and no approved GC contract
```

`FCk_Entity`'s only reflected UPROPERTYs (`_EntityID/_EntityNumber/_EntityVersion`) are `#if WITH_EDITORONLY_DATA` — debugger mirrors of its real payload, a plain `entt::entity` id. In a cooked build (`WITH_EDITORONLY_DATA=0`) it has **zero** reflected fields, so the walker rejects it. Every `FCk_Handle` contains `UPROPERTY(...) FCk_Entity _Entity;`, so the rejection cascades to essentially the whole gameplay entity layer (observed: 830 rejections across 88 AS entry points). In the editor the fields exist and the walker accepts — which is exactly why this is invisible until a real cook.

Regression from `8b039a323` ("fix(CkCore): reject unsafe untraced UObject payloads"), which introduced the validator. `FCk_Entity`'s editor-only reflection long predates it.

## The fix

Allowlist `/Script/CkEcs.Ck_Entity` as GC-independent, mirroring the existing `IsAngelScriptStruct` special-case (path-match so foundational CkCore needn't link CkEcs). `FCk_Entity` is *provably* GC-independent — it holds only an integer id, no UObject reference — so this is a certification, not a suppression. The conservative "no reflected fields → reject" default is unchanged for every other type.

## Verification

- ✅ Compiles + links (`Development` editor build, CkCore relinked clean).
- ⚠️ **The cooked path is the real gate** — an editor/PIE build runs `WITH_EDITORONLY_DATA=1`, where the bug cannot manifest, so a smoke cook + boot is the durable check (expected: no rejection storm, store reaches ready, no OOM).
- ⚠️ **No in-editor automation test can guard this** — a normal test passes before *and* after the fix. Please don't add a green in-editor test and assume it's protected; the guard is a cook, not a unit test.

If a cook surfaces a *different* `native/opaque struct [X] ...` rejection, that's another struct with the same editor-only-reflection shape — add its path to the same `ApprovedPaths` set. The reported log showed only `Ck_Entity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
