### PR TITLE
fix(crowd): partial path walked to its end reports OnGoalFailed, not OnGoalReached

### DIFF
--- a/Source/CkAnimationEditor/CkAnimationEditor_Module.cpp
+++ b/Source/CkAnimationEditor/CkAnimationEditor_Module.cpp
@@ -15,6 +15,14 @@ auto
     StartupModule()
     -> void
 {
+    // The editor binary also boots as a game process (process-level tests, and any -game run
+    // under a real RHI). There is no toolbar to extend there, and initializing the Slate style
+    // creates RHI textures that the game-process teardown destroys without releasing them —
+    // a fatal "FRenderResource was deleted without being released first". Under -nullrhi the
+    // same textures never acquire GPU resources, which is why this only bites with rendering on.
+    if (IsRunningGame())
+    { return; }
+
     FCkAnimationToolboxStyle::Initialize();
     FCkAnimationToolboxCommands::Register();
     DoRegisterTabSpawner();
@@ -50,6 +58,9 @@ auto
     ShutdownModule()
     -> void
 {
+    if (IsRunningGame())
+    { return; }
+
     DoUnregisterTabSpawner();
     FCkAnimationToolboxCommands::Unregister();
     FCkAnimationToolboxStyle::Shutdown();

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment.h
@@ -194,8 +194,10 @@ namespace ck
 
     // --------------------------------------------------------------------------------------------------------------------
     // OnGoalReached fires once when the path-follow cursor crosses the final waypoint within
-    // _ActiveArrivalRadius (Walking → Idle); OnGoalFailed once when CkNavigation reports Failed
-    // on the path query (PathPending → Idle).
+    // _ActiveArrivalRadius (Walking → Idle) — and only when that waypoint actually is the goal.
+    // OnGoalFailed fires once when CkNavigation reports Failed on the path query
+    // (PathPending → Idle), or when a PARTIAL path is walked to its end but the goal is
+    // unreachable from there (Walking → Idle; see _ActivePathEndsShortOfGoal).
     CK_DEFINE_SIGNAL_AND_UTILS_WITH_DELEGATE(
         CKCROWD_API,
         CrowdAgent_OnGoalReached,

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment_Data.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment_Data.h
@@ -269,6 +269,13 @@ private:
     UPROPERTY()
     FVector _CurrentSegmentStart = FVector::ZeroVector;
 
+    // A Partial path ends at the closest REACHABLE point, not the goal. Set at install when
+    // that end falls outside the arrival radius of the (projected) goal: the final-stop latch
+    // must then report OnGoalFailed, not OnGoalReached — an agent marooned off its goal's nav
+    // region otherwise "arrives" at the stub's end and no caller can tell the difference.
+    UPROPERTY()
+    bool _ActivePathEndsShortOfGoal = false;
+
     // Stationary-markup confirmation serial current when this path was installed. PathRefresh
     // compares it against each confirmed disc's serial: only a disc that became visible to Recast
     // AFTER the path can trigger a re-path, so a path that already chose to pay a disc's cost is
@@ -281,6 +288,7 @@ public:
     CK_PROPERTY_GET(_ActiveArrivalRadius);
     CK_PROPERTY_GET(_ActiveGoal);
     CK_PROPERTY_GET(_CurrentSegmentStart);
+    CK_PROPERTY_GET(_ActivePathEndsShortOfGoal);
     CK_PROPERTY_GET(_PathSerial);
 };
 

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment_Data.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Fragment_Data.h
@@ -69,6 +69,21 @@ enum class ECk_CrowdAgent_BlockedPolicy : uint8
 };
 CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_CrowdAgent_BlockedPolicy);
 
+// The agent's steering-state tag, exposed as a queryable value. The tags themselves
+// (FTag_CrowdAgent_Idle/PathPending/Walking) are EnTT fragments invisible to BP/AS, and
+// state discriminates failure modes no other getter can: Walking with zero desired
+// velocity (steering wedge) vs Idle with a live goal (arrival/stop wedge) vs a stale
+// PathPending (lost path request).
+UENUM(BlueprintType)
+enum class ECk_CrowdAgent_MovementState : uint8
+{
+    None,
+    Idle,
+    PathPending,
+    Walking
+};
+CK_DEFINE_CUSTOM_FORMATTER_ENUM(ECk_CrowdAgent_MovementState);
+
 // --------------------------------------------------------------------------------------------------------------------
 
 // Reflected ECS params for a crowd agent (radius, height, tags, locomotion, separation, etc.).

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_OnPathResolved_Processor.cpp
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_OnPathResolved_Processor.cpp
@@ -53,6 +53,22 @@ namespace ck
                 InPathFollow._PathSerial =
                     FProcessor_CrowdAgent_PathRefresh::Get_CurrentConfirmationSerial();
 
+                // Verdict for the final-stop latch: a Partial path whose reachable end is outside
+                // the arrival radius of the goal can never produce a genuine arrival — walking it
+                // to the end must report OnGoalFailed. Decided here, against nav-space points,
+                // so Steering never compares against a caller-supplied (possibly unprojected) goal.
+                InPathFollow._ActivePathEndsShortOfGoal = [&]() -> bool
+                {
+                    if (InPathResult.Get_Status() != ECk_Nav_PathStatus::Partial || Wps.Num() == 0)
+                    { return false; }
+
+                    const auto& Diag = InPathResult.Get_Diagnostics();
+                    const auto GoalOnMesh = Diag.Get_EndProjected()
+                        ? Diag.Get_LastProjectedEnd()
+                        : InPathResult.Get_DestinationLocation();
+                    return FVector::Dist(Wps.Last(), GoalOnMesh) > InPathFollow.Get_ActiveArrivalRadius();
+                }();
+
                 // Pick the STARTING waypoint: skip every leading corner the agent is ALREADY PAST
                 // (dot(corner - agent, onwardSegmentDir) < 0 — UPathFollowingComponent's
                 // HasReachedCurrentTarget test applied at install). Two ways a stale first corner

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Steering_Processor.cpp
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Steering_Processor.cpp
@@ -1,5 +1,7 @@
 #include "CkCrowdAgent_Steering_Processor.h"
 
+#include "CkCrowd/CkCrowd_Log.h"
+
 #include "CkEcs/Scheduler/CkProcessorRegistration.h"
 
 #include "CkEcsExt/Transform/CkTransform_Utils.h"
@@ -122,6 +124,20 @@ namespace ck
             auto NonConstHandle = InHandle;
             NonConstHandle.Try_Remove<FTag_CrowdAgent_Walking>();
             NonConstHandle.AddOrGet<FTag_CrowdAgent_Idle>();
+
+            // A partial path's final waypoint is the closest REACHABLE point, not the goal —
+            // reaching it is a FAILURE to reach the goal (verdict computed at install).
+            if (InPathFollow.Get_ActivePathEndsShortOfGoal())
+            {
+                ck::crowd::Verbose(
+                    TEXT("CrowdAgent [{}] walked its partial path to the end but the goal {} is unreachable from there — reporting OnGoalFailed"),
+                    NonConstHandle, InPathFollow.Get_ActiveGoal());
+
+                UUtils_Signal_CrowdAgent_OnGoalFailed::Broadcast(
+                    NonConstHandle,
+                    MakePayload(NonConstHandle));
+                return;
+            }
 
             UUtils_Signal_CrowdAgent_OnGoalReached::Broadcast(
                 NonConstHandle,

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.cpp
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.cpp
@@ -397,6 +397,30 @@ auto
 
 auto
     UCk_Utils_CrowdAgent_UE::
+    Get_MovementState(
+        const FCk_Handle_CrowdAgent& InAgent)
+    -> ECk_CrowdAgent_MovementState
+{
+    CK_ENSURE_IF_NOT(ck::IsValid(InAgent),
+        TEXT("Invalid CrowdAgent handle [{}] passed to Get_MovementState"), InAgent)
+    { return ECk_CrowdAgent_MovementState::None; }
+
+    if (InAgent.Has<ck::FTag_CrowdAgent_Walking>())
+    { return ECk_CrowdAgent_MovementState::Walking; }
+
+    if (InAgent.Has<ck::FTag_CrowdAgent_PathPending>())
+    { return ECk_CrowdAgent_MovementState::PathPending; }
+
+    if (InAgent.Has<ck::FTag_CrowdAgent_Idle>())
+    { return ECk_CrowdAgent_MovementState::Idle; }
+
+    return ECk_CrowdAgent_MovementState::None;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    UCk_Utils_CrowdAgent_UE::
     Get_ActiveGoal(
         const FCk_Handle_CrowdAgent& InAgent)
     -> FVector

--- a/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.h
+++ b/Source/CkCrowd/Public/CkCrowd/Agent/CkCrowdAgent_Utils.h
@@ -202,6 +202,15 @@ public:
     Get_IsGoalBlocked(
         const FCk_Handle_CrowdAgent& InAgent);
 
+    // The agent's steering state (Idle / PathPending / Walking) — the state tags are EnTT
+    // fragments BP/AS cannot read directly. None only before setup completes.
+    UFUNCTION(BlueprintPure,
+              Category = "Ck|Utils|CrowdAgent",
+              DisplayName="[Ck][CrowdAgent] Get Movement State")
+    static ECk_CrowdAgent_MovementState
+    Get_MovementState(
+        const FCk_Handle_CrowdAgent& InAgent);
+
     // The goal of the agent's current/last MoveTo (ZeroVector if it never had one). Lets a caller that
     // periodically re-anchors an agent tell "still the goal it is blocked on — leave HoldAndRetry alone"
     // from "the goal moved — a fresh MoveTo is warranted".

--- a/Source/CkCueEditor/CkCueEditor_Module.cpp
+++ b/Source/CkCueEditor/CkCueEditor_Module.cpp
@@ -15,6 +15,12 @@ auto
     StartupModule()
     -> void
 {
+    // Same hazard as CkAnimationEditor: the editor binary also boots as a game process, where
+    // there is no toolbar to extend and the Slate style's RHI textures are destroyed without
+    // being released. Only bites under a real RHI — -nullrhi never gives them GPU resources.
+    if (IsRunningGame())
+    { return; }
+
     FCkCueToolboxStyle::Initialize();
     FCkCueToolboxCommands::Register();
     DoRegisterTabSpawner();
@@ -50,6 +56,9 @@ auto
     ShutdownModule()
     -> void
 {
+    if (IsRunningGame())
+    { return; }
+
     DoUnregisterTabSpawner();
     FCkCueToolboxCommands::Unregister();
     FCkCueToolboxStyle::Shutdown();

--- a/Source/CkEditorStyle/Public/CkEditorStyle/CkEditorStyle_Utils.cpp
+++ b/Source/CkEditorStyle/Public/CkEditorStyle/CkEditorStyle_Utils.cpp
@@ -22,6 +22,15 @@ auto
     DoRegister_SlateStyle()
     -> void
 {
+    // The editor binary also boots as a game process (process-level tests, any -game run under a
+    // real RHI). There is no editor UI to style there, and the style's Slate textures are then
+    // destroyed by the game-process teardown without being released — a fatal "FRenderResource was
+    // deleted without being released first". Under -nullrhi they never acquire GPU resources, which
+    // is why this only bites with rendering on. Guarded here rather than in each of the twelve
+    // caller sites across CkEcsEditor / CkInventoryEditor / the style settings.
+    if (IsRunningGame())
+    { return; }
+
     if (ck::IsValid(_StyleInstance))
     { return; }
 
@@ -36,6 +45,11 @@ auto
     DoUnregister_SlateStyle()
     -> void
 {
+    // Symmetric with DoRegister_SlateStyle: nothing was registered in a game process, and the
+    // dereference below would be null there.
+    if (IsRunningGame())
+    { return; }
+
     FSlateStyleRegistry::UnRegisterSlateStyle(*_StyleInstance);
 
     CK_TRIGGER_ENSURE_IF(NOT _StyleInstance.IsUnique(), TEXT("{} SlateStyle instance is NOT Unique!"), _StyleSetName);
@@ -100,6 +114,11 @@ auto
     DoReloadTextures()
     -> void
 {
+    // ReloadTextureResources deletes the Slate texture atlas; in a game process that is the frame
+    // that fires the FRenderResource fatal. See DoRegister_SlateStyle.
+    if (IsRunningGame())
+    { return; }
+
     if (NOT FSlateApplication::IsInitialized())
     { return; }
 
@@ -120,6 +139,11 @@ auto
         const FCk_CustomAssetStyle_Params& InParams)
     -> void
 {
+    // Must early-out before the brush construction below, which reads _StyleInstance — left null by
+    // the guard in DoRegister_SlateStyle. See DoRegister_SlateStyle.
+    if (IsRunningGame())
+    { return; }
+
     if (ck::Is_NOT_Valid(_StyleInstance))
     {
         DoRegister_SlateStyle();


### PR DESCRIPTION
## What

Two CkCrowd changes, the first behavioral:

1. **`429f44fcf`** — a partial path whose stub ends farther than the arrival radius from the projected goal now reports **OnGoalFailed** at the final stop instead of OnGoalReached. The partiality verdict (`_ActivePathEndsShortOfGoal`) is computed once at path install, in nav-space against the projected end so navmesh snap distance can't distort it. A partial stub that ends *within* the radius still counts as arrival (queue-anchor walk-backs depend on that).
2. **`9cd7c26c4`** — diagnostic getter `Get_MovementState` (Idle/PathPending/Walking) exposing the state tags BP/AS can't read.

## Why

BusterBlock's checkout immobility wedge (Q51.3, the "NPC stuck forever" class): a marooned agent walked a partial path to its stub-end and CkCrowd reported success — so every failure net keyed on OnGoalFailed stayed permanently silent, the NPC's IsStuck latched, and the customer leaked from the population forever. Any arrival signal that can fire without the goal being reached defeats downstream failure recovery undetectably.

Consumer note: **OnGoalFailed now also means "walked a partial path to its end"**, not just query failure. BB pairs this with a retry cadence + escape-valve duration guard (BusterBlock PR #2566).

## Evidence

- Red: BB stress probe pre-fix — 2 permanent ghosts / 600s window, forensics `pathStatus=Partial, agentState=Idle, wp=2/2` far from goal.
- Green: post-fix — ghosts 0, marooned tourists reaped by the escape valve in ~30-50s, throughput unchanged (205 vs 206 served / 600s). Full gate set on the BB side green (Checkout 37/37, NpcAI 14/14, QueuePoints 2/2, wedge gauntlets PASS).

Rebase-merge per repo policy is fine — BusterBlock #2566’s submodule gitlink currently references 429f44fcf and will be re-pointed to the post-rebase SHA once this lands (one fixup on the BB PR branch).

Base includes `8b88c5369` (Slate style skip in game processes) from `bugfix/gauntlet-visual-slate-style` — it was the deliberate work-ahead this branch stacked on, and all verification ran against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
