### PR TITLE
fix(CkCore): make the AS IsValid bind symbol unique per type, not per line

### DIFF
--- a/Source/CkCore/Public/CkCore/Validation/CkIsValid_AngelScript.h
+++ b/Source/CkCore/Public/CkCore/Validation/CkIsValid_AngelScript.h
@@ -64,7 +64,10 @@ inline auto CK_UNIQUE_NAME(Register_IsValid_##_type_no_ptr_)() -> void          
         return ck::Is_NOT_Valid(InObj);                                                    \
     });                                                                                    \
 };                                                                                         \
-AS_FORCE_LINK const FAngelscriptBinds::FBind CK_UNIQUE_NAME(Bind_IsValid_)(                \
+/* Type-qualified like Register_IsValid_ above: CK_UNIQUE_NAME only appends __LINE__, so a       \
+   bare Bind_IsValid_ is unique per LINE, not per file — two .cpp files in the same unity blob   \
+   whose invocations close on the same line emit the same symbol and fail to compile. */         \
+AS_FORCE_LINK const FAngelscriptBinds::FBind CK_UNIQUE_NAME(Bind_IsValid_##_type_no_ptr_)(  \
     FAngelscriptBinds::EOrder::Late,                                                       \
     [] { CK_UNIQUE_NAME(Register_IsValid_##_type_no_ptr_)(); }                             \
 );


### PR DESCRIPTION
**Un-reds `dev`.** My merged #692 broke the build — and it did so **without changing a single line of
code.** Symbol names here are generated from `__LINE__`, so a comment is load-bearing for
compilation. The landmine is still armed for everyone else, hence fixing the macro rather than my
line count.

## The machinery

```cpp
// CkMacros.h
#define CK_CONCAT_IMPL(a, b)   a##b
#define CK_CONCAT(a, b)        CK_CONCAT_IMPL(a, b)
#define CK_UNIQUE_NAME(prefix) CK_CONCAT(prefix, __LINE__)   // ← the whole problem
```

The last line of `CK_DEFINE_ANGELSCRIPT_IS_VALID` — note the **asymmetry** between the two generated
names:

```cpp
AS_FORCE_LINK const FAngelscriptBinds::FBind CK_UNIQUE_NAME(Bind_IsValid_)(
    FAngelscriptBinds::EOrder::Late,
    [] { CK_UNIQUE_NAME(Register_IsValid_##_type_no_ptr_)(); }   // type + line
);                                                              // ↑ but the FBind is line ONLY
```

MSVC expands `__LINE__` inside a multi-line invocation to the line where the invocation **closes**.
Independent confirmation: the original crash stack that started all this contained
`Register_IsValid_UObject38`, and in that build the UObject block sat on lines 35-38.

## Before — distinct symbols, compiles

```cpp
// CkIsValid_Defaults.cpp
35  CK_DEFINE_CUSTOM_IS_VALID_CONST_PTR(UObject, IsValid_Policy_Default, [=](const UObject* InObj)
36  {
37      return ::IsValid(InObj) && NOT InObj->IsUnreachable();
38  });        // closes 38

// …expands to:
inline auto Register_IsValid_UObject38() -> void { … }
AS_FORCE_LINK const FAngelscriptBinds::FBind Bind_IsValid_38( … );

71  CK_DEFINE_CUSTOM_IS_VALID(FDataTableRowHandle, …
74  });       // closes 74  →  Bind_IsValid_74
```

```cpp
// CkIsValid.cpp — SAME unity blob (Module.CkCore.15.cpp)
73  CK_DEFINE_CUSTOM_IS_VALID_INLINE(FDummyStruct, IsValid_Policy_Default, …
77  });       // closes 77  →  Bind_IsValid_77
```

Symbols in that one translation unit: `{…, 69, 74, …}` ∪ `{55, 77}` — all distinct.

## After — +8 lines slid one onto 77

#692 added 8 lines above the later invocations (one `#include`, plus the UObject block growing
4 → 11 lines):

```cpp
36  CK_DEFINE_CUSTOM_IS_VALID_CONST_PTR(UObject, IsValid_Policy_Default, [=](const UObject* InObj)
37  {
38      // A UObject mid-destruction is removed from GUObjectArray …
…       //   (5 comment lines)
43      return ::IsValid(InObj)
44          && GUObjectArray.IsValidIndex(InObj)
45          && NOT InObj->IsUnreachable();
46  });       // closes 46  →  Bind_IsValid_46   (was 38)

71  CK_DEFINE_CUSTOM_IS_VALID(FDataTableRowHandle, …
77  });       // closes 77  →  Bind_IsValid_77   ← slid from 74 onto 77
```

So the unity translation unit now literally contains:

```cpp
AS_FORCE_LINK const FAngelscriptBinds::FBind Bind_IsValid_77( … );  // CkIsValid.cpp:73-77
AS_FORCE_LINK const FAngelscriptBinds::FBind Bind_IsValid_77( … );  // CkIsValid_Defaults.cpp:71-77
```

```
CkIsValid_Defaults.cpp(71,1): error C2374: 'Bind_IsValid_77': redefinition; multiple initialization
CkIsValid_Defaults.cpp(71,1): error C2086: 'const FAngelscriptBinds::FBind Bind_IsValid_77': redefinition
CkIsValid.cpp(73,1): note: see declaration of 'Bind_IsValid_77'
```

## The fix

```cpp
CK_UNIQUE_NAME(Bind_IsValid_##_type_no_ptr_)   // was: CK_UNIQUE_NAME(Bind_IsValid_)

// the same two sites now expand to:
const FBind Bind_IsValid_FDummyStruct77( … );          // CkIsValid.cpp
const FBind Bind_IsValid_FDataTableRowHandle77( … );   // CkIsValid_Defaults.cpp
```

A collision now requires the **same type** closing on the **same line** — a genuine duplicate, and
already caught by `FCkAngelScriptIsValidRegistrationTracker`. This also restores the symmetry the
`Register_IsValid_` line directly above already had. Symbol naming only; no behaviour change.

**Near-miss worth noticing:** after #692, `CkIsValid_Defaults.cpp` emits `Bind_IsValid_56` while
`CkIsValid.cpp` emits `Bind_IsValid_55` — one line apart. Any future comment in either file could
have re-detonated this.

## Verification

C++ build clean — 276 compile actions, real links, `Result: Succeeded`, collision errors gone.

⚠️ **The test suite could not be run, for an unrelated reason on `dev`** — see below. This PR is
compile-verified; it is **not** test-verified, because on current `dev` no tests can run at all.

## Separate blocker on `dev` (not from this PR)

The `CkPoiDisplayDefinition` refactor changed `Create` to take `FCk_Handle_Poi&`, but AngelScript
callers were not migrated — so AS compilation fails, the editor boots on stale bytecode, and the
toolbox correctly refuses the run (`AS_COMPILE_FAILED`, exit 76). **CkFoundation's own CkTests are
among the broken callers:**

- `CkTests/Script/CkPoi/CkAutoTest_Poi_PerConsumerRange_CullsOneProjector.as:66,70`
- `CkTests/Script/CkPoiDisplayDefinition/CkAutoTest_PoiDisplayDefinition_CreateMultipleOnOneOwner.as:39,42`
- `CkTests/Script/CkPoiDisplayDefinition/CkAutoTest_PoiDisplayDefinition_CreateUnderHiddenParentSeedsVote.as:55`

Plus consumer-side callers in BusterBlock (`BB_StoreManager_Utils.as:100,106`,
`BB_RentnetKiosk_Utils.as:40,46`). Attribution is clean: with CkFoundation at the pre-merge SHA, AS
compiled and 1275 tests ran; at the merged SHA it does not. That needs its owner — either migrate the
callers or add a compatible overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)