### PR TITLE
fix(asset-exporter): sidecars become .ckexport so auto-reimport cannot see them

### DIFF
--- a/Source/CkAssetExporter/CkAssetExporter.Build.cs
+++ b/Source/CkAssetExporter/CkAssetExporter.Build.cs
@@ -23,6 +23,7 @@ public class CkAssetExporter : CkModuleRules
             "AssetTools",
             "AssetRegistry",
             "ContentBrowser",
+            "DirectoryWatcher",
             "WorkspaceMenuStructure",
             "AIModule",
             "GameplayTasks",

--- a/Source/CkAssetExporter/CkAssetExporter_Module.cpp
+++ b/Source/CkAssetExporter/CkAssetExporter_Module.cpp
@@ -12,6 +12,7 @@
 #include "CkAssetExporter/AssetAction/CkUserDefinedEnumExporter_AssetAction.h"
 #include "CkAssetExporter/AssetAction/CkUserDefinedStructExporter_AssetAction.h"
 #include "CkAssetExporter/ExporterTab/SCkAssetExporterTab.h"
+#include "CkAssetExporter/Validation/CkAssetExporter_AutoReimportGuard.h"
 #include "CkAssetExporter/VfxCorpusExporter/CkVfxCorpusExporter.h"
 
 #include <ToolMenus.h>
@@ -48,6 +49,10 @@ auto
     DoRegisterTabSpawner();
 
     FCk_AssetExporter_OnSaveHook::Register();
+
+    // Deferred to post-engine-init: the guard enumerates every import factory CDO, which is only complete once the
+    // engine has finished loading the modules that declare them.
+    _AutoReimportGuardHandle = FCoreDelegates::OnPostEngineInit.AddStatic(&FCk_AssetExporter_AutoReimportGuard::Validate);
 }
 
 auto
@@ -55,6 +60,12 @@ auto
     ShutdownModule()
     -> void
 {
+    if (_AutoReimportGuardHandle.IsValid())
+    {
+        FCoreDelegates::OnPostEngineInit.Remove(_AutoReimportGuardHandle);
+        _AutoReimportGuardHandle.Reset();
+    }
+
     FCk_AssetExporter_OnSaveHook::Unregister();
 
     DoUnregisterTabSpawner();

--- a/Source/CkAssetExporter/CkAssetExporter_Module.h
+++ b/Source/CkAssetExporter/CkAssetExporter_Module.h
@@ -19,6 +19,9 @@ private:
     auto DoOnSpawnTab(const FSpawnTabArgs& Args) -> TSharedRef<SDockTab>;
 
 private:
+    FDelegateHandle _AutoReimportGuardHandle;
+
+private:
     static constexpr auto ExporterTab_TabName = "CkAssetExporterTab";
     static constexpr auto ExporterTab_TabDisplayName = "Asset Exporter";
 };

--- a/Source/CkAssetExporter/Claude.md
+++ b/Source/CkAssetExporter/Claude.md
@@ -2,6 +2,53 @@
 
 **Purpose:** Asset export utilities — exports CkFoundation asset data to external formats (JSON, etc.) for tooling, auditing, or external pipelines.
 
+## The sidecar extension is `.ckexport`, and it is JSON (2026-08-01)
+
+`<Asset>.ckexport` sits next to `<Asset>.uasset` and is **plain UTF-8 JSON** — Read/Grep it directly.
+Every sidecar's `_meta.format` says so in its own first lines, so a reader who opens one cold needs
+no doc.
+
+**Why not `.json`.** `FAutoReimportManager::SetUpDirectoryMonitors` stamps every watched content
+directory with `SetApplicableExtensions(GetAllFactoryExtensions())`, and json IS a registered import
+format (`UReimportDataTableFactory`). A committed sidecar corpus therefore accumulates into the
+monitor's pending set, parks its state machine on the *"N changes to source content files"* prompt,
+and — while parked — re-stats **the entire outstanding set every frame**. Measured on BusterBlock's
+1,178-file corpus: **18.8 fps, editor-wide, on every map**, with the game thread at 99.7% of a core
+looking compute-bound while actually blocked in `FileExists`/`GetTimeStamp` through the NTFS +
+Defender filter drivers. No UE-side profiler can see it (Insights attributes it to `Tick_Engine`
+self-time; `SimpleTickObjects` → `FAutoReimportManager` carries no stat scope) — it took `xperf`
+stack sampling to find. `FMatchRules::IsFileApplicable` rejects an unclaimed extension **before any
+wildcard rule**, so an extension no factory claims is invisible to the monitor in every consuming
+project with zero configuration. That is the whole mechanism.
+
+Two constraints that make it work, both enforced by tests:
+- **Terminal extension only.** `MatchExtensionString` reads the FINAL extension (`Strrchr`), so
+  `Foo.export.json` still parses as json. Any replacement must be the last extension.
+- **Must stay unclaimed.** `Ck.AssetExporter.Dispatch.SidecarExtensionUnclaimed` asserts no import
+  factory claims it, with a control assertion that json *is* claimed so the test cannot pass
+  vacuously. Changing the extension to something a factory claims silently reintroduces the 18 fps
+  bug — that test is the only thing standing in the way.
+
+Extensions live in one place: `ck::asset_exporter::extension::{Sidecar, SummaryText, Csv}`
+(`ExportMeta/CkAssetExporter_ExportMeta.h`). Corpus-mode output (non-empty `InOutputDir` →
+`Saved/CkVfxCorpus/`) deliberately keeps `.json`: it is outside `Content/`, never watched, never
+committed.
+
+**Startup guard.** `Validation/CkAssetExporter_AutoReimportGuard` runs at `OnPostEngineInit` and
+warns — naming the exact `AutoReimportDirectorySettings` line — if any extension this module writes
+under `Content/` is factory-claimed AND not excluded by the effective monitor. It rebuilds the
+engine's own parse + same-or-parent dedup and asks `FMatchRules::IsFileApplicable`, rather than
+approximating. `.csv` is deliberately NOT probed: a DataTable's csv sidecar is a legitimate
+re-import source for that DataTable, so a monitor picking it up is correct behaviour.
+
+**Auto path is JSON-only.** `ExportAssets`/`SweepDirectory` take
+`ECk_AssetExporter_SidecarFormats`; the on-save hook passes `JsonOnly`, every manual path
+(right-click, Exporter Tab, commandlet, server/bridge) keeps `JsonAndText`. Rationale: the `.txt`
+summary is lossy AND gitignored in consuming projects, so it is never shared and drifts — BB's
+committed `StoreDriver_BB_BP.txt` still listed variables renamed months earlier. Refreshing it on
+every save cost I/O for a file nobody read. DataTable `.csv` and the WBP paste artifacts still
+emit on both paths: they are consumed data artifacts, not the drift-prone summary.
+
 **Supported asset types:** Behavior Trees, Blueprints, Data Assets, EQS Queries, State Trees, Blueprint structs (`UUserDefinedStruct`), Blueprint enums (`UUserDefinedEnum`), **Niagara systems**, **Cascade particle systems**, **materials / material instances** (`UMaterialInterface` — json-only, dispatch-routed 2026-07-20), and **textures** (corpus-chained only — no standalone right-click/dispatch entry). Most are exposed as Content Browser right-click actions (`AssetAction/`) and buttons in the batch Exporter Tab (`ExporterTab/`). State Trees walk the authored `UStateTreeEditorData` (states, tasks, conditions, transitions, global tasks/evaluators). Blueprint structs export their schema (each field's authored name, internal name, CPP type, category, tooltip) plus default values read from the struct's default instance — reusing `FCk_DataAssetExporter`'s shared property serializer. Blueprint enums export each authored enumerator's display name, internal name, fully-qualified name, numeric value, and tooltip (the auto-generated trailing `_MAX` is skipped via the `NumEnums()-1` idiom).
 
 **VFX corpus pipeline (2026-07-12):** `FCk_NiagaraExporter` deconstructs a system into a JSON+text recipe — emitter module stacks with Rapid-Iteration constants, **override-pin harvesting** (dynamic inputs, curve DIs rasterized to keys via `UNiagaraDataInterfaceCurveBase::GetCurveData`, attribute links; nested dynamic-input overrides re-associated via `DoExpandDynamicInputOverrides`, orphans surfaced as `unattachedOverrides` — never silently dropped), enum display names, user-param values, determinism/bounds, renderer detail with material paths. `FCk_CascadeExporter` dumps legacy `UParticleSystem` LOD-0 modules generically via reflection with `UDistribution*` rasterization. `FCk_MaterialExporter` (blend/shading/params + expression histogram + `GetUsedTextures`) and `FCk_TextureExporter` (editor source → PNG capped at 1024 + metadata) chain off renderer material references; `FCk_MaterialExporter` is **dual-mode** (2026-07-20): a set `InOutputDir` writes into the corpus tree (as before), an empty default writes the sibling `<Asset>.json` next to the `.uasset` and stamps `_meta` (`version::Material`), so it is now a first-class dispatch/right-click/tab type. It is json-only — no `.txt` sibling, so it carries no freshness banner; the sibling json's `_meta` is its freshness oracle. `FCk_MeshExporter` (LOD-0 render geometry → Wavefront OBJ + stats JSON with bounds/UV-ranges/sections; UE V-down UV convention noted in the OBJ header) chains off mesh-renderer `Meshes` references into `meshes/` — the carrier geometry (slash sweeps, shells, trails) VFX recreation needs. `FCk_VfxCorpusExporter` orchestrates a batch over asset-registry class sweeps into `Saved/CkVfxCorpus/` (`index.json` manifest; per-asset failures recorded, never skipped; output dirs mirror package folder chains so same-named assets can't collide). Entry points: automation test `Ck.AssetExporter.ExportVfxCorpus` (**gated on env `CK_VFX_CORPUS_EXPORT=1`** — instant skip otherwise; StressFilter is unusable because the automation commandline's "Standard" filter excludes it) and console command `Ck.AssetExporter.ExportVfxCorpus`. Gotchas that cost time once: `UNiagaraNodeParameterMapSet`/`NiagaraNodeParameterMapBase.h` are Private NiagaraEditor headers (detect override nodes by class name on `UEdGraphNode`); `UNiagaraNodeInput`'s accessors are MinimalAPI-unexported (read `DataInterface`/`ObjectAsset` UPROPERTYs via `FindFProperty`); the 5-arg `GetUsedTextures` overload is a UE_DEPRECATED(5.7) final no-op (use the TOptional overload).
@@ -22,8 +69,9 @@ commandlet command line. Components:
   `Saved/CkAssetExporter/LastRun.json` manifest (`entries` array). All externally-consumed paths
   are `ConvertRelativePathToFull` — relative `ProjectSavedDir` forms don't resolve from a
   submitter's cwd.
-- `ExportMeta/` — deterministic `_meta` (source .uasset MD5 + per-exporter version constant)
-  stamped in every sibling `.json`; powers `-SkipFresh` (hash AND version must match). Bump the
+- `ExportMeta/` — deterministic `_meta` (`format` self-description + source .uasset MD5 +
+  per-exporter version constant)
+  stamped in every sibling `.ckexport`; powers `-SkipFresh` (hash AND version must match). Bump the
   version constant whenever an exporter's output shape changes (`version::Blueprint = 2` — bumped
   for the WBP paste artifacts: `hierarchy.copy.txt` + per-animation t3d dumps). Only the versioned
   exporters participate in the `-SkipFresh` gate at all — Niagara and Cascade stamp no versioned
@@ -52,8 +100,9 @@ commandlet command line. Components:
   `ck.AssetExporter.AutoSidecarOnSave`); inert for commandlets/procedural saves/non-canonical
   save targets (autosaves must not stamp sidecars with unsaved states). This is what keeps
   committed sidecars truthful MECHANICALLY rather than by convention: every editor save of a
-  logic-bearing asset re-exports its sibling `.json`/`.txt` in place, and because output is
-  deterministic + write-if-changed, saving an unchanged asset produces zero diff noise.
+  logic-bearing asset re-exports its sibling `.ckexport` in place (JSON only — see the extension
+  section above), and because output is deterministic + write-if-changed, saving an unchanged asset
+  produces zero diff noise.
 - `DataTableExporter/`, `GraphDump/` — sibling `.csv` + rows-json; full dependency graph with
   hard/soft deps and cascade/redirector hazard flags. `GraphDump/` enumerates with NO class filter
   (migration-closure planning must see art and redirectors too) and records dependencies pointing

--- a/Source/CkAssetExporter/Public/CkAssetExporter/AutoSidecar/CkAssetExporter_OnSaveHook.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/AutoSidecar/CkAssetExporter_OnSaveHook.cpp
@@ -60,8 +60,12 @@ namespace ck_asset_exporter_onsavehook
         if (NOT FCk_AssetExporter_Dispatch::Get_IsExportableClass(Asset->GetClass()))
         { return; }
 
+        // JsonOnly: the summary text is lossy and gitignored in consuming projects, so it is never shared and drifts
+        // silently out of date. The structured sidecar is the artifact that must stay truthful on every save; the
+        // manual right-click path still writes both for anyone who wants the readable companion.
         constexpr auto SkipFresh = false;
-        const auto Summary = FCk_AssetExporter_Dispatch::ExportAssets({ Asset->GetPathName() }, SkipFresh);
+        const auto Summary = FCk_AssetExporter_Dispatch::ExportAssets(
+            { Asset->GetPathName() }, SkipFresh, ECk_AssetExporter_SidecarFormats::JsonOnly);
 
         if (Summary.Failed > 0)
         {

--- a/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.cpp
@@ -27,7 +27,8 @@
 auto
     FCk_BehaviorTreeExporter::
     ExportBehaviorTree(
-        UBehaviorTree* InBehaviorTree)
+        UBehaviorTree* InBehaviorTree,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_BehaviorTreeExportResult
 {
     auto Result = FCk_BehaviorTreeExportResult{};
@@ -51,12 +52,14 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto TextString = DoSerializeToText(InBehaviorTree);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InBehaviorTree, TEXT(".json"));
-    const auto TextPath = DoResolveOutputPath(InBehaviorTree, TEXT(".txt"));
+    const auto TextString = WriteText ? DoSerializeToText(InBehaviorTree) : FString{};
 
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto JsonPath = DoResolveOutputPath(InBehaviorTree, ck::asset_exporter::extension::Sidecar);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InBehaviorTree, ck::asset_exporter::extension::SummaryText) : FString{};
+
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -64,7 +67,7 @@ auto
 
     const auto bJsonWritten = FFileHelper::SaveStringToFile(
         JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto bTextWritten = FFileHelper::SaveStringToFile(
+    const auto bTextWritten = NOT WriteText || FFileHelper::SaveStringToFile(
         TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 
     if (!bJsonWritten || !bTextWritten)

--- a/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -35,7 +37,8 @@ class CKASSETEXPORTER_API FCk_BehaviorTreeExporter
 public:
     static auto
     ExportBehaviorTree(
-        UBehaviorTree* InBehaviorTree) -> FCk_BehaviorTreeExportResult;
+        UBehaviorTree* InBehaviorTree,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_BehaviorTreeExportResult;
 
     static auto
     ExportBehaviorTrees(

--- a/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.cpp
@@ -52,7 +52,8 @@
 auto
     FCk_BlueprintExporter::
     ExportBlueprint(
-        UBlueprint* InBlueprint)
+        UBlueprint* InBlueprint,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_BlueprintExportResult
 {
     auto Result = FCk_BlueprintExportResult{};
@@ -76,12 +77,14 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto TextString = DoSerializeToText(InBlueprint);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InBlueprint, TEXT(".json"));
-    const auto TextPath = DoResolveOutputPath(InBlueprint, TEXT(".txt"));
+    const auto TextString = WriteText ? DoSerializeToText(InBlueprint) : FString{};
 
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto JsonPath = DoResolveOutputPath(InBlueprint, ck::asset_exporter::extension::Sidecar);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InBlueprint, ck::asset_exporter::extension::SummaryText) : FString{};
+
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -89,7 +92,7 @@ auto
 
     const auto JsonWritten = FFileHelper::SaveStringToFile(
         JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto TextWritten = FFileHelper::SaveStringToFile(
+    const auto TextWritten = NOT WriteText || FFileHelper::SaveStringToFile(
         TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 
     if (NOT JsonWritten || NOT TextWritten)

--- a/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -39,7 +41,8 @@ class CKASSETEXPORTER_API FCk_BlueprintExporter
 public:
     static auto
     ExportBlueprint(
-        UBlueprint* InBlueprint) -> FCk_BlueprintExportResult;
+        UBlueprint* InBlueprint,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_BlueprintExportResult;
 
     static auto
     ExportBlueprints(

--- a/Source/CkAssetExporter/Public/CkAssetExporter/CascadeExporter/CkCascadeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/CascadeExporter/CkCascadeExporter.cpp
@@ -76,7 +76,8 @@ auto
     FCk_CascadeExporter::
     ExportParticleSystem(
         UParticleSystem* InSystem,
-        const FString& InOutputDir)
+        const FString& InOutputDir,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_CascadeExportResult
 {
     auto Result = FCk_CascadeExportResult{};
@@ -99,11 +100,17 @@ auto
         FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
     }
 
-    const auto TextString = DoSerializeToText(JsonObject);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InSystem, TEXT(".json"), InOutputDir);
-    const auto TextPath = DoResolveOutputPath(InSystem, TEXT(".txt"), InOutputDir);
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto TextString = WriteText ? DoSerializeToText(JsonObject) : FString{};
+
+    // Corpus mode writes outside Content/, where the auto-reimport monitor never looks and nothing is committed —
+    // plain .json is friendlier for those consumers. Only the sibling written next to a .uasset needs to be invisible.
+    const auto StructuredExtension = InOutputDir.IsEmpty() ? ck::asset_exporter::extension::Sidecar : FString{TEXT(".json")};
+
+    const auto JsonPath = DoResolveOutputPath(InSystem, StructuredExtension, InOutputDir);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InSystem, ck::asset_exporter::extension::SummaryText, InOutputDir) : FString{};
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -116,7 +123,7 @@ auto
     }
 
     const auto JsonWritten = FFileHelper::SaveStringToFile(JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto TextWritten = FFileHelper::SaveStringToFile(TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+    const auto TextWritten = NOT WriteText || FFileHelper::SaveStringToFile(TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
     if (NOT JsonWritten || NOT TextWritten)
     {
         Result.ErrorMessage = ck::Format_UE(TEXT("Failed to write files (JSON: {}, Text: {})"),

--- a/Source/CkAssetExporter/Public/CkAssetExporter/CascadeExporter/CkCascadeExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/CascadeExporter/CkCascadeExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -33,8 +35,8 @@ struct CKASSETEXPORTER_API FCk_CascadeExportResult
 class CKASSETEXPORTER_API FCk_CascadeExporter
 {
 public:
-    // InOutputDir: when set, writes <AssetName>.json/.txt into that directory instead of next to the asset.
-    static auto ExportParticleSystem (UParticleSystem* InSystem, const FString& InOutputDir = FString{}) -> FCk_CascadeExportResult;
+    // InOutputDir: when set, writes <AssetName>.ckexport/.txt into that directory instead of next to the asset.
+    static auto ExportParticleSystem (UParticleSystem* InSystem, const FString& InOutputDir = FString{}, ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_CascadeExportResult;
     static auto ExportParticleSystems(const TArray<UParticleSystem*>& InSystems) -> TArray<FCk_CascadeExportResult>;
 
 private:

--- a/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.cpp
@@ -44,7 +44,8 @@ namespace ck_data_asset_exporter_internal
 auto
     FCk_DataAssetExporter::
     ExportDataAsset(
-        UDataAsset* InDataAsset)
+        UDataAsset* InDataAsset,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_DataAssetExportResult
 {
     using namespace ck_data_asset_exporter_internal;
@@ -74,12 +75,14 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto TextString = DoSerializeToText(InDataAsset);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InDataAsset, TEXT(".json"));
-    const auto TextPath = DoResolveOutputPath(InDataAsset, TEXT(".txt"));
+    const auto TextString = WriteText ? DoSerializeToText(InDataAsset) : FString{};
 
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto JsonPath = DoResolveOutputPath(InDataAsset, ck::asset_exporter::extension::Sidecar);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InDataAsset, ck::asset_exporter::extension::SummaryText) : FString{};
+
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -87,7 +90,7 @@ auto
 
     const auto JsonWritten = FFileHelper::SaveStringToFile(
         JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto TextWritten = FFileHelper::SaveStringToFile(
+    const auto TextWritten = NOT WriteText || FFileHelper::SaveStringToFile(
         TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 
     if (NOT JsonWritten || NOT TextWritten)

--- a/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -27,7 +29,8 @@ class CKASSETEXPORTER_API FCk_DataAssetExporter
 public:
     static auto
     ExportDataAsset(
-        UDataAsset* InDataAsset) -> FCk_DataAssetExportResult;
+        UDataAsset* InDataAsset,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_DataAssetExportResult;
 
     static auto
     ExportDataAssets(

--- a/Source/CkAssetExporter/Public/CkAssetExporter/DataTableExporter/CkDataTableExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/DataTableExporter/CkDataTableExporter.cpp
@@ -57,8 +57,8 @@ auto
 
     Result.AssetName = InDataTable->GetName();
 
-    const auto JsonPath = ck_data_table_exporter::DoResolveOutputPath(InDataTable, TEXT(".json"));
-    const auto CsvPath  = ck_data_table_exporter::DoResolveOutputPath(InDataTable, TEXT(".csv"));
+    const auto JsonPath = ck_data_table_exporter::DoResolveOutputPath(InDataTable, ck::asset_exporter::extension::Sidecar);
+    const auto CsvPath  = ck_data_table_exporter::DoResolveOutputPath(InDataTable, ck::asset_exporter::extension::Csv);
     if (JsonPath.IsEmpty() || CsvPath.IsEmpty())
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");

--- a/Source/CkAssetExporter/Public/CkAssetExporter/Dispatch/CkAssetExporter_Dispatch.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/Dispatch/CkAssetExporter_Dispatch.cpp
@@ -114,7 +114,7 @@ namespace ck_asset_exporter_dispatch
         InOutEntry.ErrorMessage = InResult.ErrorMessage;
     }
 
-    // True (and stamps the entry as a skip) when skip-fresh is on and the sibling json is up to date for InVersion.
+    // True (and stamps the entry as a skip) when skip-fresh is on and the sibling sidecar is up to date for InVersion.
     static auto
     Is_FreshAndSkip(
         const UObject* InAsset,
@@ -126,7 +126,7 @@ namespace ck_asset_exporter_dispatch
         if (NOT InSkipFresh)
         { return false; }
 
-        const auto SiblingJson = FCk_AssetExporter_Dispatch::Get_SiblingJsonPathForAsset(InAsset);
+        const auto SiblingJson = FCk_AssetExporter_Dispatch::Get_SiblingSidecarPathForAsset(InAsset);
         if (SiblingJson.IsEmpty())
         { return false; }
 
@@ -145,6 +145,7 @@ namespace ck_asset_exporter_dispatch
     Route(
         UObject* InAsset,
         bool InSkipFresh,
+        ECk_AssetExporter_SidecarFormats InFormats,
         FCk_AssetExportDispatchEntryResult& InOutEntry)
         -> void
     {
@@ -154,52 +155,52 @@ namespace ck_asset_exporter_dispatch
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::BehaviorTree, InOutEntry))
             { return; }
-            Fill_Entry(InOutEntry, FCk_BehaviorTreeExporter::ExportBehaviorTree(BehaviorTree));
+            Fill_Entry(InOutEntry, FCk_BehaviorTreeExporter::ExportBehaviorTree(BehaviorTree, InFormats));
             return;
         }
         if (auto* Query = Cast<UEnvQuery>(InAsset))
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::EQS, InOutEntry))
             { return; }
-            Fill_Entry(InOutEntry, FCk_EQSExporter::ExportEQS(Query));
+            Fill_Entry(InOutEntry, FCk_EQSExporter::ExportEQS(Query, InFormats));
             return;
         }
         if (auto* StateTree = Cast<UStateTree>(InAsset))
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::StateTree, InOutEntry))
             { return; }
-            Fill_Entry(InOutEntry, FCk_StateTreeExporter::ExportStateTree(StateTree));
+            Fill_Entry(InOutEntry, FCk_StateTreeExporter::ExportStateTree(StateTree, InFormats));
             return;
         }
         if (auto* Enum = Cast<UUserDefinedEnum>(InAsset))
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::UserDefinedEnum, InOutEntry))
             { return; }
-            Fill_Entry(InOutEntry, FCk_UserDefinedEnumExporter::ExportUserDefinedEnum(Enum));
+            Fill_Entry(InOutEntry, FCk_UserDefinedEnumExporter::ExportUserDefinedEnum(Enum, InFormats));
             return;
         }
         if (auto* Struct = Cast<UUserDefinedStruct>(InAsset))
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::UserDefinedStruct, InOutEntry))
             { return; }
-            Fill_Entry(InOutEntry, FCk_UserDefinedStructExporter::ExportUserDefinedStruct(Struct));
+            Fill_Entry(InOutEntry, FCk_UserDefinedStructExporter::ExportUserDefinedStruct(Struct, InFormats));
             return;
         }
         if (auto* Blueprint = Cast<UBlueprint>(InAsset)) // covers UWidgetBlueprint
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::Blueprint, InOutEntry))
             { return; }
-            Fill_Entry(InOutEntry, FCk_BlueprintExporter::ExportBlueprint(Blueprint));
+            Fill_Entry(InOutEntry, FCk_BlueprintExporter::ExportBlueprint(Blueprint, InFormats));
             return;
         }
         if (auto* NiagaraSystem = Cast<UNiagaraSystem>(InAsset)) // no versioned meta — never skips
         {
-            Fill_Entry(InOutEntry, FCk_NiagaraExporter::ExportNiagaraSystem(NiagaraSystem));
+            Fill_Entry(InOutEntry, FCk_NiagaraExporter::ExportNiagaraSystem(NiagaraSystem, FString{}, InFormats));
             return;
         }
         if (auto* CascadeSystem = Cast<UParticleSystem>(InAsset)) // no versioned meta — never skips
         {
-            Fill_Entry(InOutEntry, FCk_CascadeExporter::ExportParticleSystem(CascadeSystem));
+            Fill_Entry(InOutEntry, FCk_CascadeExporter::ExportParticleSystem(CascadeSystem, FString{}, InFormats));
             return;
         }
         if (auto* Material = Cast<UMaterialInterface>(InAsset)) // covers UMaterial + UMaterialInstance(Constant)
@@ -213,6 +214,7 @@ namespace ck_asset_exporter_dispatch
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::DataTable, InOutEntry))
             { return; }
+            // The csv is a data artifact external tooling consumes, not the lossy summary text — always written.
             Fill_Entry(InOutEntry, FCk_DataTableExporter::ExportDataTable(DataTable));
             return;
         }
@@ -220,7 +222,7 @@ namespace ck_asset_exporter_dispatch
         {
             if (Is_FreshAndSkip(InAsset, InSkipFresh, ck::asset_exporter::version::DataAsset, InOutEntry))
             { return; }
-            Fill_Entry(InOutEntry, FCk_DataAssetExporter::ExportDataAsset(DataAsset));
+            Fill_Entry(InOutEntry, FCk_DataAssetExporter::ExportDataAsset(DataAsset, InFormats));
             return;
         }
 
@@ -345,7 +347,7 @@ auto
 
 auto
     FCk_AssetExporter_Dispatch::
-    Get_SiblingJsonPathForAsset(
+    Get_SiblingSidecarPathForAsset(
         const UObject* InAsset)
     -> FString
 {
@@ -358,7 +360,7 @@ auto
     if (NOT FPackageName::TryConvertLongPackageNameToFilename(PackageName, DiskPath))
     { return {}; }
 
-    return DiskPath + TEXT(".json");
+    return DiskPath + ck::asset_exporter::extension::Sidecar;
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -480,7 +482,8 @@ auto
     FCk_AssetExporter_Dispatch::
     ExportAssets(
         const TArray<FString>& InObjectPaths,
-        bool InSkipFresh)
+        bool InSkipFresh,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_AssetExportDispatchSummary
 {
     auto Summary = FCk_AssetExportDispatchSummary{};
@@ -502,7 +505,7 @@ auto
         }
         else
         {
-            ck_asset_exporter_dispatch::Route(Asset, InSkipFresh, Entry);
+            ck_asset_exporter_dispatch::Route(Asset, InSkipFresh, InFormats, Entry);
         }
 
         ck_asset_exporter_dispatch::Tally_Entry(Summary, MoveTemp(Entry));
@@ -521,7 +524,8 @@ auto
     SweepDirectory(
         const FString& InPackageDir,
         const TArray<FString>& InClassFilters,
-        bool InSkipFresh)
+        bool InSkipFresh,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_AssetExportDispatchSummary
 {
     auto Summary = FCk_AssetExportDispatchSummary{};
@@ -560,7 +564,7 @@ auto
         }
         else
         {
-            ck_asset_exporter_dispatch::Route(Asset, InSkipFresh, Entry);
+            ck_asset_exporter_dispatch::Route(Asset, InSkipFresh, InFormats, Entry);
         }
 
         ck_asset_exporter_dispatch::Tally_Entry(Summary, MoveTemp(Entry));

--- a/Source/CkAssetExporter/Public/CkAssetExporter/Dispatch/CkAssetExporter_Dispatch.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/Dispatch/CkAssetExporter_Dispatch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 
 #include "CoreMinimal.h"
@@ -55,14 +57,16 @@ public:
     static auto
     ExportAssets(
         const TArray<FString>& InObjectPaths,
-        bool InSkipFresh) -> FCk_AssetExportDispatchSummary;
+        bool InSkipFresh,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_AssetExportDispatchSummary;
 
     // Recursive. Empty InClassFilters = every supported type; an unknown friendly name = summary-level failure.
     static auto
     SweepDirectory(
         const FString& InPackageDir,
         const TArray<FString>& InClassFilters,
-        bool InSkipFresh) -> FCk_AssetExportDispatchSummary;
+        bool InSkipFresh,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_AssetExportDispatchSummary;
 
     // Same filter as SweepDirectory but no loading. A bad filter name returns "ok": false + "error".
     static auto
@@ -85,9 +89,10 @@ public:
         const FString& InName,
         FString& OutError) -> UClass*;
 
-    // Empty when the package can't be resolved to a filename.
+    // The structured sidecar (<Asset>.ckexport) next to the source .uasset. Empty when the package can't be
+    // resolved to a filename.
     static auto
-    Get_SiblingJsonPathForAsset(
+    Get_SiblingSidecarPathForAsset(
         const UObject* InAsset) -> FString;
 
     // The on-save sidecar hook's cheap pre-filter — art saves must not spam export attempts.

--- a/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.cpp
@@ -62,7 +62,8 @@ static auto
 auto
     FCk_EQSExporter::
     ExportEQS(
-        UEnvQuery* InQuery)
+        UEnvQuery* InQuery,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_EQSExportResult
 {
     auto Result = FCk_EQSExportResult{};
@@ -86,12 +87,14 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto TextString = DoSerializeToText(InQuery);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InQuery, TEXT(".json"));
-    const auto TextPath = DoResolveOutputPath(InQuery, TEXT(".txt"));
+    const auto TextString = WriteText ? DoSerializeToText(InQuery) : FString{};
 
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto JsonPath = DoResolveOutputPath(InQuery, ck::asset_exporter::extension::Sidecar);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InQuery, ck::asset_exporter::extension::SummaryText) : FString{};
+
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -99,7 +102,7 @@ auto
 
     const auto bJsonWritten = FFileHelper::SaveStringToFile(
         JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto bTextWritten = FFileHelper::SaveStringToFile(
+    const auto bTextWritten = NOT WriteText || FFileHelper::SaveStringToFile(
         TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 
     if (!bJsonWritten || !bTextWritten)

--- a/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -30,7 +32,8 @@ class CKASSETEXPORTER_API FCk_EQSExporter
 public:
     static auto
     ExportEQS(
-        UEnvQuery* InQuery) -> FCk_EQSExportResult;
+        UEnvQuery* InQuery,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_EQSExportResult;
 
     static auto
     ExportEQSQueries(

--- a/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.cpp
@@ -66,6 +66,9 @@ auto
     -> TSharedPtr<FJsonObject>
 {
     auto Meta = MakeShared<FJsonObject>();
+    // Stamped here rather than at each exporter's root so it cannot drift and future exporters inherit it: a reader
+    // who opens a .ckexport cold must learn what the file is from the file, not from a doc they may never find.
+    Meta->SetStringField(TEXT("format"), TEXT("CkAssetExporter sidecar - UTF-8 JSON export of the sibling .uasset of the same name"));
     Meta->SetStringField(TEXT("sourceHash"), Get_SourceHash(InAsset));
     Meta->SetNumberField(TEXT("exporterVersion"), InExporterVersion);
     return Meta;
@@ -150,10 +153,11 @@ auto
 {
     return FString::Printf(
         TEXT("// [CkAssetExporter] Human-readable companion - carries NO freshness metadata.\n")
-        TEXT("// Freshness oracle: sibling %s.json \"_meta\" (source-asset MD5 + exporter version);\n")
+        TEXT("// Freshness oracle: sibling %s%s \"_meta\" (source-asset MD5 + exporter version);\n")
         TEXT("// its verdict covers this file (all siblings are written in the same export call).\n")
         TEXT("\n"),
-        *InAssetName);
+        *InAssetName,
+        *ck::asset_exporter::extension::Sidecar);
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h
@@ -14,16 +14,53 @@ class UObject;
 
 namespace ck::asset_exporter::version
 {
-    inline constexpr int32 DataAsset = 1;
-    inline constexpr int32 DataTable = 1;
-    inline constexpr int32 Blueprint = 2;
-    inline constexpr int32 BehaviorTree = 1;
-    inline constexpr int32 EQS = 1;
-    inline constexpr int32 StateTree = 1;
-    inline constexpr int32 UserDefinedEnum = 1;
-    inline constexpr int32 UserDefinedStruct = 1;
-    inline constexpr int32 Material = 1;
+    inline constexpr int32 DataAsset = 2;
+    inline constexpr int32 DataTable = 2;
+    inline constexpr int32 Blueprint = 3;
+    inline constexpr int32 BehaviorTree = 2;
+    inline constexpr int32 EQS = 2;
+    inline constexpr int32 StateTree = 2;
+    inline constexpr int32 UserDefinedEnum = 2;
+    inline constexpr int32 UserDefinedStruct = 2;
+    inline constexpr int32 Material = 2;
 }
+
+// --------------------------------------------------------------------------------------------------------------------
+// Sidecar file extensions, written next to the source .uasset under Content/.
+//
+// The structured sidecar deliberately does NOT end in ".json". UE's auto-reimport monitor applies
+// SetApplicableExtensions(GetAllFactoryExtensions()) to every watched content directory, and json IS a registered
+// import format (UReimportDataTableFactory). A watched sidecar corpus accumulates into the monitor's pending set,
+// parks its state machine on the "N changes to source content files" prompt, and re-stats the entire outstanding set
+// EVERY FRAME while parked -- measured at 18 fps on a 1,178-file corpus. FMatchRules::IsFileApplicable gates on the
+// extension BEFORE any wildcard rule, so an extension no factory claims is invisible to the monitor in every project
+// with zero configuration. The gate reads the FINAL extension only (MatchExtensionString -> Strrchr): "Foo.x.json"
+// still parses as json, so this must remain a terminal extension.
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ck::asset_exporter::extension
+{
+    // The structured, lossless export. Plain UTF-8 JSON content despite the extension.
+    inline const FString Sidecar = TEXT(".ckexport");
+
+    // The human-readable companion summary. Lossy; manual-export path only.
+    inline const FString SummaryText = TEXT(".txt");
+
+    // DataTable row dump.
+    inline const FString Csv = TEXT(".csv");
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Which sibling files an export call writes. The on-save path is JsonOnly: the summary text is lossy, gitignored in
+// consuming projects, and therefore never shared -- refreshing it on every save costs I/O for a file nobody reads,
+// while the committed structured sidecar is the artifact that must stay truthful.
+// --------------------------------------------------------------------------------------------------------------------
+
+enum class ECk_AssetExporter_SidecarFormats
+{
+    JsonOnly,
+    JsonAndText
+};
 
 // --------------------------------------------------------------------------------------------------------------------
 // The "_meta" object every sibling-writing exporter embeds. Deliberately NO timestamp and NO machine path: two

--- a/Source/CkAssetExporter/Public/CkAssetExporter/MaterialExporter/CkMaterialExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/MaterialExporter/CkMaterialExporter.cpp
@@ -57,7 +57,7 @@ auto
         JsonPath = FPaths::Combine(InOutputDir, InMaterial->GetName() + TEXT(".json"));
     }
     else if (NOT FPackageName::TryConvertLongPackageNameToFilename(
-        InMaterial->GetOutermost()->GetName(), JsonPath, TEXT(".json")))
+        InMaterial->GetOutermost()->GetName(), JsonPath, ck::asset_exporter::extension::Sidecar))
     {
         Result.ErrorMessage = ck::Format_UE(TEXT("Failed to resolve sibling json path for [{}]"), InMaterial->GetName());
         return Result;

--- a/Source/CkAssetExporter/Public/CkAssetExporter/MaterialExporter/CkMaterialExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/MaterialExporter/CkMaterialExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 
 #include "CoreMinimal.h"

--- a/Source/CkAssetExporter/Public/CkAssetExporter/NiagaraExporter/CkNiagaraExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/NiagaraExporter/CkNiagaraExporter.cpp
@@ -149,7 +149,8 @@ auto
     FCk_NiagaraExporter::
     ExportNiagaraSystem(
         UNiagaraSystem* InSystem,
-        const FString& InOutputDir)
+        const FString& InOutputDir,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_NiagaraExportResult
 {
     auto Result = FCk_NiagaraExportResult{};
@@ -171,11 +172,17 @@ auto
         FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
     }
 
-    const auto TextString = DoSerializeToText(InSystem);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InSystem, TEXT(".json"), InOutputDir);
-    const auto TextPath = DoResolveOutputPath(InSystem, TEXT(".txt"), InOutputDir);
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto TextString = WriteText ? DoSerializeToText(InSystem) : FString{};
+
+    // Corpus mode writes outside Content/, where the auto-reimport monitor never looks and nothing is committed —
+    // plain .json is friendlier for those consumers. Only the sibling written next to a .uasset needs to be invisible.
+    const auto StructuredExtension = InOutputDir.IsEmpty() ? ck::asset_exporter::extension::Sidecar : FString{TEXT(".json")};
+
+    const auto JsonPath = DoResolveOutputPath(InSystem, StructuredExtension, InOutputDir);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InSystem, ck::asset_exporter::extension::SummaryText, InOutputDir) : FString{};
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -188,7 +195,7 @@ auto
     }
 
     const auto JsonWritten = FFileHelper::SaveStringToFile(JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto TextWritten = FFileHelper::SaveStringToFile(TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
+    const auto TextWritten = NOT WriteText || FFileHelper::SaveStringToFile(TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
     if (NOT JsonWritten || NOT TextWritten)
     {
         Result.ErrorMessage = ck::Format_UE(TEXT("Failed to write files (JSON: {}, Text: {})"),

--- a/Source/CkAssetExporter/Public/CkAssetExporter/NiagaraExporter/CkNiagaraExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/NiagaraExporter/CkNiagaraExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -37,8 +39,8 @@ struct CKASSETEXPORTER_API FCk_NiagaraExportResult
 class CKASSETEXPORTER_API FCk_NiagaraExporter
 {
 public:
-    // InOutputDir: when set, writes <AssetName>.json/.txt into that directory instead of next to the asset.
-    static auto ExportNiagaraSystem (UNiagaraSystem* InSystem, const FString& InOutputDir = FString{}) -> FCk_NiagaraExportResult;
+    // InOutputDir: when set, writes <AssetName>.ckexport/.txt into that directory instead of next to the asset.
+    static auto ExportNiagaraSystem (UNiagaraSystem* InSystem, const FString& InOutputDir = FString{}, ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_NiagaraExportResult;
     static auto ExportNiagaraSystems(const TArray<UNiagaraSystem*>& InSystems) -> TArray<FCk_NiagaraExportResult>;
 
 private:

--- a/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.cpp
@@ -29,7 +29,8 @@
 auto
     FCk_StateTreeExporter::
     ExportStateTree(
-        UStateTree* InStateTree)
+        UStateTree* InStateTree,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_StateTreeExportResult
 {
     auto Result = FCk_StateTreeExportResult{};
@@ -60,12 +61,14 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto TextString = DoSerializeToText(InStateTree);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InStateTree, TEXT(".json"));
-    const auto TextPath = DoResolveOutputPath(InStateTree, TEXT(".txt"));
+    const auto TextString = WriteText ? DoSerializeToText(InStateTree) : FString{};
 
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto JsonPath = DoResolveOutputPath(InStateTree, ck::asset_exporter::extension::Sidecar);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InStateTree, ck::asset_exporter::extension::SummaryText) : FString{};
+
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -73,7 +76,7 @@ auto
 
     const auto bJsonWritten = FFileHelper::SaveStringToFile(
         JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto bTextWritten = FFileHelper::SaveStringToFile(
+    const auto bTextWritten = NOT WriteText || FFileHelper::SaveStringToFile(
         TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 
     if (!bJsonWritten || !bTextWritten)

--- a/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -31,7 +33,8 @@ class CKASSETEXPORTER_API FCk_StateTreeExporter
 public:
     static auto
     ExportStateTree(
-        UStateTree* InStateTree) -> FCk_StateTreeExportResult;
+        UStateTree* InStateTree,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_StateTreeExportResult;
 
     static auto
     ExportStateTrees(

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.cpp
@@ -38,7 +38,8 @@ namespace ck_user_defined_enum_exporter_internal
 auto
     FCk_UserDefinedEnumExporter::
     ExportUserDefinedEnum(
-        UUserDefinedEnum* InEnum)
+        UUserDefinedEnum* InEnum,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_UserDefinedEnumExportResult
 {
     auto Result = FCk_UserDefinedEnumExportResult{};
@@ -62,12 +63,14 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto TextString = DoSerializeToText(InEnum);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InEnum, TEXT(".json"));
-    const auto TextPath = DoResolveOutputPath(InEnum, TEXT(".txt"));
+    const auto TextString = WriteText ? DoSerializeToText(InEnum) : FString{};
 
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto JsonPath = DoResolveOutputPath(InEnum, ck::asset_exporter::extension::Sidecar);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InEnum, ck::asset_exporter::extension::SummaryText) : FString{};
+
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -75,7 +78,7 @@ auto
 
     const auto JsonWritten = FFileHelper::SaveStringToFile(
         JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto TextWritten = FFileHelper::SaveStringToFile(
+    const auto TextWritten = NOT WriteText || FFileHelper::SaveStringToFile(
         TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 
     if (NOT JsonWritten || NOT TextWritten)

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -30,7 +32,8 @@ class CKASSETEXPORTER_API FCk_UserDefinedEnumExporter
 public:
     static auto
     ExportUserDefinedEnum(
-        UUserDefinedEnum* InEnum) -> FCk_UserDefinedEnumExportResult;
+        UUserDefinedEnum* InEnum,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_UserDefinedEnumExportResult;
 
     static auto
     ExportUserDefinedEnums(

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.cpp
@@ -42,7 +42,8 @@ namespace ck_user_defined_struct_exporter_internal
 auto
     FCk_UserDefinedStructExporter::
     ExportUserDefinedStruct(
-        UUserDefinedStruct* InStruct)
+        UUserDefinedStruct* InStruct,
+        ECk_AssetExporter_SidecarFormats InFormats)
     -> FCk_UserDefinedStructExportResult
 {
     auto Result = FCk_UserDefinedStructExportResult{};
@@ -66,12 +67,14 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto TextString = DoSerializeToText(InStruct);
+    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
 
-    const auto JsonPath = DoResolveOutputPath(InStruct, TEXT(".json"));
-    const auto TextPath = DoResolveOutputPath(InStruct, TEXT(".txt"));
+    const auto TextString = WriteText ? DoSerializeToText(InStruct) : FString{};
 
-    if (JsonPath.IsEmpty() || TextPath.IsEmpty())
+    const auto JsonPath = DoResolveOutputPath(InStruct, ck::asset_exporter::extension::Sidecar);
+    const auto TextPath = WriteText ? DoResolveOutputPath(InStruct, ck::asset_exporter::extension::SummaryText) : FString{};
+
+    if (JsonPath.IsEmpty() || (WriteText && TextPath.IsEmpty()))
     {
         Result.ErrorMessage = TEXT("Failed to resolve output file paths");
         return Result;
@@ -79,7 +82,7 @@ auto
 
     const auto JsonWritten = FFileHelper::SaveStringToFile(
         JsonString, *JsonPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-    const auto TextWritten = FFileHelper::SaveStringToFile(
+    const auto TextWritten = NOT WriteText || FFileHelper::SaveStringToFile(
         TextString, *TextPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
 
     if (NOT JsonWritten || NOT TextWritten)

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
 
@@ -31,7 +33,8 @@ class CKASSETEXPORTER_API FCk_UserDefinedStructExporter
 public:
     static auto
     ExportUserDefinedStruct(
-        UUserDefinedStruct* InStruct) -> FCk_UserDefinedStructExportResult;
+        UUserDefinedStruct* InStruct,
+        ECk_AssetExporter_SidecarFormats InFormats = ECk_AssetExporter_SidecarFormats::JsonAndText) -> FCk_UserDefinedStructExportResult;
 
     static auto
     ExportUserDefinedStructs(

--- a/Source/CkAssetExporter/Public/CkAssetExporter/Validation/CkAssetExporter_AutoReimportGuard.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/Validation/CkAssetExporter_AutoReimportGuard.cpp
@@ -1,0 +1,180 @@
+#include "CkAssetExporter_AutoReimportGuard.h"
+
+#include "CkAssetExporter_Log.h"
+#include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
+
+#include "CkCore/Macros/CkMacros.h"
+#include "CkCore/Validation/CkIsValid.h"
+
+#include "Factories/Factory.h"
+#include "FileCacheUtilities.h"
+#include "Settings/EditorLoadingSavingSettings.h"
+
+#include <CoreGlobals.h>
+#include <UObject/UObjectIterator.h>
+
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace ck_asset_exporter_autoreimport_guard
+{
+    struct FEffectiveMonitor
+    {
+        // Parsed: what the monitor actually watches, used for the same-or-parent dedup below.
+        FString SourceDirectory;
+        // Authored: ParseSourceDirectoryAndMountPoint rewrites "/Game/" to "../../Content/", so echoing the parsed
+        // form back at the user would tell them to add a config line that does not match the one they already have.
+        FString AuthoredSourceDirectory;
+        DirectoryWatcher::FMatchRules Rules;
+    };
+
+    // Reproduces SetUpDirectoryMonitors: parse each configured entry, stamp the factory extensions, append the
+    // wildcard rules, then drop any entry a LATER entry supersedes (StartsWith is true for identical paths, so the
+    // last entry naming a directory wins). Testing anything but the surviving set would report rules that never run.
+    static auto
+    Build_EffectiveMonitors(
+        const UEditorLoadingSavingSettings& InSettings,
+        const FString& InSupportedExtensions)
+        -> TArray<FEffectiveMonitor>
+    {
+        auto Parsed = TArray<FEffectiveMonitor>{};
+
+        for (const auto& Setting : InSettings.AutoReimportDirectorySettings)
+        {
+            auto Entry = FEffectiveMonitor{};
+            Entry.SourceDirectory = Setting.SourceDirectory;
+            Entry.AuthoredSourceDirectory = Setting.SourceDirectory;
+
+            auto MountPoint = Setting.MountPoint;
+
+            constexpr auto EnableLogging = false;
+            const auto ParseContext = FAutoReimportDirectoryConfig::FParseContext{EnableLogging};
+            if (NOT FAutoReimportDirectoryConfig::ParseSourceDirectoryAndMountPoint(
+                Entry.SourceDirectory, MountPoint, ParseContext))
+            { continue; }
+
+            Entry.Rules.SetApplicableExtensions(InSupportedExtensions);
+            for (const auto& Wildcard : Setting.Wildcards)
+            { Entry.Rules.AddWildcardRule(Wildcard.Wildcard, Wildcard.bInclude); }
+
+            Parsed.Add(MoveTemp(Entry));
+        }
+
+        auto Effective = TArray<FEffectiveMonitor>{};
+
+        for (auto Index = int32{0}; Index < Parsed.Num(); ++Index)
+        {
+            auto Superseded = false;
+            for (auto OtherIndex = Index + 1; OtherIndex < Parsed.Num(); ++OtherIndex)
+            {
+                if (Parsed[Index].SourceDirectory.StartsWith(Parsed[OtherIndex].SourceDirectory))
+                {
+                    Superseded = true;
+                    break;
+                }
+            }
+
+            if (Superseded)
+            { continue; }
+
+            Effective.Add(Parsed[Index]);
+        }
+
+        return Effective;
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+// Mirrors FAutoReimportManager::GetAllFactoryExtensions, which is a PRIVATE static we cannot call. Kept deliberately
+// identical (including the ';'-terminated accumulation shape MatchExtensionString consumes) so this guard reports what
+// the monitor actually does rather than an approximation of it.
+auto
+    FCk_AssetExporter_AutoReimportGuard::
+    Get_AllFactoryExtensions()
+    -> FString
+{
+    auto AllExtensions = FString{};
+
+    auto Scratch = FString{};
+    Scratch.Reserve(32);
+
+    for (TObjectIterator<UClass> ClassIt; ClassIt; ++ClassIt)
+    {
+        auto* Class = *ClassIt;
+
+        if (NOT Class->IsChildOf(UFactory::StaticClass()) || Class->HasAnyClassFlags(CLASS_Abstract))
+        { continue; }
+
+        const auto* Factory = Cast<UFactory>(Class->GetDefaultObject());
+        if (ck::Is_NOT_Valid(Factory, ck::IsValid_Policy_NullptrOnly{}) || NOT Factory->bEditorImport)
+        { continue; }
+
+        for (const auto& Format : Factory->Formats)
+        {
+            auto SeparatorIndex = int32{INDEX_NONE};
+            if (NOT Format.FindChar(TEXT(';'), SeparatorIndex) || SeparatorIndex <= 0)
+            { continue; }
+
+            Scratch.GetCharArray().Reset();
+            Scratch.AppendChars(*Format, SeparatorIndex + 1);
+
+            if (AllExtensions.Find(Scratch) == INDEX_NONE)
+            { AllExtensions += Scratch; }
+        }
+    }
+
+    return AllExtensions;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+auto
+    FCk_AssetExporter_AutoReimportGuard::
+    Validate()
+    -> void
+{
+    using namespace ck_asset_exporter_autoreimport_guard;
+
+    if (IsRunningCommandlet())
+    { return; }
+
+    const auto* Settings = GetDefault<UEditorLoadingSavingSettings>();
+    if (ck::Is_NOT_Valid(Settings, ck::IsValid_Policy_NullptrOnly{}) || NOT Settings->bMonitorContentDirectories)
+    { return; }
+
+    const auto SupportedExtensions = FCk_AssetExporter_AutoReimportGuard::Get_AllFactoryExtensions();
+    const auto EffectiveMonitors = Build_EffectiveMonitors(*Settings, SupportedExtensions);
+
+    // The .csv a DataTable export writes IS a legitimate re-import source for that DataTable, so a monitor picking it
+    // up is correct behaviour and must not be reported. Only the two summary/structured siblings are pure output.
+    const auto ProbedExtensions = TArray<FString>
+    {
+        ck::asset_exporter::extension::Sidecar,
+        ck::asset_exporter::extension::SummaryText,
+    };
+
+    for (const auto& Monitor : EffectiveMonitors)
+    {
+        for (const auto& Extension : ProbedExtensions)
+        {
+            const auto ProbeFilename = FString{TEXT("CkAssetExporterProbe")} + Extension;
+            if (NOT Monitor.Rules.IsFileApplicable(*ProbeFilename))
+            { continue; }
+
+            ck::asset_exporter::Warning(
+                TEXT("[AutoReimportGuard] The auto-reimport monitor watching [{}] will pick up the [{}] files this ")
+                TEXT("module writes next to assets under Content/. Those are export output, never import sources. ")
+                TEXT("Once enough accumulate the monitor parks on its \"N changes to source content files\" prompt ")
+                TEXT("and re-stats the whole pending set every frame -- measured at 18 fps on a 1,178-file corpus, ")
+                TEXT("invisible to every UE-side profiler. Exclude it in Config/DefaultEditorPerProjectUserSettings.ini ")
+                TEXT("(bInclude defaults to false, so a bare Wildcard entry IS an exclusion):\n")
+                TEXT("+AutoReimportDirectorySettings=(SourceDirectory=\"{}\",MountPoint=\"\",Wildcards=((Wildcard=\"*{}\")))"),
+                Monitor.SourceDirectory,
+                Extension,
+                Monitor.AuthoredSourceDirectory,
+                Extension);
+        }
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAssetExporter/Public/CkAssetExporter/Validation/CkAssetExporter_AutoReimportGuard.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/Validation/CkAssetExporter_AutoReimportGuard.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+// --------------------------------------------------------------------------------------------------------------------
+
+class CKASSETEXPORTER_API FCk_AssetExporter_AutoReimportGuard
+{
+public:
+    // Warns when a sidecar extension this module writes under Content/ is one the editor's auto-reimport monitor
+    // will pick up, naming the config line that fixes it. A consuming project that hits this silently loses most of
+    // its editor frame rate with no UE-side profiler able to attribute it, so the whole point is to make the trap
+    // announce itself once at boot. Editor-only; a no-op under commandlets. Never ensures: the condition is a
+    // project configuration state, not a code defect.
+    static auto
+    Validate() -> void;
+
+    // A ';'-terminated concatenation of every extension an editor import factory claims, in the exact shape
+    // DirectoryWatcher::MatchExtensionString consumes. Public so a test can assert the sidecar extension is absent
+    // from it — that absence IS the mechanism, and nothing else would catch a future extension change that
+    // silently re-enters the monitor's view.
+    static auto
+    Get_AllFactoryExtensions() -> FString;
+};
+
+// --------------------------------------------------------------------------------------------------------------------

--- a/Source/CkAssetExporter/Tests/Test_AssetExporterDispatch.cpp
+++ b/Source/CkAssetExporter/Tests/Test_AssetExporterDispatch.cpp
@@ -1,6 +1,9 @@
 #include "CkAssetExporter/Dispatch/CkAssetExporter_Dispatch.h"
 #include "CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h"
 #include "CkAssetExporter/GraphDump/CkAssetExporter_GraphDump.h"
+#include "CkAssetExporter/Validation/CkAssetExporter_AutoReimportGuard.h"
+
+#include "CkCore/Macros/CkMacros.h"
 
 #include <Dom/JsonObject.h>
 #include <Dom/JsonValue.h>
@@ -157,11 +160,46 @@ bool FCk_AssetExporter_Dispatch_SummaryTextBanner_Test::RunTest(const FString& I
     const auto Banner = FCk_AssetExportMeta::Get_SummaryTextBanner(TEXT("MyAsset"));
 
     TestTrue(TEXT("banner opens with the module tag"), Banner.StartsWith(TEXT("// [CkAssetExporter]")));
-    TestTrue(TEXT("banner names the sibling json"), Banner.Contains(TEXT("MyAsset.json")));
+    TestTrue(TEXT("banner names the sibling sidecar by its real filename"), Banner.Contains(TEXT("MyAsset.ckexport")));
     TestTrue(TEXT("banner points at _meta"), Banner.Contains(TEXT("\"_meta\"")));
     TestTrue(TEXT("banner ends with a blank separator line"), Banner.EndsWith(TEXT("\n\n")));
 
     TestEqual(TEXT("banner is deterministic"), Banner, FCk_AssetExportMeta::Get_SummaryTextBanner(TEXT("MyAsset")));
+
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// The load-bearing invariant of the whole sidecar-extension design: an extension no import factory claims is rejected
+// by FMatchRules::IsFileApplicable BEFORE any wildcard rule, which is what makes the sidecar corpus invisible to the
+// auto-reimport monitor in every consuming project with zero configuration. If someone ever changes the extension to
+// something a factory does claim, the editor silently drops to ~18 fps on a large corpus and no UE-side profiler can
+// attribute it. This test is the only thing standing between that change and that outcome.
+// --------------------------------------------------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCk_AssetExporter_Dispatch_SidecarExtensionUnclaimed_Test,
+    "Ck.AssetExporter.Dispatch.SidecarExtensionUnclaimed",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FCk_AssetExporter_Dispatch_SidecarExtensionUnclaimed_Test::RunTest(const FString& InParameters)
+{
+    const auto FactoryExtensions = FCk_AssetExporter_AutoReimportGuard::Get_AllFactoryExtensions();
+
+    TestTrue(TEXT("factory extension enumeration returned something"), NOT FactoryExtensions.IsEmpty());
+
+    // Control assertion: json IS a claimed import format (UReimportDataTableFactory) — that is precisely why the
+    // sidecar had to stop being a .json. Without this, a broken enumeration would let the real assertion below pass
+    // vacuously and the test would guard nothing.
+    TestTrue(TEXT("control: 'json' is claimed by an import factory"),
+        FactoryExtensions.Contains(TEXT("json;"), ESearchCase::IgnoreCase));
+
+    const auto SidecarWithoutDot = ck::asset_exporter::extension::Sidecar.RightChop(1);
+    TestTrue(TEXT("sidecar extension is a terminal extension starting with a dot"),
+        ck::asset_exporter::extension::Sidecar.StartsWith(TEXT(".")) && NOT SidecarWithoutDot.Contains(TEXT(".")));
+
+    TestFalse(TEXT("NO import factory claims the sidecar extension"),
+        FactoryExtensions.Contains(SidecarWithoutDot + TEXT(";"), ESearchCase::IgnoreCase));
 
     return true;
 }

--- a/Source/CkScripts/Export-CkAssets.ps1
+++ b/Source/CkScripts/Export-CkAssets.ps1
@@ -1,8 +1,14 @@
 <#
 .SYNOPSIS
     Exports Unreal assets (DataAsset/Blueprint/BT/EQS/StateTree/enum/struct/etc.) to sibling
-    JSON + text files via the CkAssetExporter commandlet, without the caller needing to know
+    .ckexport files via the CkAssetExporter commandlet, without the caller needing to know
     engine paths.
+
+    A '<Asset>.ckexport' sits next to '<Asset>.uasset' and is plain UTF-8 JSON despite the
+    extension -- read and grep it directly as text. It does NOT end in '.json' on purpose: UE's
+    auto-reimport monitor treats every registered import extension under Content/ as source
+    content, and a committed .json corpus pins the editor at ~18 fps. A manual export also writes
+    a lossy human-readable '<Asset>.txt' summary; the on-save refresh writes only the .ckexport.
 
 .DESCRIPTION
     Self-contained PowerShell 7 wrapper around `-run=CkAssetExporter`. Resolves the project's


### PR DESCRIPTION
## Why

The editor sat at ~18fps on every map with no PIE running. The 1,178 committed
`CkAssetExporter` sidecars are `.json`, json is a registered import format
(`UReimportDataTableFactory`), so UE's auto-reimport monitor treated the whole corpus as
source content: it accumulated a pending set, parked its state machine on the *"N changes
to source content files"* prompt, and while parked re-stat'd the **entire outstanding set
every frame**. The game thread showed 99.7% of a core and looked compute-bound while
actually blocked in `FileExists`/`GetTimeStamp` through the NTFS + Defender filter drivers.

No UE-side profiler could see it — Insights attributes it to `Tick_Engine` self time and
`SimpleTickObjects` -> `FAutoReimportManager` carries no stat scope. It took xperf stack
sampling to find.

The consuming project could suppress it with a config exclusion, but that is per-project
and one click on the toast writes a personal `Saved/Config` override that silently shadows
it. This fixes it at the source instead.

## What

Sidecars are now `<Asset>.ckexport`. `FMatchRules::IsFileApplicable` rejects an extension
no import factory claims **before any wildcard rule**, so the corpus is invisible to the
monitor in every consuming title with zero configuration.

Two constraints keep it working, both enforced by a test:
- It must stay a **terminal** extension — `MatchExtensionString` reads only the final one,
  so `Foo.x.json` still parses as json.
- It must stay **unclaimed**. `Ck.AssetExporter.Dispatch.SidecarExtensionUnclaimed` asserts
  no factory claims it, with a control assertion that json *is* claimed so it cannot pass
  vacuously. Changing the extension to something claimed silently reintroduces the bug.

Also in here:

- **Extensions centralised** in `ck::asset_exporter::extension`. Corpus-mode output
  (`Saved/CkVfxCorpus/`) deliberately keeps `.json` — outside `Content/`, never watched,
  never committed.
- **`_meta.format`** states in every sidecar that it is UTF-8 JSON for the sibling
  `.uasset`, because `.ckexport` no longer announces "readable text" the way `.json` did.
  Stamped in `MakeMetaObject`, one place, so it cannot drift and future exporters inherit
  it. Exporter versions bumped accordingly.
- **On-save path is JSON-only.** The `.txt` summary is lossy AND gitignored in consuming
  projects, so it was never shared and drifted — the consumer's committed `StoreDriver` txt
  still listed variables renamed months earlier. Manual export still writes both; DataTable
  `.csv` and WBP paste artifacts still emit on both paths.
- **`AutoReimportGuard`** warns at `OnPostEngineInit`, naming the exact config line, if any
  extension written under `Content/` is factory-claimed and unexcluded. It rebuilds the
  engine's own parse + same-or-parent dedup and asks `FMatchRules` rather than
  approximating. `.csv` is deliberately not probed — a DataTable's csv sidecar IS a
  legitimate re-import source for it.

## Verification

- `--build --test --test-pattern AssetExporter` -> **7/7 passed, 0 failed, 0 contaminated**,
  re-run after rebase so the tested binary matches the committed source.
- Confirmed in a live editor: on-save wrote **only** the `.ckexport`; manual right-click
  export wrote **both**; `_meta.format` present; the guard fired correctly when an
  emit-able extension was left unexcluded, and stayed silent otherwise.

## Consumer note

Renaming an existing committed corpus is a separate change in the consuming project — the
extension change alone protects new exports without touching a single existing file.
