### PR TITLE
fix(camera): stamp camera layers save-transient so the loader stops respawning husks

### DIFF
--- a/Source/CkCamera/Public/CkCamera/Camera/CameraLayer/CkCameraLayer_Utils.cpp
+++ b/Source/CkCamera/Public/CkCamera/Camera/CameraLayer/CkCameraLayer_Utils.cpp
@@ -11,6 +11,7 @@
 #include "CkEcs/EntityScript/CkEntityScript_Fragment.h"
 #include "CkEcs/EntityScript/CkEntityScript_Utils.h"
 #include "CkEcs/Handle/CkHandle_Utils.h"
+#include "CkEcs/Snapshot/CkSnapshot_RestoreMarker.h" // FTag_Snapshot_SaveTransient
 
 #include "CkAttribute/FloatAttribute/CkFloatAttribute_Utils.h"
 #include "CkAttribute/VectorAttribute/CkVectorAttribute_Utils.h"
@@ -31,6 +32,10 @@ auto
     { return {}; }
 
     auto NewLayer = UCk_Utils_EntityLifetime_UE::Request_CreateEntity(InCamera);
+
+    // Derived presentation — save-transient, the camera's re-drive re-pushes it (see CkSmTask_Utils::Create).
+    NewLayer.Add<ck::FTag_Snapshot_SaveTransient>();
+
     UCk_Utils_Handle_UE::Set_DebugName(NewLayer, InLayerClass->GetFName());
 
     // MUST precede the EntityScript attach below: the layer's DoEnter acquires modifiers through this back-ref.


### PR DESCRIPTION
## What

One line in `UCk_Utils_CameraLayer_UE::Create`: stamp `ck::FTag_Snapshot_SaveTransient` on the layer entity.

## Why

A camera layer is **derived state** — the owning camera's re-drive re-pushes it after a load. But `Create` composes it in six steps and only the last (`UCk_Utils_EntityScript_UE::Add`) is the EntityScript, which unconditionally retains a spawn recipe.

Without the marker, v3 capture files the layer `RuntimeSpawned` (rule 4) and the loader respawns it replaying **only** that recipe. The other five steps — the `OwningCamera` back-ref, `Params`, `Blend`, `AcquiredModifiers`, the Record connect — never run. `BeginPlay` then reaches `DoEnter` through an unchecked `StaticCast` on an entity with no back-ref:

```
CkEnsure: Error: Has(InHandle)
Handle [..|..[E_New](Default__Bb_CameraLayer_Scooter)] does NOT have an EntityHolder
 == AS CallStack ==
[1]   void UBb_CameraLayer_Scooter::DoEnter_Implementation(...) | Line 109
CkEnsure: Error: false
Unable to Get Fragment [ck::FFragment_Camera_Rig]. Handle [TOMBSTONE] does NOT have a valid Registry.
```

Because the acquires are revocable, the modifiers are never applied *and* never revoked.

**This fires on every load, in every project using CkCamera + CkSnapshot.** Only a layer that acquires in `DoEnter` produces the ensure — the default layer acquires none and tick-driven layers acquire later, so those return as silent husks.

## Why here, and why this marker

Every sibling in the same category already stamps it, all in CkFoundation:

| unit | site |
|---|---|
| SmTask | `CkSmTask_Utils.cpp:40` |
| SmState | `CkSmState_Utils.cpp:110` |
| SmCondition | `CkSmCondition_Utils.cpp:45` |
| SmTransition | `CkSmTransition_Utils.cpp:43` |
| SubStateMachine | `CkSmTask_SubStateMachine.cpp:46` |
| Cue | `CkCue_EntityScript.cpp:96` |
| **CameraLayer** | **— was missing —** |

The tag's own header in `CkSnapshot_RestoreMarker.h` prescribes exactly this case. `Create` is the correct site — CkSnapshot cannot special-case CkCamera without a tier violation.

`SaveTransient` rather than `ReconstructOnly`: the layer's fragments are native with no registered handler and the script declares no `SaveGame` fields, so it produces no payload — no AUDIT warning either way. Reconcile explicitly *preserves* SaveTransient children, so nothing is destroyed.

## Risk

Low. It removes a "restoration" that never worked — the respawned layer had no back-ref, so nothing could have depended on it.

## Verification (in BusterBlock)

- Husk ensure cascade gone; `Bb_CameraLayer_Scooter` mentions in the load log: 2 → 0.
- Captured entities 160 → 159 — exactly one fewer, the layer that is no longer a row.
- Load report closes: `orphaned [0] · dropped [0] · unresolved-owner [0]`, 0 camera-related capture audits.
- Snapshot AutoTests (incl. the full CkSnapshot parity suite): 72 total, 70 passed, 2 failed, 0 contaminated. Both failures are pre-existing and unrelated — `Ck.Snapshot.Meta.RepDataRestoreCoverage` (three `Ck_RepData_VoiceChat*` types with no coverage decision) and `Bb.Snapshot.PlayerRestore` (head-slot cosmetic hiding + hit-point regen).
- 6/6 BusterBlock save/load Gauntlet gates PASS.

Paired with BusterBlock PR (linked below). The submodule pointer bump is deliberately **not** included there yet — this repo merges by rebase, so the SHA changes on merge and the bump lands afterwards.
