### PR TITLE
test(asset-exporter): pin the sidecar format gate and path suffix

### DIFF
--- a/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BehaviorTreeExporter/CkBehaviorTreeExporter.cpp
@@ -52,7 +52,7 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InBehaviorTree) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/BlueprintExporter/CkBlueprintExporter.cpp
@@ -77,7 +77,7 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InBlueprint) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/CascadeExporter/CkCascadeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/CascadeExporter/CkCascadeExporter.cpp
@@ -100,7 +100,7 @@ auto
         FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
     }
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(JsonObject) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/DataAssetExporter/CkDataAssetExporter.cpp
@@ -75,7 +75,7 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InDataAsset) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/EQSExporter/CkEQSExporter.cpp
@@ -87,7 +87,7 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InQuery) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/ExportMeta/CkAssetExporter_ExportMeta.h
@@ -62,6 +62,16 @@ enum class ECk_AssetExporter_SidecarFormats
     JsonAndText
 };
 
+namespace ck::asset_exporter
+{
+    // The single gate every exporter consults before writing its lossy .txt summary. Centralized so the JsonOnly
+    // auto path cannot regress in one exporter silently -- Ck.AssetExporter.Dispatch.SummaryTextFormatGate pins it.
+    constexpr auto ShouldWrite_SummaryText(ECk_AssetExporter_SidecarFormats InFormats) -> bool
+    {
+        return InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    }
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 // The "_meta" object every sibling-writing exporter embeds. Deliberately NO timestamp and NO machine path: two
 // exports of identical input must be byte-identical, or the freshness gate and external diff tooling cannot trust it.

--- a/Source/CkAssetExporter/Public/CkAssetExporter/NiagaraExporter/CkNiagaraExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/NiagaraExporter/CkNiagaraExporter.cpp
@@ -172,7 +172,7 @@ auto
         FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
     }
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InSystem) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/StateTreeExporter/CkStateTreeExporter.cpp
@@ -61,7 +61,7 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InStateTree) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedEnumExporter/CkUserDefinedEnumExporter.cpp
@@ -63,7 +63,7 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InEnum) : FString{};
 

--- a/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.cpp
+++ b/Source/CkAssetExporter/Public/CkAssetExporter/UserDefinedStructExporter/CkUserDefinedStructExporter.cpp
@@ -67,7 +67,7 @@ auto
     const auto JsonWriter = TJsonWriterFactory<>::Create(&JsonString);
     FJsonSerializer::Serialize(JsonObject.ToSharedRef(), JsonWriter);
 
-    const auto WriteText = InFormats == ECk_AssetExporter_SidecarFormats::JsonAndText;
+    const auto WriteText = ck::asset_exporter::ShouldWrite_SummaryText(InFormats);
 
     const auto TextString = WriteText ? DoSerializeToText(InStruct) : FString{};
 

--- a/Source/CkAssetExporter/Tests/Test_AssetExporterDispatch.cpp
+++ b/Source/CkAssetExporter/Tests/Test_AssetExporterDispatch.cpp
@@ -13,7 +13,9 @@
 #include <Materials/MaterialInterface.h>
 #include <Misc/AutomationTest.h>
 #include <Misc/FileHelper.h>
+#include <Misc/PackageName.h>
 #include <Misc/Paths.h>
+#include <UObject/Package.h>
 #include <Serialization/JsonSerializer.h>
 #include <Serialization/JsonWriter.h>
 
@@ -188,18 +190,82 @@ bool FCk_AssetExporter_Dispatch_SidecarExtensionUnclaimed_Test::RunTest(const FS
 
     TestTrue(TEXT("factory extension enumeration returned something"), NOT FactoryExtensions.IsEmpty());
 
+    // Every element of the enumeration ends in ';', so prepending one bounds each element as ";ext;" and a
+    // substring match cannot hit inside a longer extension (e.g. "json" inside "geojson").
+    const auto DelimitedExtensions = TEXT(";") + FactoryExtensions;
+
     // Control assertion: json IS a claimed import format (UReimportDataTableFactory) — that is precisely why the
     // sidecar had to stop being a .json. Without this, a broken enumeration would let the real assertion below pass
     // vacuously and the test would guard nothing.
     TestTrue(TEXT("control: 'json' is claimed by an import factory"),
-        FactoryExtensions.Contains(TEXT("json;"), ESearchCase::IgnoreCase));
+        DelimitedExtensions.Contains(TEXT(";json;"), ESearchCase::IgnoreCase));
 
     const auto SidecarWithoutDot = ck::asset_exporter::extension::Sidecar.RightChop(1);
     TestTrue(TEXT("sidecar extension is a terminal extension starting with a dot"),
         ck::asset_exporter::extension::Sidecar.StartsWith(TEXT(".")) && NOT SidecarWithoutDot.Contains(TEXT(".")));
 
     TestFalse(TEXT("NO import factory claims the sidecar extension"),
-        FactoryExtensions.Contains(SidecarWithoutDot + TEXT(";"), ESearchCase::IgnoreCase));
+        DelimitedExtensions.Contains(TEXT(";") + SidecarWithoutDot + TEXT(";"), ESearchCase::IgnoreCase));
+
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// The on-save hook passes JsonOnly so an editor save refreshes the committed .ckexport without churning the lossy,
+// gitignored .txt summary. All nine sibling-writing exporters gate their .txt through ShouldWrite_SummaryText — this
+// test pins the single shared gate, so no exporter can silently resume writing .txt on the auto path.
+// --------------------------------------------------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCk_AssetExporter_Dispatch_SummaryTextFormatGate_Test,
+    "Ck.AssetExporter.Dispatch.SummaryTextFormatGate",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FCk_AssetExporter_Dispatch_SummaryTextFormatGate_Test::RunTest(const FString& InParameters)
+{
+    TestFalse(TEXT("JsonOnly (the on-save auto path) writes NO summary text"),
+        ck::asset_exporter::ShouldWrite_SummaryText(ECk_AssetExporter_SidecarFormats::JsonOnly));
+
+    TestTrue(TEXT("JsonAndText (every manual path) writes the summary text"),
+        ck::asset_exporter::ShouldWrite_SummaryText(ECk_AssetExporter_SidecarFormats::JsonAndText));
+
+    return true;
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+    FCk_AssetExporter_Dispatch_SiblingSidecarPath_Test,
+    "Ck.AssetExporter.Dispatch.SiblingSidecarPath",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FCk_AssetExporter_Dispatch_SiblingSidecarPath_Test::RunTest(const FString& InParameters)
+{
+    // An in-memory package under a mounted root resolves to a disk path without any asset existing on disk, and the
+    // function only reads the outermost package name — so the package itself is a sufficient probe (instantiating
+    // an object inside a saveable package would trip the engine's abstract-class allocation ensure).
+    const auto PackageName = FString{TEXT("/Game/__CkAssetExporterTest_SidecarPath")};
+    auto* Package = CreatePackage(*PackageName);
+    TestNotNull(TEXT("test package created"), Package);
+    if (Package == nullptr)
+    { return false; }
+
+    const auto SidecarPath = FCk_AssetExporter_Dispatch::Get_SiblingSidecarPathForAsset(Package);
+    TestTrue(TEXT("sidecar path resolves"), NOT SidecarPath.IsEmpty());
+    TestTrue(TEXT("sidecar path ends with the sidecar extension"),
+        SidecarPath.EndsWith(ck::asset_exporter::extension::Sidecar));
+    TestFalse(TEXT("sidecar path does NOT end in .json"), SidecarPath.EndsWith(TEXT(".json")));
+
+    auto ExpectedBase = FString{};
+    if (TestTrue(TEXT("package name converts to a filename"),
+        FPackageName::TryConvertLongPackageNameToFilename(PackageName, ExpectedBase)))
+    {
+        TestEqual(TEXT("sidecar path is the package's disk path plus the sidecar extension"),
+            SidecarPath, ExpectedBase + ck::asset_exporter::extension::Sidecar);
+    }
+
+    TestTrue(TEXT("null asset resolves to an empty sidecar path"),
+        FCk_AssetExporter_Dispatch::Get_SiblingSidecarPathForAsset(nullptr).IsEmpty());
 
     return true;
 }


### PR DESCRIPTION
The nine sibling-writing exporters each branched on `JsonAndText` independently, so any one of them could silently resume writing the lossy `.txt` summary on the on-save auto path — the JsonOnly/JsonAndText split shipped in #705 had no test at all. They now all route through a single `ck::asset_exporter::ShouldWrite_SummaryText` gate, pinned by `Ck.AssetExporter.Dispatch.SummaryTextFormatGate`.

Also:
- `Ck.AssetExporter.Dispatch.SiblingSidecarPath` pins `Get_SiblingSidecarPathForAsset`'s `.ckexport` suffix directly (previously only pinned indirectly through the summary-text banner). Probes an in-memory package — instantiating an object in a saveable package trips the engine's abstract-class allocation ensure.
- `SidecarExtensionUnclaimed`'s assertions are now delimiter-precise (`;json;`) so a token cannot match inside a longer extension such as `geojson`.

Gate: `--build --test` pattern `AssetExporter` → 9/9 passed, 0 contaminated. Full BB suite run alongside: the only fails are pre-existing dev reds / new upstream tests, none in this module (provenance table in the session log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)