### PR TITLE
fix(objective): stop re-seeding default objectives after a snapshot load

### DIFF
--- a/Source/CkObjective/Public/CkObjective/ObjectiveOwner/CkObjectiveOwner_Processor.cpp
+++ b/Source/CkObjective/Public/CkObjective/ObjectiveOwner/CkObjectiveOwner_Processor.cpp
@@ -2,10 +2,13 @@
 
 #include "CkCore/Algorithms/CkAlgorithms.h"
 #include "CkCore/Validation/CkIsValid.h"
+#include "CkEcs/EntityLifetime/CkEntityLifetime_Utils.h"
 #include "CkEcs/EntityScript/CkEntityScript_Utils.h"
 #include "CkEcs/EntityScript/CkEntityScript_Fragment.h"
 #include "CkEcs/Net/CkNet_Utils.h"
 #include "CkEcs/Request/CkRequest_Completion.h"
+#include "CkEcs/Snapshot/CkSnapshot_RestoreMarker.h"
+#include "CkEcs/Subsystem/CkEcsWorld_Subsystem.h"
 #include "CkEntityCollection/CkEntityCollection_Utils.h"
 #include "CkObjective/Objective/CkObjective_Utils.h"
 #include "CkObjective/ObjectiveOwner/CkObjectiveOwner_Utils.h"
@@ -44,6 +47,22 @@ namespace ck_objective
             ck::UUtils_Signal_OnObjectiveOwner_ObjectiveRemoved::Broadcast(ObjectiveOwner, ck::MakePayload(ObjectiveOwner, ObjectiveRemoved));
         }
     }
+
+    // Also true during escalated full-scope passes, which tick gated processors before restore provenance is stamped.
+    auto Get_IsLoadGateActive(
+        const FCk_Handle& InHandle)
+        -> bool
+    {
+        const auto World = UCk_Utils_EntityLifetime_UE::Get_WorldForEntity(InHandle);
+        if (ck::Is_NOT_Valid(World))
+        { return false; }
+
+        const auto* EcsWorld = World->GetSubsystem<UCk_EcsWorld_Subsystem_UE>();
+        if (ck::Is_NOT_Valid(EcsWorld))
+        { return false; }
+
+        return EcsWorld->Get_IsLoadGateActive();
+    }
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -59,24 +78,32 @@ namespace ck
             FFragment_ObjectiveOwner_Current& InCurrent)
         -> void
     {
+        // Ahead of the marker consume on purpose: leaving it set re-runs this once the gate drops.
+        if (ck_objective::Get_IsLoadGateActive(InHandle))
+        { return; }
+
         InHandle.Remove<MarkedDirtyBy>();
 
         const auto& CollectionHandle = InCurrent.Get_ObjectivesEntityCollection();
         UUtils_Signal_EntityCollection_OnCollectionUpdated::Bind<&ck_objective::OnObjectiveCollectionUpdated>(
             CollectionHandle, ECk_Signal_BindingPolicy::FireIfPayloadInFlightThisFrame, ECk_Signal_PostFireBehavior::DoNothing);
 
-        if (UCk_Utils_Net_UE::Get_HasAuthority(InHandle))
-        {
-            for (const auto& DefaultObjectives = InParams.Get_DefaultObjectives();
-                const auto& ObjectiveClass : DefaultObjectives)
-            {
-                CK_ENSURE_IF_NOT(ck::IsValid(ObjectiveClass), TEXT("Entity [{}] has an INVALID default Objective in its Params!"), InHandle)
-                { continue; }
+        if (NOT UCk_Utils_Net_UE::Get_HasAuthority(InHandle))
+        { return; }
 
-                if (ck::IsValid(ObjectiveClass))
-                {
-                    UCk_Utils_ObjectiveOwner_UE::Request_AddObjective(InHandle, FCk_Request_ObjectiveOwner_AddObjective{ObjectiveClass}, {});
-                }
+        // Restored children respawn from their own recipes; seeding on top of them is the duplicate.
+        if (InHandle.Has<FTag_Snapshot_JustRestored>())
+        { return; }
+
+        for (const auto& DefaultObjectives = InParams.Get_DefaultObjectives();
+            const auto& ObjectiveClass : DefaultObjectives)
+        {
+            CK_ENSURE_IF_NOT(ck::IsValid(ObjectiveClass), TEXT("Entity [{}] has an INVALID default Objective in its Params!"), InHandle)
+            { continue; }
+
+            if (ck::IsValid(ObjectiveClass))
+            {
+                UCk_Utils_ObjectiveOwner_UE::Request_AddObjective(InHandle, FCk_Request_ObjectiveOwner_AddObjective{ObjectiveClass}, {});
             }
         }
     }


### PR DESCRIPTION
## The defect

`FProcessor_ObjectiveOwner_Setup` seeds `FCk_ObjectiveOwner_ParamsData::_DefaultObjectives` unconditionally. A CkSnapshot v3 load **replays the owner's `DoConstruct` by design**, which re-stamps `FTag_ObjectiveOwner_NeedsSetup` — so the processor fires again the moment the load gate lifts and creates a second copy of every default child, beside the ones the loader already respawned from their own recipes.

Nothing recorded that the defaults were already materialized: CkObjective registers no persistence handler and stamps no snapshot tags. It is the failure class `CkEntityScript.h:110-114` already names — *"a producer whose spawn REQUESTS drain via a load-gated processor lands entirely after the gate lifts, where nothing suppresses it."*

Found via BusterBlock, where the objective feed rendered every card twice after a load (it keys cards on `FCk_Handle_Objective`, so two entities are two cards).

## The fix

Seeding defers while `Get_IsLoadGateActive()`, and is skipped outright on an owner carrying `FTag_Snapshot_JustRestored`. The defer deliberately does **not** consume the dirty marker, so the processor re-runs once the world is coherent instead of losing the seed.

Both signals live in **CkEcs**, which CkObjective already depends on — no new module dependency, no new persistence projection, no timer/retry.

### Why not the two more obvious guards

Both were tried against the load machine and are unsafe:

- **`FTag_Snapshot_JustRestored` alone** — on a rebuild stall the loader escalates to full-scope ticks (`CkSnapshot_Subsystem.cpp:1475-1478`), which tick `GatedDuringLoad` processors *before* `DoHydrate_Enqueue` stamps that tag.
- **A name reconcile against the owner's EntityCollection** — in the post-gate pump `FGroup_Gameplay` runs ahead of `FGroup_DeferredApply`, so the collection is still empty on the first pass.

The load gate is held for the whole rebuild and escalation never clears it (`:1441` sets, `:1531` clears), so it is the only signal covering both.

## Scope

A fresh boot takes neither branch and is byte-identical to before — the non-load path is untouched.

**Known limitation, deliberately accepted:** a restored owner never seeds, so a default added to the class *after* a save was taken will not appear on that save. Today that case only "works" by producing duplicates. Covering it needs a post-settle reconcile (`Promise_OnLoadComplete`) and is a separate change.

## Verification

Gate lives in the consuming project (BusterBlock, `Bb.Snapshot.ObjectiveRestore`, separate PR). Same command, fix reverted vs applied:

| | red | green |
|---|---|---|
| after load | `objectives=4 A=2 B=2` | `objectives=2 A=1 B=1` |
| after 2nd cycle | `objectives=4 A=2 B=2` | `objectives=2 A=1 B=1` |
| owner | `restored=1` | `restored=1` |

Six assertions red -> all green. Full `Bb.Snapshot` suite 15/16 pass; the only red is `PlayerRestore`, failing with identical assertions in both runs (inherited). Log-verified: `orphaned=0`, `dropped=0`, accounting closed, 0 AngelScript errors, 0 ensures, and the 52 `v3 capture AUDIT` hits are identical red-vs-green with none mentioning Objective.

Not verified: the rendered feed under a real RHI — `-nullrhi` cannot draw it, and the gate's fixture is a synthetic 2-objective owner rather than BusterBlock's 17-child Tutorial mission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)