### PR TITLE
fix(CkFx,CkAudio,CkResourceLoader): soft-ref sound params, loader-resolved and rooted in Current

### DIFF
--- a/Source/CkAudio/CkAudio.Build.cs
+++ b/Source/CkAudio/CkAudio.Build.cs
@@ -25,6 +25,7 @@ public class CkAudio : CkModuleRules
 
             "CkProvider",
             "CkRecord",
+            "CkResourceLoader",
             "CkSettings",
             "CkTimer"
         });

--- a/Source/CkAudio/Public/CkAudio/AudioTrack/CkAudioTrack_Fragment.h
+++ b/Source/CkAudio/Public/CkAudio/AudioTrack/CkAudioTrack_Fragment.h
@@ -4,6 +4,8 @@
 
 #include "CkEcs/Signal/CkSignal_Macros.h"
 
+#include "CkResourceLoader/CkResourceLoader_Fragment_Data.h"
+
 #include <Components/AudioComponent.h>
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -15,6 +17,7 @@ class UCk_Utils_AudioTrack_UE;
 namespace ck
 {
     CK_DEFINE_ECS_TAG(FTag_AudioTrack_NeedsSetup);
+    CK_DEFINE_ECS_TAG(FTag_AudioTrack_PendingAssetLoad);
     CK_DEFINE_ECS_TAG(FTag_AudioTrack_IsPlaying);
     CK_DEFINE_ECS_TAG(FTag_AudioTrack_IsFading);
 
@@ -40,6 +43,11 @@ namespace ck
     private:
         // WEAK — lifetime owned by the CkCore ObjectPooling subsystem (DestroyOnRelease)
         TWeakObjectPtr<UAudioComponent> _AudioComponent;
+
+        // The GC root for the track's resolved sound + library settings: the batch's streamable
+        // handle keeps them loaded for exactly as long as this fragment holds it (reset at EndPlay).
+        FCk_ResourceLoader_RootedAssetBatch _LoadedAssets;
+
         ECk_AudioTrack_State _State = ECk_AudioTrack_State::Stopped;
         float _CurrentVolume = 0.0f;
         float _TargetVolume = 0.0f;

--- a/Source/CkAudio/Public/CkAudio/AudioTrack/CkAudioTrack_Fragment_Data.h
+++ b/Source/CkAudio/Public/CkAudio/AudioTrack/CkAudioTrack_Fragment_Data.h
@@ -75,9 +75,13 @@ private:
               meta = (AllowPrivateAccess = true))
     FName _TrackName = NAME_None;
 
+    // Soft by design: path-serialized, so it is safe to author in DataAssets/Blueprints (a weak ref
+    // silently saves as null there; a hard ref force-loads the asset with the owning package). The
+    // fragment never roots the asset — Setup resolves these through CkResourceLoader and the rooted
+    // result lives on the track's Current.
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    TObjectPtr<USoundBase> _Sound;
+    TSoftObjectPtr<USoundBase> _Sound;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true, UIMin = 1, ClampMin = 1))
@@ -109,22 +113,23 @@ private:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    TObjectPtr<USoundAttenuation> _LibraryAttenuationSettings;
+    TSoftObjectPtr<USoundAttenuation> _LibraryAttenuationSettings;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    TObjectPtr<USoundConcurrency> _LibraryConcurrencySettings;
+    TSoftObjectPtr<USoundConcurrency> _LibraryConcurrencySettings;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    TObjectPtr<USoundClass> _LibrarySoundClassSettings;
+    TSoftObjectPtr<USoundClass> _LibrarySoundClassSettings;
 
 public:
-    // Auto-derives from sound asset name when _TrackName is not explicitly set
+    // Auto-derives from the sound asset's name when _TrackName is not explicitly set — from the
+    // soft PATH, so naming a track never touches or forces a load.
     FName Get_TrackName() const
     {
         if (_TrackName != NAME_None) { return _TrackName; }
-        if (IsValid(_Sound)) { return _Sound->GetFName(); }
+        if (NOT _Sound.IsNull()) { return _Sound.ToSoftObjectPath().GetAssetFName(); }
         return NAME_None;
     }
     CK_PROPERTY_GET(_Sound);

--- a/Source/CkAudio/Public/CkAudio/AudioTrack/CkAudioTrack_Processor.cpp
+++ b/Source/CkAudio/Public/CkAudio/AudioTrack/CkAudioTrack_Processor.cpp
@@ -10,6 +10,8 @@
 #include "CkAudio/CkAudio_Stats.h"
 #include "CkAudioTrack_Utils.h"
 
+#include "CkResourceLoader/CkResourceLoader_Utils.h"
+
 #include "CkAudio/CkAudio_Settings.h"
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -58,7 +60,64 @@ namespace ck
             FFragment_AudioTrack_Current& InCurrent)
             -> void
     {
+        if (NOT InCurrent._LoadedAssets.Get_IsRequested())
+        {
+            const auto SoundIsAuthored = ck::IsValid(InParams.Get_Sound());
+            CK_ENSURE_IF_NOT(SoundIsAuthored, TEXT("Cannot setup AudioTrack [{}] - its Sound soft reference is unset"), InHandle)
+            {}
+
+            if (NOT SoundIsAuthored)
+            {
+                InHandle.Remove<MarkedDirtyBy>();
+                return;
+            }
+
+            auto PathsToLoad = TArray<FSoftObjectPath>{};
+            PathsToLoad.Emplace(InParams.Get_Sound().ToSoftObjectPath());
+
+            if (ck::IsValid(InParams.Get_LibraryAttenuationSettings()))
+            { PathsToLoad.Emplace(InParams.Get_LibraryAttenuationSettings().ToSoftObjectPath()); }
+            if (ck::IsValid(InParams.Get_LibraryConcurrencySettings()))
+            { PathsToLoad.Emplace(InParams.Get_LibraryConcurrencySettings().ToSoftObjectPath()); }
+            if (ck::IsValid(InParams.Get_LibrarySoundClassSettings()))
+            { PathsToLoad.Emplace(InParams.Get_LibrarySoundClassSettings().ToSoftObjectPath()); }
+
+            InCurrent._LoadedAssets = UCk_Utils_ResourceLoader_UE::RequestLoad_RootedBatch(
+                TEXT("AudioTrack.Setup"), PathsToLoad);
+        }
+
+        if (NOT InCurrent._LoadedAssets.Get_IsReady())
+        {
+            InHandle.AddOrGet<FTag_AudioTrack_PendingAssetLoad>();
+            return;
+        }
+
+        const auto ResolvedSound = Cast<USoundBase>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(InParams.Get_Sound().ToSoftObjectPath()));
+        const auto AssetsAreLoaded = NOT InCurrent._LoadedAssets.Get_HasFailed() && ck::IsValid(ResolvedSound);
+
+        CK_ENSURE_IF_NOT(AssetsAreLoaded,
+            TEXT("Cannot setup AudioTrack [{}] - loading its Sound [{}] (or a library setting) through CkResourceLoader failed"),
+            InHandle, InParams.Get_Sound().ToSoftObjectPath())
+        {}
+
+        if (NOT AssetsAreLoaded)
+        {
+            InCurrent._LoadedAssets = {};
+            InHandle.Try_Remove<FTag_AudioTrack_PendingAssetLoad>();
+            InHandle.Remove<MarkedDirtyBy>();
+            return;
+        }
+
+        InHandle.Try_Remove<FTag_AudioTrack_PendingAssetLoad>();
         InHandle.Remove<MarkedDirtyBy>();
+
+        const auto ResolvedLibraryAttenuation = Cast<USoundAttenuation>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(InParams.Get_LibraryAttenuationSettings().ToSoftObjectPath()));
+        const auto ResolvedLibraryConcurrency = Cast<USoundConcurrency>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(InParams.Get_LibraryConcurrencySettings().ToSoftObjectPath()));
+        const auto ResolvedLibrarySoundClass = Cast<USoundClass>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(InParams.Get_LibrarySoundClassSettings().ToSoftObjectPath()));
 
         const auto World = UCk_Utils_EntityLifetime_UE::Get_WorldForEntity(InHandle);
         CK_ENSURE_IF_NOT(ck::IsValid(World), TEXT("Cannot setup AudioTrack [{}] - no valid world"), InHandle)
@@ -76,7 +135,7 @@ namespace ck
         if (ck::IsValid(InParams.Get_ScriptAsset()))
         { UCk_Utils_EntityScript_UE::Add(InHandle, InParams.Get_ScriptAsset(), FInstancedStruct{}); }
 
-        AudioComponent->SetSound(InParams.Get_Sound());
+        AudioComponent->SetSound(ResolvedSound);
         AudioComponent->bAutoActivate = false;
         AudioComponent->SetVolumeMultiplier(0.0f);
 
@@ -95,7 +154,7 @@ namespace ck
             auto SoundCueOverridesConcurrency = false;
             auto SoundCueOverridesSoundClass = false;
 
-            if (auto* SoundCue = Cast<USoundCue>(InParams.Get_Sound());
+            if (auto* SoundCue = Cast<USoundCue>(ResolvedSound);
                 ck::IsValid(SoundCue))
             {
                 if (SoundCue->bOverrideAttenuation)
@@ -126,15 +185,15 @@ namespace ck
 
             if (NOT SoundCueOverridesAttenuation && ck::Is_NOT_Valid(AttenuationToUse))
             {
-                AttenuationToUse = InParams.Get_LibraryAttenuationSettings();
+                AttenuationToUse = ResolvedLibraryAttenuation;
             }
             if (NOT SoundCueOverridesConcurrency && ck::Is_NOT_Valid(ConcurrencyToUse))
             {
-                ConcurrencyToUse = InParams.Get_LibraryConcurrencySettings();
+                ConcurrencyToUse = ResolvedLibraryConcurrency;
             }
             if (NOT SoundCueOverridesSoundClass && ck::Is_NOT_Valid(SoundClassToUse))
             {
-                SoundClassToUse = InParams.Get_LibrarySoundClassSettings();
+                SoundClassToUse = ResolvedLibrarySoundClass;
             }
 
             if (NOT SoundCueOverridesAttenuation)
@@ -190,7 +249,7 @@ namespace ck
             bool SoundCueOverridesConcurrency = false;
             bool SoundCueOverridesSoundClass = false;
 
-            if (auto* SoundCue = Cast<USoundCue>(InParams.Get_Sound()))
+            if (auto* SoundCue = Cast<USoundCue>(ResolvedSound))
             {
                 if (SoundCue->bOverrideConcurrency)
                 {
@@ -210,11 +269,11 @@ namespace ck
 
             if (NOT SoundCueOverridesConcurrency && ck::Is_NOT_Valid(ConcurrencyToUse))
             {
-                ConcurrencyToUse = InParams.Get_LibraryConcurrencySettings();
+                ConcurrencyToUse = ResolvedLibraryConcurrency;
             }
             if (NOT SoundCueOverridesSoundClass && ck::Is_NOT_Valid(SoundClassToUse))
             {
-                SoundClassToUse = InParams.Get_LibrarySoundClassSettings();
+                SoundClassToUse = ResolvedLibrarySoundClass;
             }
 
             if (NOT SoundCueOverridesConcurrency && ck::IsValid(ConcurrencyToUse))
@@ -247,7 +306,7 @@ namespace ck
 
         ck::audio::Verbose(TEXT("Setup AudioTrack [{}] with sound [{}], spatial: [{}]"),
             InParams.Get_TrackName(),
-            InParams.Get_Sound() ? InParams.Get_Sound()->GetName() : TEXT("None"),
+            ResolvedSound->GetName(),
             IsSpatial);
     }
 
@@ -444,7 +503,18 @@ namespace ck
 
         if (InCurrent._State == ECk_AudioTrack_State::Stopped || NOT InCurrent._AudioComponent->IsPlaying())
         {
-            InCurrent._AudioComponent->SetSound(InParams.Get_Sound());
+            const auto ResolvedSound = Cast<USoundBase>(
+                InCurrent._LoadedAssets.Get_ResolvedObject(InParams.Get_Sound().ToSoftObjectPath()));
+            const auto SoundIsResolved = ck::IsValid(ResolvedSound);
+
+            CK_ENSURE_IF_NOT(SoundIsResolved, TEXT("Cannot play AudioTrack [{}] - its resolved Sound is missing. "
+                "Setup completed, so the loader-rooted asset should still be alive; this should be unreachable."), InHandle)
+            {}
+
+            if (NOT SoundIsResolved)
+            { return; }
+
+            InCurrent._AudioComponent->SetSound(ResolvedSound);
             InCurrent._AudioComponent->SetBoolParameter(TEXT("Loop"), InParams.Get_LoopBehavior() == ECk_LoopBehavior::Loop);
             InCurrent._AudioComponent->Play();
 
@@ -680,6 +750,9 @@ namespace ck
             InCurrent._AudioComponent->DestroyComponent();
             InCurrent._AudioComponent = nullptr;
         }
+
+        // Drops the streamable handle — the track's assets become collectible again
+        InCurrent._LoadedAssets = {};
     }
 
     auto
@@ -986,7 +1059,7 @@ namespace ck
         const auto TextPosition = Position + FVector(0, 0, BoundaryRadius + 50.0f);
         const auto TrackNameStr = InParams.Get_TrackName().ToString();
         const auto SoundAssetName = ck::IsValid(InParams.Get_Sound())
-            ? InParams.Get_Sound()->GetName()
+            ? InParams.Get_Sound().GetAssetName()
             : FString(TEXT("None"));
         const auto bShowSoundName = (TrackNameStr != SoundAssetName);
         const auto TrackInfo = bShowSoundName
@@ -1108,7 +1181,7 @@ namespace ck
         );
 
         const auto SoundName = ck::IsValid(InParams.Get_Sound())
-            ? InParams.Get_Sound()->GetName()
+            ? InParams.Get_Sound().GetAssetName()
             : FString(TEXT("None"));
         const auto bShowSoundName = (TrackNameText != SoundName);
         auto NextLineIndex = 1;

--- a/Source/CkFx/CkFx.Build.cs
+++ b/Source/CkFx/CkFx.Build.cs
@@ -23,6 +23,7 @@ public class CkFx : CkModuleRules
             "CkLog",
 
             "CkRecord",
+            "CkResourceLoader",
             "CkSettings",
         });
     }

--- a/Source/CkFx/Claude.md
+++ b/Source/CkFx/Claude.md
@@ -9,13 +9,19 @@
 
 ## Key API
 
-- `UCk_Utils_Sfx_UE` — spawn SFX at entity position with params.
+- `UCk_Utils_Sfx_UE` — compose Sfx on an entity (`Add`), then `Request_PlayAttached` /
+  `Request_PlayAtLocation` (deferred — drained by `FProcessor_Sfx_HandleRequests` on the audio
+  group's tick; both carry the request-completion delegate).
+- Params hold `TSoftObjectPtr` sound/settings refs; `FProcessor_Sfx_Setup` resolves them through
+  CkResourceLoader (`"Sfx.Setup"` consumer id) and roots the resolved batch on the Sfx `Current`.
+  Play requests queue while setup/loading is in flight (`FTag_Sfx_NeedsSetup` gates the drain).
 
 ---
 
 ## Pattern
 
-Use for one-shot sounds. For looping / managed audio tracks, use `CkAudio`.
+Use for one-shot sounds. For looping / managed audio tracks, use `CkAudio`. Add early (the asset
+load is a non-blocking preload at composition); play later.
 
 ---
 

--- a/Source/CkFx/Public/Sfx/CkSfx_Fragment.h
+++ b/Source/CkFx/Public/Sfx/CkSfx_Fragment.h
@@ -6,6 +6,8 @@
 
 #include "CkEcs/Handle/CkDebugCallstack_Macros.h"
 
+#include "CkResourceLoader/CkResourceLoader_Fragment_Data.h"
+
 // --------------------------------------------------------------------------------------------------------------------
 
 class UCk_Utils_Sfx_UE;
@@ -14,6 +16,11 @@ class UCk_Utils_Sfx_UE;
 
 namespace ck
 {
+    CK_DEFINE_ECS_TAG(FTag_Sfx_NeedsSetup);
+    CK_DEFINE_ECS_TAG(FTag_Sfx_PendingAssetLoad);
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     struct CKFX_API FFragment_Sfx_Params
     {
     public:
@@ -40,11 +47,15 @@ namespace ck
         CK_GENERATED_BODY(FFragment_Sfx_Current);
 
     public:
+        friend class FProcessor_Sfx_Setup;
         friend class FProcessor_Sfx_HandleRequests;
+        friend class FProcessor_Sfx_EndPlay;
         friend class UCk_Utils_Sfx_UE;
 
     private:
-        int32 _DummyProperty = 0;
+        // The GC root for the sfx's resolved cue + settings: the batch's streamable handle keeps
+        // them loaded for exactly as long as this fragment holds it (reset at EndPlay).
+        FCk_ResourceLoader_RootedAssetBatch _LoadedAssets;
     };
 
     // --------------------------------------------------------------------------------------------------------------------
@@ -58,8 +69,18 @@ namespace ck
         friend class FProcessor_Sfx_HandleRequests;
         friend class UCk_Utils_Sfx_UE;
 
+    public:
+        using RequestType = std::variant<
+            FCk_Request_Sfx_PlayAttached,
+            FCk_Request_Sfx_PlayAtLocation
+        >;
+        using RequestList = TArray<RequestType>;
+
     private:
-        int32 _DummyProperty = 0;
+        RequestList _Requests;
+
+    public:
+        CK_PROPERTY_GET(_Requests);
     };
 
     // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkFx/Public/Sfx/CkSfx_Fragment_Data.h
+++ b/Source/CkFx/Public/Sfx/CkSfx_Fragment_Data.h
@@ -68,17 +68,21 @@ private:
               meta = (AllowPrivateAccess = true, Categories = "Sfx"))
     FGameplayTag _Name;
 
+    // Soft by design: path-serialized, so it is safe to author in DataAssets/Blueprints (a weak ref
+    // silently saves as null there; a hard ref force-loads the asset with the owning package). The
+    // fragment never roots the asset — Setup resolves these through CkResourceLoader and the rooted
+    // result lives on the Sfx's Current.
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    TObjectPtr<USoundBase> _SoundCue;
+    TSoftObjectPtr<USoundBase> _SoundCue;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    TObjectPtr<USoundAttenuation> _AttenuationSettings;
+    TSoftObjectPtr<USoundAttenuation> _AttenuationSettings;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))
-    TObjectPtr<USoundConcurrency> _ConcurrencySettings;
+    TSoftObjectPtr<USoundConcurrency> _ConcurrencySettings;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite,
               meta = (AllowPrivateAccess = true))

--- a/Source/CkFx/Public/Sfx/CkSfx_Processor.cpp
+++ b/Source/CkFx/Public/Sfx/CkSfx_Processor.cpp
@@ -2,26 +2,269 @@
 
 #include "CkCore/Algorithms/CkAlgorithms.h"
 
-#include "CkFx/CkFx_Log.h"
-
-#include "CkEcs/Net/CkNet_Utils.h"
+#include "CkEcs/Request/CkRequest_Completion.h"
 #include "CkEcs/Scheduler/CkProcessorRegistration.h"
+
+#include "CkFx/CkFx_Log.h"
+#include "CkFx/CkFx_Stats.h"
+
+#include "CkResourceLoader/CkResourceLoader_Utils.h"
+
+#include <Kismet/GameplayStatics.h>
 
 // --------------------------------------------------------------------------------------------------------------------
 
+CK_REGISTER_PROCESSOR(ck::FProcessor_Sfx_Setup);
 CK_REGISTER_PROCESSOR(ck::FProcessor_Sfx_HandleRequests);
+CK_REGISTER_PROCESSOR(ck::FProcessor_Sfx_CancelPendingRequests);
+CK_REGISTER_PROCESSOR(ck::FProcessor_Sfx_EndPlay);
+
+// --------------------------------------------------------------------------------------------------------------------
+
+DECLARE_CYCLE_STAT(TEXT("Fx::SfxSpawnAttached"),   STAT_Fx_SfxSpawnAttached,   STATGROUP_CkFx);
+DECLARE_CYCLE_STAT(TEXT("Fx::SfxSpawnAtLocation"), STAT_Fx_SfxSpawnAtLocation, STATGROUP_CkFx);
+
+// "Fx Effects Spawned" counter is the single shared stat declared EXTERN in CkFx_Stats.h (defined in CkVfx_Utils.cpp).
+
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace ck
 {
+    auto
+        FProcessor_Sfx_Setup::
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent)
+            -> void
+    {
+        const auto& Params = InParams.Get_Params();
+
+        if (NOT InCurrent._LoadedAssets.Get_IsRequested())
+        {
+            // An unset cue is a legal composition (pinned by Ck_AutoTest_Sfx_Add_CreatesValidHandle):
+            // the sfx composes inert and the PLAY path is where an unset/unresolved cue gets loud.
+            if (ck::Is_NOT_Valid(Params.Get_SoundCue()))
+            {
+                fx::Verbose(TEXT("Sfx [{}] composed without a SoundCue - setting up inert"), InHandle);
+                InHandle.Remove<MarkedDirtyBy>();
+                return;
+            }
+
+            auto PathsToLoad = TArray<FSoftObjectPath>{};
+            PathsToLoad.Emplace(Params.Get_SoundCue().ToSoftObjectPath());
+
+            if (ck::IsValid(Params.Get_AttenuationSettings()))
+            { PathsToLoad.Emplace(Params.Get_AttenuationSettings().ToSoftObjectPath()); }
+            if (ck::IsValid(Params.Get_ConcurrencySettings()))
+            { PathsToLoad.Emplace(Params.Get_ConcurrencySettings().ToSoftObjectPath()); }
+
+            InCurrent._LoadedAssets = UCk_Utils_ResourceLoader_UE::RequestLoad_RootedBatch(
+                TEXT("Sfx.Setup"), PathsToLoad);
+        }
+
+        if (NOT InCurrent._LoadedAssets.Get_IsReady())
+        {
+            InHandle.AddOrGet<FTag_Sfx_PendingAssetLoad>();
+            return;
+        }
+
+        const auto ResolvedSoundCue = Cast<USoundBase>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(Params.Get_SoundCue().ToSoftObjectPath()));
+        const auto AssetsAreLoaded = NOT InCurrent._LoadedAssets.Get_HasFailed() && ck::IsValid(ResolvedSoundCue);
+
+        CK_ENSURE_IF_NOT(AssetsAreLoaded,
+            TEXT("Cannot setup Sfx [{}] - loading its SoundCue [{}] (or a settings asset) through CkResourceLoader failed"),
+            InHandle, Params.Get_SoundCue().ToSoftObjectPath())
+        {}
+
+        if (NOT AssetsAreLoaded)
+        { InCurrent._LoadedAssets = {}; }
+
+        InHandle.Try_Remove<FTag_Sfx_PendingAssetLoad>();
+        InHandle.Remove<MarkedDirtyBy>();
+    }
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     auto
         FProcessor_Sfx_HandleRequests::
         ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
-            FFragment_Sfx_Current& InComp,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent,
             FFragment_Sfx_Requests& InRequestsComp) const
         -> void
     {
+        const auto RequestsCopy = InRequestsComp._Requests;
+        InRequestsComp._Requests.Reset();
+
+        algo::ForEachRequest(RequestsCopy, ck::Visitor(
+        [&](const auto& InRequest) -> void
+        {
+            auto Result = ECk_Request_OperationResult::Failed;
+            const auto Guard = MakeCompletionGuard(InRequest, InHandle, Result);
+
+            Result = DoHandleRequest(InHandle, InParams, InCurrent, InRequest);
+        }), policy::DontResetContainer{});
+
+        if (InRequestsComp._Requests.IsEmpty())
+        {
+            InHandle.Remove<MarkedDirtyBy>();
+        }
+    }
+
+    auto
+        FProcessor_Sfx_HandleRequests::
+        DoHandleRequest(
+            HandleType InHandle,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent,
+            const FCk_Request_Sfx_PlayAttached& InRequest)
+        -> ECk_Request_OperationResult
+    {
+        SCOPE_CYCLE_COUNTER(STAT_Fx_SfxSpawnAttached);
+
+        const auto& Params = InParams.Get_Params();
+
+        const auto ResolvedSoundCue = Cast<USoundBase>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(Params.Get_SoundCue().ToSoftObjectPath()));
+        const auto SoundCueIsResolved = ck::IsValid(ResolvedSoundCue);
+
+        CK_ENSURE_IF_NOT(SoundCueIsResolved, TEXT("Sfx [{}] cannot play - its SoundCue is not resolved "
+            "(the asset load failed at Setup, or the loader-rooted asset was lost)"), InHandle)
+        {}
+
+        if (NOT SoundCueIsResolved)
+        { return ECk_Request_OperationResult::Failed; }
+
+        // The attach component may legitimately die between enqueue and drain — a Failed completion,
+        // not an ensure.
+        const auto AttachComponent = InRequest.Get_AttachComponent().Get();
+        if (ck::Is_NOT_Valid(AttachComponent))
+        {
+            ck::fx::Verbose(TEXT("Sfx [{}] skipping PlayAttached - the attach component is no longer valid"), InHandle);
+            return ECk_Request_OperationResult::Failed;
+        }
+
+        const auto& AudioSettings = InRequest.Get_OverrideAudioSettings()
+                                        ? InRequest.Get_OverridenAudioSettings()
+                                        : Params.Get_DefaultAudioSettings();
+
+        const auto ResolvedAttenuation = Cast<USoundAttenuation>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(Params.Get_AttenuationSettings().ToSoftObjectPath()));
+        const auto ResolvedConcurrency = Cast<USoundConcurrency>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(Params.Get_ConcurrencySettings().ToSoftObjectPath()));
+
+        constexpr auto StartTime = 0.0f;
+        UGameplayStatics::SpawnSoundAttached
+        (
+            ResolvedSoundCue,
+            AttachComponent,
+            NAME_None,
+            InRequest.Get_RelativeTransformSettings().Get_Location(),
+            InRequest.Get_RelativeTransformSettings().Get_Rotation(),
+            EAttachLocation::Type::KeepRelativeOffset,
+            InRequest.Get_StopPolicy() == ECk_Sfx_Stop_Policy::StopWhenFinishedOrDetached,
+            AudioSettings.Get_VolumeMultipler(),
+            AudioSettings.Get_PitchMultipler(),
+            StartTime,
+            ResolvedAttenuation,
+            ResolvedConcurrency
+        );
+
+        INC_DWORD_STAT(STAT_Fx_EffectsSpawned);
+
+        return ECk_Request_OperationResult::Succeeded;
+    }
+
+    auto
+        FProcessor_Sfx_HandleRequests::
+        DoHandleRequest(
+            HandleType InHandle,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent,
+            const FCk_Request_Sfx_PlayAtLocation& InRequest)
+        -> ECk_Request_OperationResult
+    {
+        SCOPE_CYCLE_COUNTER(STAT_Fx_SfxSpawnAtLocation);
+
+        const auto& Params = InParams.Get_Params();
+
+        const auto ResolvedSoundCue = Cast<USoundBase>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(Params.Get_SoundCue().ToSoftObjectPath()));
+        const auto SoundCueIsResolved = ck::IsValid(ResolvedSoundCue);
+
+        CK_ENSURE_IF_NOT(SoundCueIsResolved, TEXT("Sfx [{}] cannot play - its SoundCue is not resolved "
+            "(the asset load failed at Setup, or the loader-rooted asset was lost)"), InHandle)
+        {}
+
+        if (NOT SoundCueIsResolved)
+        { return ECk_Request_OperationResult::Failed; }
+
+        // The outer may legitimately die between enqueue and drain — a Failed completion, not an ensure.
+        const auto Outer = InRequest.Get_Outer().Get();
+        if (ck::Is_NOT_Valid(Outer))
+        {
+            ck::fx::Verbose(TEXT("Sfx [{}] skipping PlayAtLocation - the outer is no longer valid"), InHandle);
+            return ECk_Request_OperationResult::Failed;
+        }
+
+        const auto& AudioSettings = InRequest.Get_OverrideAudioSettings()
+                                        ? InRequest.Get_OverridenAudioSettings()
+                                        : Params.Get_DefaultAudioSettings();
+
+        const auto ResolvedAttenuation = Cast<USoundAttenuation>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(Params.Get_AttenuationSettings().ToSoftObjectPath()));
+        const auto ResolvedConcurrency = Cast<USoundConcurrency>(
+            InCurrent._LoadedAssets.Get_ResolvedObject(Params.Get_ConcurrencySettings().ToSoftObjectPath()));
+
+        constexpr auto StartTime = 0.0f;
+        UGameplayStatics::SpawnSoundAtLocation
+        (
+            Outer,
+            ResolvedSoundCue,
+            InRequest.Get_TransformSettings().Get_Location(),
+            InRequest.Get_TransformSettings().Get_Rotation(),
+            AudioSettings.Get_VolumeMultipler(),
+            AudioSettings.Get_PitchMultipler(),
+            StartTime,
+            ResolvedAttenuation,
+            ResolvedConcurrency
+        );
+
+        INC_DWORD_STAT(STAT_Fx_EffectsSpawned);
+
+        return ECk_Request_OperationResult::Succeeded;
+    }
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    auto
+        FProcessor_Sfx_CancelPendingRequests::
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            const FFragment_Sfx_Requests& InRequestsComp)
+        -> void
+    {
+        request::FireCancelledForPending(InHandle, InRequestsComp.Get_Requests());
+    }
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    auto
+        FProcessor_Sfx_EndPlay::
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            FFragment_Sfx_Current& InCurrent)
+            -> void
+    {
+        // Drops the streamable handle — the sfx's assets become collectible again
+        InCurrent._LoadedAssets = {};
     }
 }
 

--- a/Source/CkFx/Public/Sfx/CkSfx_Processor.h
+++ b/Source/CkFx/Public/Sfx/CkSfx_Processor.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "CkSfx_Fragment.h"
-#include "CkEcs/EntityLifetime/CkEntityLifetime_Fragment.h"
+#include "Sfx/CkSfx_Fragment.h"
 
+#include "CkEcs/EntityLifetime/CkEntityLifetime_Fragment.h"
 #include "CkEcs/Processor/CkProcessor.h"
 #include "CkEcs/Scheduler/CkProcessorGroups.h"
 
@@ -10,26 +10,123 @@
 
 namespace ck
 {
-    class CKFX_API FProcessor_Sfx_HandleRequests : public ck_exp::TProcessor<
-            FProcessor_Sfx_HandleRequests,
+    class CKFX_API FProcessor_Sfx_Setup : public ck_exp::TProcessor<
+            FProcessor_Sfx_Setup,
             FCk_Handle_Sfx,
+            TReadOnly<FFragment_Sfx_Params>,
             TReadWrite<FFragment_Sfx_Current>,
-            TReadWrite<FFragment_Sfx_Requests>,
+            FTag_Sfx_NeedsSetup,
             CK_IGNORE_PENDING_KILL>
     {
     public:
         using Group = FGroup_Gameplay_Audio;
+        using MarkedDirtyBy = FTag_Sfx_NeedsSetup;
+
+    public:
+        using TProcessor::TProcessor;
+
+    public:
+        static auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent)
+            -> void;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    class CKFX_API FProcessor_Sfx_HandleRequests : public ck_exp::TProcessor<
+            FProcessor_Sfx_HandleRequests,
+            FCk_Handle_Sfx,
+            TReadOnly<FFragment_Sfx_Params>,
+            TReadWrite<FFragment_Sfx_Current>,
+            TReadWrite<FFragment_Sfx_Requests>,
+            TExclude<FTag_Sfx_NeedsSetup>,
+            TExclude<FTag_DestroyEntity_Initiate>,
+            CK_IGNORE_PENDING_KILL>
+    {
+    public:
+        using Group = FGroup_Gameplay_Audio;
+        using RunAfter = TDepList<FProcessor_Sfx_Setup>;
         using MarkedDirtyBy = FFragment_Sfx_Requests;
 
     public:
         using TProcessor::TProcessor;
 
     public:
-        auto ForEachEntity(
+        auto
+        ForEachEntity(
             TimeType InDeltaT,
             HandleType InHandle,
-            FFragment_Sfx_Current& InComp,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent,
             FFragment_Sfx_Requests& InRequestsComp) const -> void;
+
+    private:
+        static auto
+        DoHandleRequest(
+            HandleType InHandle,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent,
+            const FCk_Request_Sfx_PlayAttached& InRequest) -> ECk_Request_OperationResult;
+
+        static auto
+        DoHandleRequest(
+            HandleType InHandle,
+            const FFragment_Sfx_Params& InParams,
+            FFragment_Sfx_Current& InCurrent,
+            const FCk_Request_Sfx_PlayAtLocation& InRequest) -> ECk_Request_OperationResult;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    // HandleRequests excludes owners already tagged for destruction, so a destroyed sfx's still-queued
+    // requests are never drained. This fires each pending request's completion delegate with
+    // Failed_Cancelled so a caller awaiting completion terminates instead of hanging.
+    class CKFX_API FProcessor_Sfx_CancelPendingRequests : public ck_exp::TProcessor<
+            FProcessor_Sfx_CancelPendingRequests,
+            FCk_Handle_Sfx,
+            TReadOnly<FFragment_Sfx_Requests>,
+            CK_IF_END_PLAY>
+    {
+    public:
+        using Group = FGroup_EndPlay;
+
+    public:
+        using TProcessor::TProcessor;
+
+    public:
+        static auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            const FFragment_Sfx_Requests& InRequestsComp)
+            -> void;
+    };
+
+    // --------------------------------------------------------------------------------------------------------------------
+
+    class CKFX_API FProcessor_Sfx_EndPlay : public ck_exp::TProcessor<
+            FProcessor_Sfx_EndPlay,
+            FCk_Handle_Sfx,
+            TReadWrite<FFragment_Sfx_Current>,
+            CK_IF_END_PLAY>
+    {
+    public:
+        using Group = FGroup_EndPlay;
+
+    public:
+        using TProcessor::TProcessor;
+
+    public:
+        static auto
+        ForEachEntity(
+            TimeType InDeltaT,
+            HandleType InHandle,
+            FFragment_Sfx_Current& InCurrent)
+            -> void;
     };
 }
 

--- a/Source/CkFx/Public/Sfx/CkSfx_Utils.cpp
+++ b/Source/CkFx/Public/Sfx/CkSfx_Utils.cpp
@@ -2,19 +2,7 @@
 
 #include "Sfx/CkSfx_Fragment.h"
 
-#include "CkFx/CkFx_Log.h"
-#include "CkFx/CkFx_Stats.h"
-
 #include "CkEcs/Handle/CkDebugCallstack_Macros.h"
-
-#include <Kismet/GameplayStatics.h>
-
-// --------------------------------------------------------------------------------------------------------------------
-
-DECLARE_CYCLE_STAT(TEXT("Fx::SfxSpawnAttached"),   STAT_Fx_SfxSpawnAttached,   STATGROUP_CkFx);
-DECLARE_CYCLE_STAT(TEXT("Fx::SfxSpawnAtLocation"), STAT_Fx_SfxSpawnAtLocation, STATGROUP_CkFx);
-
-// "Fx Effects Spawned" counter is the single shared stat declared EXTERN in CkFx_Stats.h (defined in CkVfx_Utils.cpp).
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -31,6 +19,7 @@ auto
 
         InNewEntity.Add<ck::FFragment_Sfx_Params>(InParams);
         InNewEntity.Add<ck::FFragment_Sfx_Current>();
+        InNewEntity.Add<ck::FTag_Sfx_NeedsSetup>();
     });
 
     auto NewSfxEntity = Cast(NewEntity);
@@ -86,7 +75,11 @@ auto
         const FCk_Handle_Sfx& InSfxHandle)
     -> USoundBase*
 {
-    return InSfxHandle.Get<ck::FFragment_Sfx_Params>().Get_Params().Get_SoundCue();
+    // Resolved from the loader-rooted batch on Current — null until Setup has loaded the assets
+    const auto& Params = InSfxHandle.Get<ck::FFragment_Sfx_Params>().Get_Params();
+    const auto& Current = InSfxHandle.Get<ck::FFragment_Sfx_Current>();
+
+    return ::Cast<USoundBase>(Current._LoadedAssets.Get_ResolvedObject(Params.Get_SoundCue().ToSoftObjectPath()));
 }
 
 auto
@@ -127,40 +120,14 @@ auto
         const FCk_Delegate_Request_OnCompleted& InDelegate)
     -> FCk_Handle_Sfx
 {
-    SCOPE_CYCLE_COUNTER(STAT_Fx_SfxSpawnAttached);
-
     CK_CALLSTACK_RECORD(ck::FFragment_Sfx_Requests, InSfxHandle);
 
-    // TODO: Move this to processor
+    auto Request = InRequest;
 
-    const auto& SoundCue = Get_SoundCue(InSfxHandle);
-    const auto& Params = InSfxHandle.Get<ck::FFragment_Sfx_Params>().Get_Params();
+    if (InDelegate.IsBound())
+    { Request.Set_CompletionDelegate(InDelegate); }
 
-    const auto& AudioSettings = InRequest.Get_OverrideAudioSettings()
-                                    ? InRequest.Get_OverridenAudioSettings()
-                                    : Params.Get_DefaultAudioSettings();
-
-    constexpr auto StartTime = 0.0f;
-    UGameplayStatics::SpawnSoundAttached
-    (
-        SoundCue,
-        InRequest.Get_AttachComponent().Get(),
-        NAME_None,
-        InRequest.Get_RelativeTransformSettings().Get_Location(),
-        InRequest.Get_RelativeTransformSettings().Get_Rotation(),
-        EAttachLocation::Type::KeepRelativeOffset,
-        InRequest.Get_StopPolicy() == ECk_Sfx_Stop_Policy::StopWhenFinishedOrDetached,
-        AudioSettings.Get_VolumeMultipler(),
-        AudioSettings.Get_PitchMultipler(),
-        StartTime,
-        Params.Get_AttenuationSettings(),
-        Params.Get_ConcurrencySettings()
-    );
-
-    INC_DWORD_STAT(STAT_Fx_EffectsSpawned);
-
-    // Immediate mutation — nothing is enqueued, so completion is synchronous on this stack.
-    InDelegate.ExecuteIfBound(InSfxHandle, ECk_Request_OperationResult::Succeeded);
+    InSfxHandle.AddOrGet<ck::FFragment_Sfx_Requests>()._Requests.Emplace(Request);
 
     return InSfxHandle;
 }
@@ -173,37 +140,14 @@ auto
         const FCk_Delegate_Request_OnCompleted& InDelegate)
     -> FCk_Handle_Sfx
 {
-    SCOPE_CYCLE_COUNTER(STAT_Fx_SfxSpawnAtLocation);
-
     CK_CALLSTACK_RECORD(ck::FFragment_Sfx_Requests, InSfxHandle);
 
-    // TODO: Move this to processor
+    auto Request = InRequest;
 
-    const auto& SoundCue = Get_SoundCue(InSfxHandle);
-    const auto& Params = InSfxHandle.Get<ck::FFragment_Sfx_Params>().Get_Params();
+    if (InDelegate.IsBound())
+    { Request.Set_CompletionDelegate(InDelegate); }
 
-    const auto& AudioSettings = InRequest.Get_OverrideAudioSettings()
-                                    ? InRequest.Get_OverridenAudioSettings()
-                                    : Params.Get_DefaultAudioSettings();
-
-    constexpr auto StartTime = 0.0f;
-    UGameplayStatics::SpawnSoundAtLocation
-    (
-        InRequest.Get_Outer().Get(),
-        SoundCue,
-        InRequest.Get_TransformSettings().Get_Location(),
-        InRequest.Get_TransformSettings().Get_Rotation(),
-        AudioSettings.Get_VolumeMultipler(),
-        AudioSettings.Get_PitchMultipler(),
-        StartTime,
-        Params.Get_AttenuationSettings(),
-        Params.Get_ConcurrencySettings()
-    );
-
-    INC_DWORD_STAT(STAT_Fx_EffectsSpawned);
-
-    // Immediate mutation — nothing is enqueued, so completion is synchronous on this stack.
-    InDelegate.ExecuteIfBound(InSfxHandle, ECk_Request_OperationResult::Succeeded);
+    InSfxHandle.AddOrGet<ck::FFragment_Sfx_Requests>()._Requests.Emplace(Request);
 
     return InSfxHandle;
 }

--- a/Source/CkResourceLoader/Claude.md
+++ b/Source/CkResourceLoader/Claude.md
@@ -10,7 +10,15 @@
 ## Key API
 
 - `UCk_Utils_ResourceLoader_UE` — request async load of an asset path; bind a delegate for completion; cancel pending loads on entity destroy.
-- `FProcessor_ResourceLoader_HandleRequests` — processes load requests each tick.
+- `UCk_Utils_ResourceLoader_UE::RequestLoad_RootedBatch(ConsumerId, SoftPaths)` — C++-only,
+  processor-friendly load returning `FCk_ResourceLoader_RootedAssetBatch`. No request entity, no
+  delegate: the caller polls `Get_IsReady()` / `Get_HasFailed()` and resolves via
+  `Get_ResolvedObject(SoftPath)`. **The batch's streamable handle is the GC root for both
+  policies** — store the batch in the feature's `Current`, reset it (EndPlay) to release the assets.
+- `UCk_ResourceLoader_ProjectSettings_UE` — `_DefaultLoadingPolicy` (**Async**) +
+  `_PerConsumerLoadingPolicyOverrides` (`TMap<FName, policy>`): flip one consumer (e.g.
+  `"AudioTrack.Setup"`) to `Synchronous` in one project alone — the per-project debug knob.
+- `FProcessor_ResourceLoader_HandleRequests` — processes delegate-API load requests each tick.
 
 ---
 
@@ -18,11 +26,18 @@
 
 Request a load at entity setup; bind the `OnLoaded` signal; the setup processor waits for the signal before moving the entity to its 'ready' state.
 
+Processor-side (no UObject to bind a delegate to): kick `RequestLoad_RootedBatch` in the fresh
+branch of Setup, fall through to the ready check the same tick (a sync-overridden load AND a warm
+async load complete immediately), and poll `Get_IsReady()` on later ticks while a NeedsSetup-style
+tag gates the feature's requests. Canonical consumers: `CkAudio` AudioTrack Setup, `CkFx` Sfx Setup.
+
 ---
 
 ## Anti-patterns
 
-Don't synchronously load assets inside a Processor `ForEachEntity` body — it stalls the game thread.
+Don't synchronously load assets inside a Processor `ForEachEntity` body — it stalls the game
+thread. (The `Synchronous` per-consumer override does exactly this once per entity setup, by
+explicit per-project opt-in, for debugging — that is the sanctioned exception, not a license.)
 
 ---
 

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.cpp
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.cpp
@@ -1,5 +1,8 @@
 #include "CkResourceLoader_Fragment_Data.h"
 
+#include "CkCore/Algorithms/CkAlgorithms.h"
+#include "CkCore/Validation/CkIsValid.h"
+
 // --------------------------------------------------------------------------------------------------------------------
 auto
     FCk_ResourceLoader_ObjectReference_Soft::
@@ -104,6 +107,65 @@ auto
 {
     return Get_UniqueLoadedObjects() == InOther.Get_UniqueLoadedObjects() &&
         Get_AllOrderedLoadedObjects() == InOther.Get_AllOrderedLoadedObjects();
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_ResourceLoader_RootedAssetBatch::
+    Get_IsRequested() const
+    -> bool
+{
+    return _Requested;
+}
+
+auto
+    FCk_ResourceLoader_RootedAssetBatch::
+    Get_IsReady() const
+    -> bool
+{
+    if (NOT Get_IsRequested())
+    { return false; }
+
+    if (NOT _StreamableHandle.IsValid())
+    { return true; }
+
+    return _StreamableHandle->HasLoadCompleted() || _StreamableHandle->WasCanceled();
+}
+
+auto
+    FCk_ResourceLoader_RootedAssetBatch::
+    Get_HasFailed() const
+    -> bool
+{
+    if (NOT Get_IsRequested())
+    { return false; }
+
+    if (NOT _StreamableHandle.IsValid())
+    { return true; }
+
+    if (_StreamableHandle->WasCanceled())
+    { return true; }
+
+    if (NOT _StreamableHandle->HasLoadCompleted())
+    { return false; }
+
+    return ck::algo::AnyOf(_RequestedPaths, [](const FSoftObjectPath& InPath)
+    {
+        return ck::Is_NOT_Valid(InPath.ResolveObject(), ck::IsValid_Policy_NullptrOnly{});
+    });
+}
+
+auto
+    FCk_ResourceLoader_RootedAssetBatch::
+    Get_ResolvedObject(
+        const FSoftObjectPath& InPath) const
+    -> UObject*
+{
+    if (NOT _StreamableHandle.IsValid() || NOT _StreamableHandle->HasLoadCompleted())
+    { return nullptr; }
+
+    return InPath.ResolveObject();
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.h
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.h
@@ -67,8 +67,14 @@ public:
     CK_DECL_AND_DEF_OPERATOR_NOT_EQUAL(ThisType);
 
 private:
+    // "Hard" means RESOLVED rather than soft — it is not what keeps the asset alive, and must not be
+    // mistaken for a root. This struct travels inside FCk_ResourceLoader_LoadedObject, which is stored
+    // in ECS fragments; UE's GC does not walk the EnTT registry, so a strong reference here would root
+    // nothing. The asset is actually held by two things that DO work from a fragment: the sibling
+    // TSharedPtr<FStreamableHandle> on the LoadedObject (FStreamableManager keeps its targets loaded
+    // for the handle's lifetime), and the loader subsystem's UPROPERTY TSet of tracked resources.
     UPROPERTY(EditAnywhere, BlueprintReadWrite, meta = (AllowPrivateAccess = true))
-    TObjectPtr<UObject> _Object;
+    TWeakObjectPtr<UObject> _Object;
 
 public:
     CK_PROPERTY_GET(_Object);

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.h
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Fragment_Data.h
@@ -153,6 +153,36 @@ public:
 
 // --------------------------------------------------------------------------------------------------------------------
 
+// Plain value type, deliberately NOT a USTRUCT: instances live inside EnTT fragments, never in
+// reflected surfaces. The streamable handle IS the GC root for every asset in the batch — for both
+// loading policies — so resetting/replacing this struct releases the assets (FStreamableManager
+// keeps a handle's targets loaded for the handle's lifetime). UE's GC does not trace fragments;
+// nothing here relies on it.
+struct CKRESOURCELOADER_API FCk_ResourceLoader_RootedAssetBatch
+{
+public:
+    CK_GENERATED_BODY(FCk_ResourceLoader_RootedAssetBatch);
+
+public:
+    auto Get_IsRequested() const -> bool;
+    auto Get_IsReady() const -> bool;
+    auto Get_HasFailed() const -> bool;
+    auto Get_ResolvedObject(const FSoftObjectPath& InPath) const -> UObject*;
+
+private:
+    bool _Requested = false;
+    TArray<FSoftObjectPath> _RequestedPaths;
+    TSharedPtr<FStreamableHandle> _StreamableHandle;
+
+public:
+    CK_PROPERTY_GET(_RequestedPaths);
+
+private:
+    friend class UCk_Utils_ResourceLoader_UE;
+};
+
+// --------------------------------------------------------------------------------------------------------------------
+
 USTRUCT(BlueprintType)
 struct CKRESOURCELOADER_API FCk_ResourceLoader_PendingObject
 {

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Utils.cpp
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Utils.cpp
@@ -1,7 +1,15 @@
 #include "CkResourceLoader_Utils.h"
 
+#include "CkCore/Algorithms/CkAlgorithms.h"
+#include "CkCore/Ensure/CkEnsure.h"
+
 #include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 #include "CkEcs/Handle/CkDebugCallstack_Macros.h"
+
+#include "CkResourceLoader/CkResourceLoader_Log.h"
+#include "CkResourceLoader/Settings/CkResourceLoader_Settings.h"
+
+#include <Engine/AssetManager.h>
 
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -45,6 +53,60 @@ auto
     RequestEntity.AddOrGet<ck::FFragment_ResourceLoader_Requests>()._Requests.Emplace(InRequest);
 
     ck::UUtils_Signal_ResourceLoader_OnObjectBatchLoaded_PostFireUnbind::Bind(RequestEntity, InDelegate, ECk_Signal_BindingPolicy::FireIfPayloadInFlight);
+}
+
+auto
+    UCk_Utils_ResourceLoader_UE::
+    RequestLoad_RootedBatch(
+        FName InConsumerId,
+        const TArray<FSoftObjectPath>& InSoftPaths)
+    -> FCk_ResourceLoader_RootedAssetBatch
+{
+    auto Batch = FCk_ResourceLoader_RootedAssetBatch{};
+    Batch._Requested = true;
+    Batch._RequestedPaths = InSoftPaths;
+
+    const auto AllPathsAreValid = ck::algo::NoneOf(InSoftPaths, [](const FSoftObjectPath& InPath)
+    {
+        return InPath.IsNull();
+    });
+
+    CK_ENSURE_IF_NOT(NOT InSoftPaths.IsEmpty() && AllPathsAreValid,
+        TEXT("RequestLoad_RootedBatch for Consumer [{}] rejected - the soft path list is empty or contains a null path"),
+        InConsumerId)
+    {}
+
+    if (InSoftPaths.IsEmpty() || NOT AllPathsAreValid)
+    { return Batch; }
+
+    const auto LoadingPolicy = UCk_Utils_ResourceLoader_Settings_UE::Get_LoadingPolicyForConsumer(InConsumerId);
+
+    auto& StreamableManager = UAssetManager::GetStreamableManager();
+    auto PathsToStream = InSoftPaths;
+
+    switch (LoadingPolicy)
+    {
+        case ECk_ResourceLoader_LoadingPolicy::Synchronous:
+        {
+            Batch._StreamableHandle = StreamableManager.RequestSyncLoad(MoveTemp(PathsToStream));
+            break;
+        }
+        case ECk_ResourceLoader_LoadingPolicy::Async:
+        {
+            Batch._StreamableHandle = StreamableManager.RequestAsyncLoad(MoveTemp(PathsToStream));
+            break;
+        }
+        default:
+        {
+            CK_INVALID_ENUM(LoadingPolicy);
+            break;
+        }
+    }
+
+    ck::resource_loader::VeryVerbose(TEXT("RootedBatch load requested by Consumer [{}] with Policy [{}] for [{}] path(s)"),
+        InConsumerId, LoadingPolicy, InSoftPaths.Num());
+
+    return Batch;
 }
 
 auto

--- a/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Utils.h
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/CkResourceLoader_Utils.h
@@ -51,6 +51,18 @@ public:
         const FCk_Delegate_ResourceLoader_OnObjectBatchLoaded& InDelegate,
         const FCk_Delegate_Request_OnCompleted& InCompletionDelegate);
 
+public:
+    // C++-only, processor-friendly load: no request entity, no delegate to bind. The loading policy
+    // resolves from the loader project settings — the per-consumer override for InConsumerId if one
+    // is configured, else the project default (Async). Synchronous is ready on return; Async is
+    // polled via the returned batch (an async request whose assets are already resident completes
+    // inline). The batch's streamable handle is the GC root for the loaded assets: store the batch
+    // where the assets must stay alive, reset it to release them.
+    static auto
+    RequestLoad_RootedBatch(
+        FName InConsumerId,
+        const TArray<FSoftObjectPath>& InSoftPaths) -> FCk_ResourceLoader_RootedAssetBatch;
+
     UFUNCTION(BlueprintPure,
         DisplayName = "[Ck] Convert Soft Class Reference To Soft Resource Loader Object Reference",
         Category = "Ck|Utils|ResourceLoader",

--- a/Source/CkResourceLoader/Public/CkResourceLoader/Settings/CkResourceLoader_Settings.cpp
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/Settings/CkResourceLoader_Settings.cpp
@@ -12,4 +12,26 @@ auto
     return UCk_Utils_Object_UE::Get_ClassDefaultObject<UCk_ResourceLoader_ProjectSettings_UE>()->Get_MaxNumberOfCachedResourcesPerType();
 }
 
+auto
+    UCk_Utils_ResourceLoader_Settings_UE::
+    Get_DefaultLoadingPolicy()
+    -> ECk_ResourceLoader_LoadingPolicy
+{
+    return UCk_Utils_Object_UE::Get_ClassDefaultObject<UCk_ResourceLoader_ProjectSettings_UE>()->Get_DefaultLoadingPolicy();
+}
+
+auto
+    UCk_Utils_ResourceLoader_Settings_UE::
+    Get_LoadingPolicyForConsumer(
+        FName InConsumerId)
+    -> ECk_ResourceLoader_LoadingPolicy
+{
+    const auto& Overrides = UCk_Utils_Object_UE::Get_ClassDefaultObject<UCk_ResourceLoader_ProjectSettings_UE>()->Get_PerConsumerLoadingPolicyOverrides();
+
+    if (const auto* Override = Overrides.Find(InConsumerId))
+    { return *Override; }
+
+    return Get_DefaultLoadingPolicy();
+}
+
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkResourceLoader/Public/CkResourceLoader/Settings/CkResourceLoader_Settings.h
+++ b/Source/CkResourceLoader/Public/CkResourceLoader/Settings/CkResourceLoader_Settings.h
@@ -2,6 +2,8 @@
 
 #include "CkCore/Macros/CkMacros.h"
 
+#include "CkResourceLoader/CkResourceLoader_Fragment_Data.h"
+
 #include "CkSettings/ProjectSettings/CkProjectSettings.h"
 
 #include "CkResourceLoader_Settings.generated.h"
@@ -21,8 +23,21 @@ private:
               meta = (AllowPrivateAccess = true, UIMin = 100, ClampMin = 100))
     int32 _MaxNumberOfCachedResourcesPerType = 100;
 
+    UPROPERTY(Config, EditDefaultsOnly, BlueprintReadOnly, Category = "Loading",
+              meta = (AllowPrivateAccess = true))
+    ECk_ResourceLoader_LoadingPolicy _DefaultLoadingPolicy = ECk_ResourceLoader_LoadingPolicy::Async;
+
+    // Per-consumer loading-policy override — the per-project debug knob. Key = the ConsumerId a
+    // processor passes to RequestLoad_RootedBatch (e.g. "AudioTrack.Setup"); flip that one consumer
+    // to Synchronous in this project alone via Project Settings or the config ini.
+    UPROPERTY(Config, EditDefaultsOnly, BlueprintReadOnly, Category = "Loading",
+              meta = (AllowPrivateAccess = true))
+    TMap<FName, ECk_ResourceLoader_LoadingPolicy> _PerConsumerLoadingPolicyOverrides;
+
 public:
     CK_PROPERTY_GET(_MaxNumberOfCachedResourcesPerType);
+    CK_PROPERTY_GET(_DefaultLoadingPolicy);
+    CK_PROPERTY_GET(_PerConsumerLoadingPolicyOverrides);
 };
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -31,6 +46,8 @@ class CKRESOURCELOADER_API UCk_Utils_ResourceLoader_Settings_UE
 {
 public:
     static auto Get_MaxNumberOfCachedResourcesPerType() -> int32;
+    static auto Get_DefaultLoadingPolicy() -> ECk_ResourceLoader_LoadingPolicy;
+    static auto Get_LoadingPolicyForConsumer(FName InConsumerId) -> ECk_ResourceLoader_LoadingPolicy;
 };
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fragment-held sound-asset params (`CkAudio` AudioTrack, `CkFx` Sfx) go **`TSoftObjectPtr`**, resolved
through **CkResourceLoader** at Setup, with the resolved assets **rooted by the streamable handle
held in the feature's `Current`** (reset at EndPlay → asset lifetime = feature lifetime).

Supersedes the earlier weak-ptr shape this PR previously carried — weak fixes the GC dangle but a
`TWeakObjectPtr` UPROPERTY **silently serializes as null on a non-cooking editor save**
(`FPackageHarvester` skips weak refs), so it is wrong for anything a designer can author in a
DataAsset/Blueprint — and `CkAudioCue_EntityScript`'s `_SingleTrack`/`_TrackLibrary` are already
editor-facing.

## Why (the original crash)

UE's GC does not walk the EnTT registry: a fragment-held `TObjectPtr` to a sound dangles once
nothing else roots the asset (real packaged crash — the NPC downed-scream cue, fixed independently
in BusterBlock #2529). Soft-in-Params + loader-rooted-Current fixes the dangle AND the editor-save
trap, and centralizes rooting in the framework instead of making every code caller anchor the asset
externally. Bonus: soft is self-healing — if a caller's anchor drops before Setup, the path just
re-loads (weak nulled forever).

## Design

- **CkResourceLoader** gains one delegate-free, processor-friendly primitive:
  `RequestLoad_RootedBatch(ConsumerId, SoftPaths) -> FCk_ResourceLoader_RootedAssetBatch`
  (`RequestSyncLoad`/`RequestAsyncLoad` under the hood; the batch's `TSharedPtr<FStreamableHandle>`
  IS the GC root for both policies; poll `Get_IsReady()`/`Get_HasFailed()`). The existing
  delegate/request-entity API is untouched.
- **Policy is a per-project runtime concern, not authored data**: `Async` by default, with a
  per-consumer override map in the loader's project settings
  (`_PerConsumerLoadingPolicyOverrides["AudioTrack.Setup"] = Synchronous` in one project's ini
  flips one processor to blocking loads for debugging).
- **AudioTrack Setup** becomes fresh → pending → ready: kick the batch, fall through to the ready
  check the same tick (sync override AND warm async complete immediately), otherwise keep
  `FTag_AudioTrack_NeedsSetup` — the existing `HandleRequests` exclusion queues Play/Stop/SetVolume
  until the assets land. No new request-side gating.
- **Sfx finally pays off its `// TODO: Move this to processor`**: real
  `FProcessor_Sfx_Setup`/`HandleRequests` pair (the old stub processor is replaced),
  `Request_Play*` become true enqueues adopting the request-completion convention (trailing
  `OnCompleted` delegate, `MakeCompletionGuard`, `Failed_Cancelled` at teardown via
  `FProcessor_Sfx_CancelPendingRequests`).

## Behavior changes (deliberate, flagged)

- Sfx spawn moves from caller-stack-immediate to the audio group's tick (≤1 frame warm; a play
  racing the initial async load waits for it — it queues instead of silently ensuring).
- Async-default means the load window sits at Add/composition time (a non-blocking preload);
  consumers that Add early see no first-play change.
- `UCk_Utils_Sfx_UE::Get_SoundCue` resolves from Current — null before Setup completes.
- No warm global cache: a destroyed-then-re-added track re-loads (an opt-in LRU on the subsystem is
  the future answer if ever needed, not a process-lifetime pin).

## Alternatives rejected (so review can audit the calls)

- `TObjectPtr` + root-at-ingest: also fixes both bugs, smaller diff — but hard-imports entire track
  libraries with the owning asset and forecloses async.
- `TryLoad` + the loader subsystem's acquire-only TSet as the root: a process-lifetime pin (nothing
  ever unloads) plus delegate machinery the processors can't use.
- Landing the weak shape as an interim: ships the null-on-editor-save trap to the first Blueprint
  author.

## Verification

- Full suite green vs the pre-change baseline (same 3 inherited dev reds, nothing new); the two
  CkTests GC regression tests flip green under the soft contract (they failed by design against
  `TObjectPtr`).
- New AutoTests (CkTests #47) pin the resolve/queue/root pipeline end-to-end incl. a full GC while
  playing.
- `[EDITOR-VERIFY]` set `_SingleTrack._Sound` on a BP cue subclass, save, reload — value persists.
- `[COOK-VERIFY]` first packaged build: code-side-only soft refs still cook.
